### PR TITLE
fix(macro-designer): comment preservation, parser indent fixes, simulation fidelity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, 'feature/**']
+    branches: [main, 'feature/**', 'fix/**']
   pull_request:
 
 jobs:

--- a/backend/api/macro_log_routes.py
+++ b/backend/api/macro_log_routes.py
@@ -1,0 +1,53 @@
+"""Macro Designer trace log API — durable event log for debugging/testing.
+
+The frontend Macro Designer posts structured events (apply decisions,
+section matching, comment preservation, simulation plan summaries) to
+this endpoint. Events are appended as timestamped JSON lines to
+``macro_designer.log`` in the backend directory, so the log survives
+browser reloads and can be read/tailed directly (e.g. by an agent or
+during user testing) without asking the user to copy anything.
+
+Companion to the ai_chat.log pattern (kwc.ai logger in ai_routes.py).
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+logger = logging.getLogger("kwc.macro_designer")
+
+BACKEND_DIR = Path(__file__).parent.parent
+MACRO_DESIGNER_LOG = BACKEND_DIR / "macro_designer.log"
+
+# Attach a dedicated file handler once (module import time).
+if not logger.handlers:
+    _file_handler = logging.FileHandler(MACRO_DESIGNER_LOG, mode="a", encoding="utf-8")
+    _file_handler.setLevel(logging.INFO)
+    _formatter = logging.Formatter("%(asctime)s | %(message)s")
+    _file_handler.setFormatter(_formatter)
+    logger.addHandler(_file_handler)
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+
+router = APIRouter()
+
+
+class MacroDesignerLogRequest(BaseModel):
+    events: list[dict[str, Any]] = []
+
+
+@router.post("/log/macro-designer")
+async def log_macro_designer(req: MacroDesignerLogRequest) -> dict:
+    """Append each frontend event as one timestamped JSON line."""
+    for event in req.events:
+        try:
+            line = json.dumps(event, ensure_ascii=False, separators=(",", ":"))
+        except (TypeError, ValueError):
+            continue
+        logger.info("EVENT %s", line)
+    return {"ok": True, "count": len(req.events)}

--- a/backend/main.py
+++ b/backend/main.py
@@ -10,6 +10,7 @@ from api.routes import router
 from api.native_routes import router as native_router
 from api.ai_routes import router as ai_router
 from api.printer_memory_routes import router as printer_memory_router
+from api.macro_log_routes import router as macro_log_router
 from mcp_server import McpServer, get_index
 from fastapi.responses import JSONResponse
 
@@ -60,6 +61,7 @@ app.include_router(router, prefix="/api")
 app.include_router(native_router, prefix="/api/native")
 app.include_router(ai_router)
 app.include_router(printer_memory_router, prefix="/api")
+app.include_router(macro_log_router, prefix="/api")
 
 PROJECTS_DIR = Path(os.environ.get("KWC_PROJECTS_DIR", "./projects"))
 PROJECTS_DIR.mkdir(parents=True, exist_ok=True)

--- a/backend/parser/config_parser.py
+++ b/backend/parser/config_parser.py
@@ -113,7 +113,7 @@ COMMENTED_PARAM_RE = re.compile(r"^#\s*(\w[\w]*)\s*([:=])\s*(.*?)(?:\s*#(.*))?$"
 SAVE_CONFIG_BANNER_RE = re.compile(r"^#\*#\s*<.*SAVE_CONFIG.*>\s*$")
 SAVE_CONFIG_SECTION_RE = re.compile(r"^#\*#\s*\[([^\]]+)\]\s*(?:#.*)?$")
 SAVE_CONFIG_PARAM_RE = re.compile(r"^#\*#\s*(\w[\w]*)\s*([:=])\s*(.*?)(?:\s*#(.*))?$")
-CONTINUATION_RE = re.compile(r"^[ \t]+(\S.*)$")
+CONTINUATION_RE = re.compile(r"^([ \t]+\S.*)$")
 
 # Section types that take a name parameter
 NAMED_SECTION_TYPES = {

--- a/backend/parser/config_writer.py
+++ b/backend/parser/config_writer.py
@@ -269,8 +269,15 @@ def _render_value_line(prefix: str, line: str) -> str:
 def _build_multiline_prefix(raw_line: str, original_value_line: str, fallback: str) -> str:
     if not raw_line:
         return fallback
-    if not original_value_line:
-        return raw_line
+    # The original raw line's leading whitespace IS the block indent.
+    # (Value lines now carry their own indentation, so we can't recover it
+    # by subtracting the value from the raw line anymore.)
+    prefix = raw_line[: len(raw_line) - len(raw_line.lstrip(" \t"))]
+    if prefix:
+        return prefix
+    # Fall back for lines with no leading whitespace (e.g. a flat body or
+    # the section's first line): preserve the old subtraction-based logic
+    # so first-line handling keeps working.
     if raw_line.endswith(original_value_line):
         return raw_line[:-len(original_value_line)]
     return fallback

--- a/backend/parser/config_writer.py
+++ b/backend/parser/config_writer.py
@@ -240,7 +240,7 @@ def _format_param(param: ConfigParam) -> str:
         result = first
         for vl in value_lines[1:]:
             if vl.strip():
-                result += f"\n{prefix}  {vl}"
+                result += "\n" + _render_value_line(f"{prefix}  ", vl)
             else:
                 result += "\n"
         return result + comment_suffix
@@ -250,6 +250,20 @@ def _format_param(param: ConfigParam) -> str:
         return f"{prefix}{param.key} = {param.value}{comment_suffix}"
     else:
         return f"{prefix}{param.key}: {param.value}{comment_suffix}"
+
+
+def _render_value_line(prefix: str, line: str) -> str:
+    """Render one multi-line value line under *prefix*.
+
+    If the line already carries its own leading whitespace (gcode bodies are
+    conventionally indented and the parser now preserves that), use it
+    verbatim instead of stacking another prefix on top.
+    """
+    if not line:
+        return prefix.rstrip()
+    if line[0] in (" ", "\t"):
+        return line
+    return f"{prefix}{line}"
 
 
 def _build_multiline_prefix(raw_line: str, original_value_line: str, fallback: str) -> str:
@@ -286,19 +300,19 @@ def _format_multiline_param_preserving_original(param: ConfigParam, original_par
                     rendered_lines[new_idx] = original_raw_lines[orig_idx]
                 else:
                     prefix = first_prefix if new_idx == 0 else continuation_fallback
-                    rendered_lines[new_idx] = f"{prefix}{new_value_lines[new_idx]}" if new_value_lines[new_idx] else prefix.rstrip()
+                    rendered_lines[new_idx] = _render_value_line(prefix, new_value_lines[new_idx])
             continue
 
         for new_idx in range(j1, j2):
             if new_idx == 0:
-                rendered_lines[new_idx] = f"{first_prefix}{new_value_lines[new_idx]}" if new_value_lines[new_idx] else first_prefix.rstrip()
+                rendered_lines[new_idx] = _render_value_line(first_prefix, new_value_lines[new_idx])
                 continue
 
             orig_idx = i1 + min(new_idx - j1, max(0, i2 - i1 - 1))
             prefix = continuation_fallback
             if 0 <= orig_idx < len(original_raw_lines) and orig_idx < len(original_value_lines):
                 prefix = _build_multiline_prefix(original_raw_lines[orig_idx], original_value_lines[orig_idx], continuation_fallback)
-            rendered_lines[new_idx] = f"{prefix}{new_value_lines[new_idx]}" if new_value_lines[new_idx] else prefix.rstrip()
+            rendered_lines[new_idx] = _render_value_line(prefix, new_value_lines[new_idx])
 
     return "\n".join(rendered_lines)
 

--- a/frontend/src/components/dialogs/MacroDesignerDialog.tsx
+++ b/frontend/src/components/dialogs/MacroDesignerDialog.tsx
@@ -37,6 +37,7 @@ import {
   computeTrapezoidalProfile,
   createInitialRuntimeState,
   executeSimulationStep,
+  executeStandaloneCommand,
   parseParams,
   trapezoidalPositionAtTime,
 } from '../../utils/gcodeSimulator';
@@ -368,6 +369,8 @@ export default function MacroDesignerDialog({ onClose }: MacroDesignerDialogProp
   const [runtimeHistory, setRuntimeHistory] = useState<MacroRuntimeState[]>([]);
   const [simulationLog, setSimulationLog] = useState<SimulationLogEntry[]>([]);
   const [selectedLogWarning, setSelectedLogWarning] = useState<string | null>(null);
+  const [seedInput, setSeedInput] = useState('');
+  const [seededRuntime, setSeededRuntime] = useState<MacroRuntimeState | null>(null);
   const [goToX, setGoToX] = useState('');
   const [goToY, setGoToY] = useState('');
   const [goToZ, setGoToZ] = useState('');
@@ -526,8 +529,8 @@ export default function MacroDesignerDialog({ onClose }: MacroDesignerDialogProp
     return buildSimulationSteps(selectedItem, allMacroItems, machineProfile, configFiles, {
       params: simulationRootParams,
       rawparams: simulationParamsInput.trim(),
-    });
-  }, [allMacroItems, configFiles, machineProfile, selectedItem, simulationRootParams, simulationParamsInput]);
+    }, seededRuntime ?? undefined);
+  }, [allMacroItems, configFiles, machineProfile, selectedItem, simulationRootParams, simulationParamsInput, seededRuntime]);
 
   const simulationTimeline = useMemo<SimulationTimelineState>(() => {
     if (!selectedItem) {
@@ -539,7 +542,7 @@ export default function MacroDesignerDialog({ onClose }: MacroDesignerDialogProp
       };
     }
 
-    const initialRuntime = createInitialRuntimeState(machineProfile, selectedItem.title);
+    const initialRuntime = seededRuntime ?? createInitialRuntimeState(machineProfile, selectedItem.title);
     const states: MacroRuntimeState[] = [initialRuntime];
     const logs: SimulationLogEntry[] = [];
     const lastTraceByStep: Array<MovementTrace | null> = [null];
@@ -578,7 +581,7 @@ export default function MacroDesignerDialog({ onClose }: MacroDesignerDialogProp
       lastTraceByStep,
       zIndicatorByStep,
     };
-  }, [machineProfile, selectedItem, simulationPlan.steps]);
+  }, [machineProfile, selectedItem, seededRuntime, simulationPlan.steps]);
 
   const cancelAnimation = useCallback((skipCompletion = false) => {
     if (animFrameRef.current !== null) {
@@ -1320,6 +1323,30 @@ export default function MacroDesignerDialog({ onClose }: MacroDesignerDialogProp
   const handleTimelineScrub = (event: React.ChangeEvent<HTMLInputElement>) => {
     syncSimulationPosition(Number(event.target.value));
   };
+
+  const handleSeedCommand = useCallback(() => {
+    const line = seedInput.trim();
+    if (!line) return;
+    const baseState = seededRuntime ?? createInitialRuntimeState(machineProfile, selectedItem?.title || 'seed');
+    const result = executeStandaloneCommand(line, baseState, machineProfile, configFiles);
+    setSeededRuntime(result.nextState);
+    setRuntime(result.nextState);
+    setRuntimeHistory((prev) => [...prev, result.nextState]);
+    setSelectedLogWarning(result.warnings.length ? result.warnings.join(' ') : null);
+    setSimulationLog((prev) => [...prev, {
+      id: `seed-${Date.now()}`,
+      raw: line,
+      sourceName: 'seed',
+      lineNumber: 0,
+      summary: result.eventSummary,
+      warnings: result.warnings,
+      timelineStepIndex: -1,
+    }]);
+    setSeedInput('');
+    setMessage(result.warnings.length
+      ? `${result.eventSummary} — ${result.warnings.join(' ')}`
+      : `${result.eventSummary} (seeded)`);
+  }, [configFiles, machineProfile, seededRuntime, seedInput, selectedItem, setRuntime]);
 
   const handleGoTo = () => {
     const currentPosition = getCurrentToolheadPosition();
@@ -2365,6 +2392,35 @@ export default function MacroDesignerDialog({ onClose }: MacroDesignerDialogProp
                   <div className="mt-2 min-h-[2.75rem] rounded-md border border-[var(--color-bg-tertiary)] bg-[var(--color-bg-secondary)] px-2.5 py-2 text-[11px] text-[var(--color-text-secondary)]">
                     {simulationOutputSummary}
                   </div>
+                  <div className="mt-2 flex items-center gap-2">
+                    <input
+                      value={seedInput}
+                      onChange={(event) => setSeedInput(event.target.value)}
+                      onKeyDown={(event) => {
+                        if (event.key === 'Enter') {
+                          event.preventDefault();
+                          handleSeedCommand();
+                        }
+                      }}
+                      disabled={isRunning}
+                      placeholder="Seed a command, e.g. G28 or M104 S200"
+                      className="min-w-0 flex-1 rounded-md border border-[var(--color-bg-tertiary)] bg-[var(--color-bg-secondary)] px-2 py-1.5 font-mono text-[11px] text-[var(--color-text-primary)] disabled:opacity-40"
+                    />
+                    <button onClick={handleSeedCommand} disabled={isRunning || !seedInput.trim()} className="shrink-0 rounded-md bg-[var(--color-accent)] px-3 py-1.5 text-[11px] font-semibold text-[var(--color-bg-primary)] disabled:opacity-40">Send</button>
+                  </div>
+                  {seededRuntime && (
+                    <div className="mt-1 flex items-center justify-between gap-2 text-[10px] text-[var(--color-text-secondary)]">
+                      <span className="min-w-0 truncate">
+                        Seeded: X {formatNumber(seededRuntime.x)} Y {formatNumber(seededRuntime.y)} Z {formatNumber(seededRuntime.z)}
+                        {seededRuntime.homedAxes.length ? ` | homed: ${seededRuntime.homedAxes.join('')}` : ' | not homed'}
+                      </span>
+                      <button onClick={() => {
+                        setSeededRuntime(null);
+                        setSelectedLogWarning(null);
+                        setMessage('Machine state reset to default (center, not homed, heaters off).');
+                      }} className="shrink-0 rounded-md border border-[var(--color-bg-tertiary)] px-2 py-0.5 text-[10px] text-[var(--color-text-primary)] hover:border-red-400/60 hover:text-red-300">Reset</button>
+                    </div>
+                  )}
                 </div>
               </div>
             </div>

--- a/frontend/src/components/dialogs/MacroDesignerDialog.tsx
+++ b/frontend/src/components/dialogs/MacroDesignerDialog.tsx
@@ -2492,6 +2492,25 @@ export default function MacroDesignerDialog({ onClose }: MacroDesignerDialogProp
                     value={displayedItem?.gcode || ''}
                     disabled={!editMode}
                     onChange={(event) => updateEditedItem({ gcode: parseMacroGcodeFromEditorView(event.target.value) })}
+                    onKeyDown={(event) => {
+                      // Carry forward the current line's leading whitespace on
+                      // Enter, so new commands inside an indented block keep
+                      // the block's indentation instead of dropping to col 0.
+                      if (event.key === 'Enter' && !event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey) {
+                        const el = event.currentTarget;
+                        const start = el.selectionStart;
+                        const end = el.selectionEnd;
+                        const before = el.value.slice(0, start);
+                        const lineStart = before.lastIndexOf('\n') + 1;
+                        const indent = before.slice(lineStart).match(/^[ \t]*/)?.[0] ?? '';
+                        event.preventDefault();
+                        const next = before + '\n' + indent + el.value.slice(end);
+                        updateEditedItem({ gcode: parseMacroGcodeFromEditorView(next) });
+                        requestAnimationFrame(() => {
+                          el.selectionStart = el.selectionEnd = start + 1 + indent.length;
+                        });
+                      }
+                    }}
                     rows={12}
                     spellCheck={false}
                     className="w-full resize-y overflow-y-auto rounded-xl border border-[var(--color-bg-tertiary)] bg-[var(--color-bg-primary)] px-3 py-3 font-mono text-xs leading-5 text-[var(--color-text-primary)] focus:border-[var(--color-accent)] focus:outline-none disabled:opacity-70"

--- a/frontend/src/components/dialogs/MacroDesignerDialog.tsx
+++ b/frontend/src/components/dialogs/MacroDesignerDialog.tsx
@@ -2551,42 +2551,6 @@ export default function MacroDesignerDialog({ onClose }: MacroDesignerDialogProp
                     </div>
                   </div>
                 </div>
-                <div className="rounded-xl border border-[var(--color-bg-tertiary)] bg-[var(--color-bg-primary)] p-3">
-                  <div className="mb-2 text-xs font-semibold uppercase tracking-[0.16em] text-[var(--color-text-secondary)]">Canvas selection</div>
-                  {selectedZone ? (
-                    <div className="space-y-2 text-xs">
-                      <div className="rounded-lg border border-[var(--color-bg-tertiary)] bg-[var(--color-bg-secondary)] px-3 py-2 text-[11px] text-[var(--color-text-primary)]">
-                        <div className="font-semibold text-[var(--color-text-primary)]">{selectedZone.name}</div>
-                        <div className="mt-1 text-[var(--color-text-secondary)]">
-                          X {formatNumber(selectedZone.x)} | Y {formatNumber(selectedZone.y)} | W {formatNumber(selectedZone.width)} | H {formatNumber(selectedZone.height)}
-                        </div>
-                      </div>
-                      <div className="flex flex-wrap items-center gap-2">
-                        <button onClick={() => openExactPositionDialog('zone', selectedZone.id)} className="rounded-md border border-[var(--color-bg-tertiary)] px-3 py-1 text-xs text-[var(--color-text-primary)]">Set exact position</button>
-                        <button onClick={() => {
-                          deleteNoGoZone(selectedZone.id);
-                          setMessage(`Deleted ${selectedZone.name}.`);
-                        }} className="rounded-md border border-red-400/60 px-3 py-1 text-xs text-red-300">Delete</button>
-                      </div>
-                    </div>
-                  ) : isDockSelected && dockPosition ? (
-                    <div className="space-y-2 text-xs">
-                      <div className="rounded-lg border border-[var(--color-bg-tertiary)] bg-[var(--color-bg-secondary)] px-3 py-2 text-[11px] text-[var(--color-text-primary)]">
-                        <div className="font-semibold text-[var(--color-text-primary)]">Dock</div>
-                        <div className="mt-1 text-[var(--color-text-secondary)]">X {formatNumber(dockPosition.x)} | Y {formatNumber(dockPosition.y)}</div>
-                      </div>
-                      <div className="flex flex-wrap items-center gap-2">
-                        <button onClick={() => openExactPositionDialog('dock')} className="rounded-md border border-[var(--color-bg-tertiary)] px-3 py-1 text-xs text-[var(--color-text-primary)]">Set exact position</button>
-                        <button onClick={() => {
-                          setDockPosition(null);
-                          setMessage('Dock deleted.');
-                        }} className="rounded-md border border-red-400/60 px-3 py-1 text-xs text-red-300">Delete</button>
-                      </div>
-                    </div>
-                  ) : (
-                    <div className="text-[11px] text-[var(--color-text-secondary)]">Right-click a no-go zone or dock on the grid and choose Set exact position to edit it in a popup.</div>
-                  )}
-                </div>
                 {message && <div className="rounded-xl border border-[var(--color-bg-tertiary)] bg-[var(--color-bg-primary)] px-3 py-2 text-[11px] text-[var(--color-text-secondary)]">{message}</div>}
               </div>
             ) : (

--- a/frontend/src/components/dialogs/MacroDesignerDialog.tsx
+++ b/frontend/src/components/dialogs/MacroDesignerDialog.tsx
@@ -39,6 +39,7 @@ import {
   executeSimulationStep,
   trapezoidalPositionAtTime,
 } from '../../utils/gcodeSimulator';
+import { logMacroDesignerEvent } from '../../utils/macroDesignerLog';
 import type { TrapezoidalProfile } from '../../utils/gcodeSimulator';
 
 interface MacroDesignerDialogProps {
@@ -968,6 +969,19 @@ export default function MacroDesignerDialog({ onClose }: MacroDesignerDialogProp
         existingTargetSection?.line_number,
       );
     }
+
+    logMacroDesignerEvent({
+      event: 'apply',
+      title: item.title,
+      destinationFile,
+      action: existingTargetSection ? (sameHeader ? 'update' : 'rename') : 'add',
+      structuralChanged: Boolean(existingTargetSection) && structuralChanged,
+      gcodeChanged: Boolean(existingTargetSection) && existingGcode !== selectedGcode,
+      headerComments: macroSection.header_comments.length,
+      trailingComments: macroSection.trailing_comments?.length ?? 0,
+      targetLine: macroSection.line_number,
+      source: item.source,
+    });
 
     const graphStore = useGraphStore.getState();
     const alreadyInGraph = graphStore.nodes.some((node) => {

--- a/frontend/src/components/dialogs/MacroDesignerDialog.tsx
+++ b/frontend/src/components/dialogs/MacroDesignerDialog.tsx
@@ -1923,7 +1923,7 @@ export default function MacroDesignerDialog({ onClose }: MacroDesignerDialogProp
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/55" onClick={handleCloseRequest}>
-      <div className="h-[min(92vh,980px)] w-[min(98vw,1680px)] overflow-hidden rounded-2xl border border-[var(--color-bg-tertiary)] bg-[var(--color-bg-secondary)] shadow-2xl" onClick={(event) => event.stopPropagation()}>
+      <div className="h-[min(94vh,1100px)] w-[min(99vw,1920px)] overflow-hidden rounded-2xl border border-[var(--color-bg-tertiary)] bg-[var(--color-bg-secondary)] shadow-2xl" onClick={(event) => event.stopPropagation()}>
         <input
           ref={playbackFileInputRef}
           type="file"
@@ -2090,7 +2090,7 @@ export default function MacroDesignerDialog({ onClose }: MacroDesignerDialogProp
               </div>
             </div>
 
-            <div className="flex min-h-0 flex-1 flex-col">
+            <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
               <div className="mx-4 mt-3 flex flex-shrink-0 gap-3">
                 <div className="flex-1 rounded-lg border border-[var(--color-bg-tertiary)] bg-[rgba(15,23,42,0.72)] px-3 py-2 text-[10px] text-[var(--color-text-secondary)]">
                   <div className="mb-1 text-[10px] font-semibold uppercase tracking-[0.16em]">Legend</div>
@@ -2163,7 +2163,7 @@ export default function MacroDesignerDialog({ onClose }: MacroDesignerDialogProp
               </div>
 
               {/* SVG Grid */}
-              <div className="relative m-4 mt-2 min-h-0 flex-1 overflow-hidden border border-[var(--color-bg-tertiary)] bg-[linear-gradient(180deg,rgba(15,23,42,0.9),rgba(30,41,59,0.95))]">
+              <div className="relative m-4 mt-2 min-h-[16rem] flex-1 overflow-hidden border border-[var(--color-bg-tertiary)] bg-[linear-gradient(180deg,rgba(15,23,42,0.9),rgba(30,41,59,0.95))]">
                 <svg
                   ref={svgRef}
                   viewBox={viewBox}
@@ -2402,7 +2402,7 @@ export default function MacroDesignerDialog({ onClose }: MacroDesignerDialogProp
                   {planWarnings.length > 0 && (
                     <div className="mt-2 rounded-md border border-amber-400/25 bg-amber-500/10 px-2 py-1 text-[11px] text-amber-100">{planWarnings.join(' ')}</div>
                   )}
-                  <div ref={executionOutputRef} className="mt-2 h-[26vh] min-h-[7rem] max-h-[12rem] overflow-y-auto rounded-md border border-[var(--color-bg-tertiary)] bg-[var(--color-bg-secondary)] px-2 py-1 font-mono text-[11px]">
+                  <div ref={executionOutputRef} className="mt-2 h-[20vh] min-h-[5rem] max-h-[10rem] overflow-y-auto rounded-md border border-[var(--color-bg-tertiary)] bg-[var(--color-bg-secondary)] px-2 py-1 font-mono text-[11px]">
                     {simulationLog.length === 0 ? (
                       <div className="text-[var(--color-text-secondary)]">No commands executed.</div>
                     ) : simulationLog.map((entry) => (

--- a/frontend/src/components/dialogs/MacroDesignerDialog.tsx
+++ b/frontend/src/components/dialogs/MacroDesignerDialog.tsx
@@ -37,6 +37,7 @@ import {
   computeTrapezoidalProfile,
   createInitialRuntimeState,
   executeSimulationStep,
+  parseParams,
   trapezoidalPositionAtTime,
 } from '../../utils/gcodeSimulator';
 import { logMacroDesignerEvent } from '../../utils/macroDesignerLog';
@@ -339,6 +340,7 @@ export default function MacroDesignerDialog({ onClose }: MacroDesignerDialogProp
   const [runtime, setRuntime] = useState<MacroRuntimeState | null>(null);
   const [stepIndex, setStepIndex] = useState(0);
   const [planWarnings, setPlanWarnings] = useState<string[]>([]);
+  const [simulationParamsInput, setSimulationParamsInput] = useState('');
   const [isRunning, setIsRunning] = useState(false);
   const [moveFeedRate, setMoveFeedRate] = useState('');
   const [nozzleTarget, setNozzleTarget] = useState('200');
@@ -515,12 +517,17 @@ export default function MacroDesignerDialog({ onClose }: MacroDesignerDialogProp
     return { x: r.x, y: viewBounds.viewMaxY - r.y };
   }, [machineProfile, rotation, viewBounds.viewMaxY]);
 
+  const simulationRootParams = useMemo(() => parseParams(simulationParamsInput.trim().split(/\s+/)), [simulationParamsInput]);
+
   const simulationPlan = useMemo(() => {
     if (!selectedItem) {
       return { steps: [], warnings: [] };
     }
-    return buildSimulationSteps(selectedItem, allMacroItems, machineProfile, configFiles);
-  }, [allMacroItems, configFiles, machineProfile, selectedItem]);
+    return buildSimulationSteps(selectedItem, allMacroItems, machineProfile, configFiles, {
+      params: simulationRootParams,
+      rawparams: simulationParamsInput.trim(),
+    });
+  }, [allMacroItems, configFiles, machineProfile, selectedItem, simulationRootParams, simulationParamsInput]);
 
   const simulationTimeline = useMemo<SimulationTimelineState>(() => {
     if (!selectedItem) {
@@ -2295,6 +2302,19 @@ export default function MacroDesignerDialog({ onClose }: MacroDesignerDialogProp
                       <span>Max {formatNumber(machineProfile.maxVelocity)} mm/s</span>
                       <span>Accel {formatNumber(machineProfile.maxAccel)} mm/s²</span>
                     </div>
+                  </div>
+                  <div className="mt-3 flex flex-wrap items-center gap-2 rounded-lg border border-[var(--color-bg-tertiary)] bg-[var(--color-bg-secondary)] px-3 py-2">
+                    <label htmlFor="simulation-params" className="shrink-0 text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--color-text-secondary)]">Params</label>
+                    <input
+                      id="simulation-params"
+                      type="text"
+                      value={simulationParamsInput}
+                      onChange={(event) => setSimulationParamsInput(event.target.value)}
+                      placeholder="TEMP=60 FAN=255"
+                      spellCheck={false}
+                      className="min-w-0 flex-1 rounded-md border border-[var(--color-bg-tertiary)] bg-[var(--color-bg-primary)] px-2 py-1 font-mono text-[11px] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-secondary)] focus:border-[var(--color-accent)] focus:outline-none"
+                    />
+                    <span className="text-[10px] text-[var(--color-text-secondary)]">Applied to root macro</span>
                   </div>
                   <div className="mt-3 rounded-lg border border-[var(--color-bg-tertiary)] bg-[var(--color-bg-secondary)] px-3 py-2">
                     <div className="flex items-start justify-between gap-3">

--- a/frontend/src/components/dialogs/MacroDesignerDialog.tsx
+++ b/frontend/src/components/dialogs/MacroDesignerDialog.tsx
@@ -640,6 +640,7 @@ export default function MacroDesignerDialog({ onClose }: MacroDesignerDialogProp
     setToolheadDragPos(null);
     setEditMode(false);
     setEditDraft(null);
+    setSeededRuntime(null);
   }, [selectedKey]);
 
   useEffect(() => {
@@ -1347,6 +1348,25 @@ export default function MacroDesignerDialog({ onClose }: MacroDesignerDialogProp
       ? `${result.eventSummary} — ${result.warnings.join(' ')}`
       : `${result.eventSummary} (seeded)`);
   }, [configFiles, machineProfile, seededRuntime, seedInput, selectedItem, setRuntime]);
+
+  const handleResetMachineState = useCallback(() => {
+    cancelAnimation(true);
+    setIsRunning(false);
+    setSeededRuntime(null);
+    setToolheadDragPos(null);
+    setSelectedLogWarning(null);
+    setRuntimeHistory([]);
+    setSimulationLog([]);
+    setLastMovementTrace(null);
+    setSimulationZIndicator(null);
+    setStepIndex(0);
+    setGoToX('');
+    setGoToY('');
+    setGoToZ('');
+    const fresh = createInitialRuntimeState(machineProfile, selectedItem?.title || 'reset');
+    setRuntime(fresh);
+    setMessage('Machine state reset: toolhead centered, not homed, heaters off.');
+  }, [cancelAnimation, machineProfile, selectedItem, setRuntime]);
 
   const handleGoTo = () => {
     const currentPosition = getCurrentToolheadPosition();
@@ -2086,11 +2106,21 @@ export default function MacroDesignerDialog({ onClose }: MacroDesignerDialogProp
                 <div className="min-w-[360px] basis-[24rem] flex-shrink-0 rounded-lg border border-[var(--color-bg-tertiary)] bg-[rgba(15,23,42,0.72)] px-3 py-2 text-[10px] text-[var(--color-text-secondary)]">
                   <div className="mb-1 flex items-center justify-between gap-3">
                     <div className="text-[10px] font-semibold uppercase tracking-[0.16em]">Machine state</div>
-                    <div className="inline-flex overflow-hidden rounded-md border border-[var(--color-bg-tertiary)]">
+                    <div className="flex items-center gap-2">
                       <button
                         type="button"
-                        disabled={!editMode || !displayedItem}
-                        onClick={() => handleSetMoveMode('absolute')}
+                        disabled={editMode || !displayedItem}
+                        onClick={handleResetMachineState}
+                        className="rounded-md border border-[var(--color-bg-tertiary)] px-2 py-0.5 text-[10px] text-[var(--color-text-primary)] hover:border-red-400/60 hover:text-red-300 disabled:opacity-40"
+                        title="Stop simulation, clear seeded commands, reset toolhead to centered/cold"
+                      >
+                        Reset
+                      </button>
+                      <div className="inline-flex overflow-hidden rounded-md border border-[var(--color-bg-tertiary)]">
+                        <button
+                          type="button"
+                          disabled={!editMode || !displayedItem}
+                          onClick={() => handleSetMoveMode('absolute')}
                         className={`px-2.5 py-0.5 text-[10px] font-semibold transition-colors disabled:opacity-60 ${activeMoveMode === 'absolute' ? 'bg-[var(--color-accent)] text-[var(--color-bg-primary)]' : 'text-[var(--color-text-primary)]'}`}
                       >
                         Absolute
@@ -2103,6 +2133,7 @@ export default function MacroDesignerDialog({ onClose }: MacroDesignerDialogProp
                       >
                         Relative
                       </button>
+                    </div>
                     </div>
                   </div>
                   <div className="grid grid-cols-[minmax(13rem,1.25fr)_minmax(0,1fr)] gap-x-5 gap-y-1 font-mono tabular-nums text-[var(--color-text-primary)]">
@@ -2414,11 +2445,7 @@ export default function MacroDesignerDialog({ onClose }: MacroDesignerDialogProp
                         Seeded: X {formatNumber(seededRuntime.x)} Y {formatNumber(seededRuntime.y)} Z {formatNumber(seededRuntime.z)}
                         {seededRuntime.homedAxes.length ? ` | homed: ${seededRuntime.homedAxes.join('')}` : ' | not homed'}
                       </span>
-                      <button onClick={() => {
-                        setSeededRuntime(null);
-                        setSelectedLogWarning(null);
-                        setMessage('Machine state reset to default (center, not homed, heaters off).');
-                      }} className="shrink-0 rounded-md border border-[var(--color-bg-tertiary)] px-2 py-0.5 text-[10px] text-[var(--color-text-primary)] hover:border-red-400/60 hover:text-red-300">Reset</button>
+                      <button onClick={handleResetMachineState} className="shrink-0 rounded-md border border-[var(--color-bg-tertiary)] px-2 py-0.5 text-[10px] text-[var(--color-text-primary)] hover:border-red-400/60 hover:text-red-300">Reset</button>
                     </div>
                   )}
                 </div>

--- a/frontend/src/components/dialogs/MacroDesignerDialog.tsx
+++ b/frontend/src/components/dialogs/MacroDesignerDialog.tsx
@@ -3,7 +3,7 @@ import { useConfigStore } from '../../stores/configStore';
 import { useGraphStore } from '../../stores/graphStore';
 import { createDefaultDraft, useMacroDesignerStore } from '../../stores/macroDesignerStore';
 import * as api from '../../services/api';
-import type { ConfigFile, ConfigSection } from '../../types/config';
+import type { ConfigFile } from '../../types/config';
 import type {
   MacroDraft,
   MachineProfile,
@@ -13,17 +13,22 @@ import type {
   SimulationTickResult,
 } from '../../types/macroDesigner';
 import {
+  areEquivalentMacroItems,
   buildConfigMacroItemKey,
+  createGcodeMacroSection,
   createMachineProfile,
   deriveAvailableBuiltInMacros,
   deriveCurrentMacroItems,
+  findMatchingTargetMacroSection,
   findPathZoneHit,
   findZoneHit,
   fuzzyFilterItems,
+  getSectionParamValue,
+  isMacroItemUnchangedInSection,
   isPointInMoveBounds,
   normalizeMacroGcodeForConfig,
+  normalizePlainText,
   parseMacroGcodeFromEditorView,
-  parseMacroVariables,
   sanitizeMacroName,
   serializeMacroVariables,
 } from '../../utils/macroDesigner';
@@ -163,52 +168,6 @@ const SUPPORTED_GCODE_COMMANDS: SupportedGcodeCommand[] = [
 
 const PLAYBACK_ITEM_KEY = 'playback:loaded';
 
-function createGcodeMacroSection(item: MacroSourceItem): ConfigSection {
-  const params = [];
-  if (item.description.trim()) {
-    params.push({ key: 'description', value: item.description.trim(), comment: '', is_commented_out: false, separator: ':' });
-  }
-  if (item.renameExisting.trim()) {
-    params.push({ key: 'rename_existing', value: item.renameExisting.trim(), comment: '', is_commented_out: false, separator: ':' });
-  }
-  params.push(...parseMacroVariables(item.variables));
-  params.push({
-    key: 'gcode',
-    value: normalizeMacroGcodeForConfig(item.gcode) || '\n',
-    comment: '',
-    is_commented_out: false,
-    separator: ':',
-  });
-  return {
-    section_type: 'gcode_macro',
-    section_name: sanitizeMacroName(item.title),
-    full_header: `gcode_macro ${sanitizeMacroName(item.title)}`,
-    line_number: item.sourceLine ?? 0,
-    params,
-    header_comments: [],
-    trailing_comments: [],
-    is_commented_out: false,
-  };
-}
-
-function getSectionParamValue(section: ConfigSection | undefined, key: string): string {
-  return section?.params.find((param) => param.key === key && !param.is_commented_out)?.value || '';
-}
-
-function normalizePlainText(value: string): string {
-  return value.replace(/\r\n?/g, '\n').trim();
-}
-
-function areEquivalentMacroItems(left: MacroSourceItem, right: MacroSourceItem): boolean {
-  return (
-    sanitizeMacroName(left.title) === sanitizeMacroName(right.title)
-    && normalizePlainText(left.renameExisting) === normalizePlainText(right.renameExisting)
-    && normalizePlainText(left.description) === normalizePlainText(right.description)
-    && normalizePlainText(left.variables) === normalizePlainText(right.variables)
-    && normalizeMacroGcodeForConfig(left.gcode) === normalizeMacroGcodeForConfig(right.gcode)
-  );
-}
-
 function createStandaloneDraftItem(draft: MacroDraft): MacroSourceItem {
   return {
     key: `draft:${draft.id}`,
@@ -221,41 +180,6 @@ function createStandaloneDraftItem(draft: MacroDraft): MacroSourceItem {
     draftId: draft.id,
     isDraft: true,
   };
-}
-
-function findMatchingTargetMacroSection(
-  configFiles: Record<string, ConfigFile>,
-  item: MacroSourceItem,
-  targetFile: string,
-): ConfigSection | null {
-  const macroSection = createGcodeMacroSection(item);
-  const sections = configFiles[targetFile]?.sections || [];
-
-  return sections.find((candidate) => {
-    if (candidate.full_header !== macroSection.full_header) {
-      return false;
-    }
-    if (item.source === 'config' && item.sourceFile === targetFile && macroSection.line_number > 0) {
-      return candidate.line_number === macroSection.line_number;
-    }
-    return true;
-  }) || null;
-}
-
-function isMacroItemUnchangedInSection(item: MacroSourceItem, section: ConfigSection | null): boolean {
-  if (!section) {
-    return false;
-  }
-
-  const existingGcode = normalizeMacroGcodeForConfig(getSectionParamValue(section, 'gcode'));
-  const selectedGcode = normalizeMacroGcodeForConfig(item.gcode);
-
-  return (
-    existingGcode === selectedGcode
-    && normalizePlainText(getSectionParamValue(section, 'rename_existing')) === normalizePlainText(item.renameExisting)
-    && normalizePlainText(getSectionParamValue(section, 'description')) === normalizePlainText(item.description)
-    && normalizePlainText(serializeMacroVariables(section)) === normalizePlainText(item.variables)
-  );
 }
 
 function getMacroItemBadges(item: MacroSourceItem): string[] {
@@ -1011,8 +935,8 @@ export default function MacroDesignerDialog({ onClose }: MacroDesignerDialogProp
       return false;
     }
 
-    const macroSection = createGcodeMacroSection(item);
     const existingTargetSection = findMatchingTargetMacroSection(configFiles, item, destinationFile);
+    const macroSection = createGcodeMacroSection(item, existingTargetSection);
     if (existingTargetSection && isMacroItemUnchangedInSection(item, existingTargetSection)) {
       return false;
     }

--- a/frontend/src/components/dialogs/MacroDesignerDialog.tsx
+++ b/frontend/src/components/dialogs/MacroDesignerDialog.tsx
@@ -2372,7 +2372,6 @@ export default function MacroDesignerDialog({ onClose }: MacroDesignerDialogProp
                       spellCheck={false}
                       className="min-w-0 flex-1 rounded-md border border-[var(--color-bg-tertiary)] bg-[var(--color-bg-primary)] px-2 py-1 font-mono text-[11px] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-secondary)] focus:border-[var(--color-accent)] focus:outline-none"
                     />
-                    <span className="text-[10px] text-[var(--color-text-secondary)]">Applied to root macro</span>
                   </div>
                   <div className="mt-3 rounded-lg border border-[var(--color-bg-tertiary)] bg-[var(--color-bg-secondary)] px-3 py-2">
                     <div className="flex items-start justify-between gap-3">

--- a/frontend/src/utils/__tests__/gcodeSimulator.test.ts
+++ b/frontend/src/utils/__tests__/gcodeSimulator.test.ts
@@ -251,3 +251,47 @@ describe('executeSimulationStep', () => {
     expect(result.nextState.activeProbePoint).toEqual({ x: 100, y: 100, label: 'PROBE' });
   });
 });
+
+describe('unresolved template symbols (P0-3 crash guard)', () => {
+  it('does not throw when range() receives an unresolved symbol arg', () => {
+    const profile = makeProfile();
+    // params.COUNT is not supplied → resolves to the TEMPLATE_UNRESOLVED
+    // symbol; Number(Symbol) previously threw inside evaluateTemplateCall.
+    const macro = makeMacro(
+      '{% for i in range(params.COUNT) %}\nG1 X{10 + i}\n{% endfor %}',
+      { title: 'RANGE_UNRESOLVED' },
+    );
+    expect(() => buildSimulationSteps(macro, [macro], profile)).not.toThrow();
+  });
+
+  it('does not throw when range() receives an unresolved reference', () => {
+    const profile = makeProfile();
+    // printer.foo is not a known object → unresolved symbol.
+    const macro = makeMacro(
+      '{% for i in range(printer.foo.bar) %}\nG1 X{i}\n{% endfor %}',
+      { title: 'RANGE_REF_UNRESOLVED' },
+    );
+    expect(() => buildSimulationSteps(macro, [macro], profile)).not.toThrow();
+  });
+
+  it('degrades to a warning rather than crashing on unresolved range bounds', () => {
+    const profile = makeProfile();
+    const macro = makeMacro(
+      '{% for i in range(printer.foo.bar) %}\nG1 X{i}\n{% endfor %}',
+      { title: 'RANGE_WARN' },
+    );
+    const plan = buildSimulationSteps(macro, [macro], profile);
+    expect(Array.isArray(plan.warnings)).toBe(true);
+  });
+
+  it('does not throw when printf formatting receives an unresolved symbol in a list', () => {
+    const profile = makeProfile();
+    // '%d' % [unresolved] — the list keeps the Symbol inside, bypassing
+    // the binary-operator guard; Number(Symbol) previously threw.
+    const macro = makeMacro(
+      "{% set msg = '%d' % [printer.foo.bar] %}\nRESPOND MSG={msg}",
+      { title: 'PRINTF_UNRESOLVED' },
+    );
+    expect(() => buildSimulationSteps(macro, [macro], profile)).not.toThrow();
+  });
+});

--- a/frontend/src/utils/__tests__/gcodeSimulator.test.ts
+++ b/frontend/src/utils/__tests__/gcodeSimulator.test.ts
@@ -284,6 +284,28 @@ describe('unresolved template symbols (P0-3 crash guard)', () => {
     expect(Array.isArray(plan.warnings)).toBe(true);
   });
 
+  it('skips the loop body when range() is unresolvable', () => {
+    const profile = makeProfile();
+    const macro = makeMacro(
+      '{% for i in range(params.LAYERS) %}\nG1 X10\n{% endfor %}\nG28',
+      { title: 'RANGE_SKIP_BODY' },
+    );
+    const result = buildSimulationSteps(macro, [macro], profile);
+    const moveSteps = result.steps.filter((s): s is Extract<typeof s, { kind: 'move' }> => s.kind === 'move');
+    expect(moveSteps).toHaveLength(0);
+  });
+
+  it('keeps numeric range() working', () => {
+    const profile = makeProfile();
+    const macro = makeMacro(
+      '{% for i in range(0, 3) %}\nM117 pass {{ i }}\n{% endfor %}',
+      { title: 'RANGE_NUMERIC' },
+    );
+    const result = buildSimulationSteps(macro, [macro], profile);
+    const respondSteps = result.steps.filter((s) => s.kind === 'command' && s.command.command === 'M117');
+    expect(respondSteps.length).toBe(3);
+  });
+
   it('does not throw when printf formatting receives an unresolved symbol in a list', () => {
     const profile = makeProfile();
     // '%d' % [unresolved] — the list keeps the Symbol inside, bypassing

--- a/frontend/src/utils/__tests__/gcodeSimulator.test.ts
+++ b/frontend/src/utils/__tests__/gcodeSimulator.test.ts
@@ -7,7 +7,7 @@ import {
   parseGcodeLine,
   trapezoidalPositionAtTime,
 } from '@/utils/gcodeSimulator';
-import type { MachineProfile, MacroSourceItem } from '@/types/macroDesigner';
+import type { MachineProfile, MacroSourceItem, SimulationStep } from '@/types/macroDesigner';
 
 function makeProfile(overrides: Partial<MachineProfile> = {}): MachineProfile {
   return {
@@ -292,6 +292,75 @@ describe('unresolved template symbols (P0-3 crash guard)', () => {
       "{% set msg = '%d' % [printer.foo.bar] %}\nRESPOND MSG={msg}",
       { title: 'PRINTF_UNRESOLVED' },
     );
+    expect(() => buildSimulationSteps(macro, [macro], profile)).not.toThrow();
+  });
+});
+
+describe('root macro invocation params (P0-2)', () => {
+  it('resolves params.* references from the root invocation', () => {
+    const profile = makeProfile();
+    const macro = makeMacro(
+      'M104 S{params.TEMP}',
+      { title: 'SET_TEMP' },
+    );
+    const plan = buildSimulationSteps(macro, [macro], profile, undefined, {
+      params: { TEMP: '80' },
+      rawparams: 'TEMP=80',
+    });
+    // The M104 target should be 80, not unresolved.
+    expect(plan.steps.length).toBe(1);
+    expect(plan.warnings).toEqual([]);
+    expect(plan.steps[0].kind).toBe('command');
+    const step = plan.steps[0] as Extract<SimulationStep, { kind: 'command' }>;
+    expect(step.command.raw).toContain('S80');
+  });
+
+  it('propagates params written on a nested macro call line', () => {
+    const profile = makeProfile();
+    const root = makeMacro(
+      'MY_HEATER TEMP=90',
+      { title: 'ROOT', key: 'root' },
+    );
+    const nested = makeMacro(
+      'M104 S{params.TEMP}',
+      { title: 'MY_HEATER', key: 'nested' },
+    );
+    const plan = buildSimulationSteps(root, [root, nested], profile, undefined, {
+      params: { TEMP: '50' },
+      rawparams: 'TEMP=50',
+    });
+    // Params are per-invocation (Klipper semantics): the nested macro
+    // receives TEMP from its own call line, not from the root.
+    expect(plan.steps[0].kind).toBe('command');
+    const step = plan.steps[0] as Extract<SimulationStep, { kind: 'command' }>;
+    expect(step.command.raw).toContain('S90');
+  });
+
+  it('does not inherit root params into a bare nested call (Klipper semantics)', () => {
+    const profile = makeProfile();
+    const root = makeMacro(
+      'MY_HEATER',
+      { title: 'ROOT', key: 'root' },
+    );
+    const nested = makeMacro(
+      'M104 S{params.TEMP}',
+      { title: 'MY_HEATER', key: 'nested' },
+    );
+    const plan = buildSimulationSteps(root, [root, nested], profile, undefined, {
+      params: { TEMP: '90' },
+      rawparams: 'TEMP=90',
+    });
+    // A bare call passes no params; the reference stays unresolved but
+    // must not throw (P0-3 regression guard).
+    expect(plan.steps[0].kind).toBe('command');
+    expect(plan.steps).toHaveLength(1);
+  });
+
+  it('treats an empty params object the same as before (no params)', () => {
+    const profile = makeProfile();
+    const macro = makeMacro('M104 S{params.TEMP}', { title: 'NO_PARAMS' });
+    // No rootInvocation supplied — the reference stays unresolved, but
+    // must not throw (regression guard for the Symbol crash).
     expect(() => buildSimulationSteps(macro, [macro], profile)).not.toThrow();
   });
 });

--- a/frontend/src/utils/__tests__/macroDesigner.test.ts
+++ b/frontend/src/utils/__tests__/macroDesigner.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from 'vitest';
+import type { ConfigFile, ConfigParam, ConfigSection } from '@/types/config';
+import type { MacroSourceItem } from '@/types/macroDesigner';
+import {
+  areEquivalentMacroItems,
+  createGcodeMacroSection,
+  findMatchingTargetMacroSection,
+  isMacroItemUnchangedInSection,
+  normalizeMacroGcodeForConfig,
+  normalizePlainText,
+  parseMacroGcodeFromEditorView,
+  parseMacroVariables,
+  serializeMacroVariables,
+} from '@/utils/macroDesigner';
+
+function makeSection(overrides: Partial<ConfigSection> = {}): ConfigSection {
+  return {
+    section_type: 'gcode_macro',
+    section_name: 'TEST',
+    full_header: 'gcode_macro TEST',
+    line_number: 10,
+    params: [],
+    header_comments: [],
+    trailing_comments: [],
+    is_commented_out: false,
+    ...overrides,
+  };
+}
+
+function makeParam(key: string, value: string, overrides: Partial<ConfigParam> = {}): ConfigParam {
+  return {
+    key,
+    value,
+    is_commented_out: false,
+    comment: '',
+    separator: ':',
+    ...overrides,
+  };
+}
+
+function makeMacro(overrides: Partial<MacroSourceItem> = {}): MacroSourceItem {
+  return {
+    key: 'config:printer.cfg:gcode_macro TEST:10',
+    source: 'config',
+    title: 'TEST',
+    renameExisting: '',
+    description: '',
+    variables: '',
+    gcode: 'G28\n',
+    ...overrides,
+  };
+}
+
+describe('createGcodeMacroSection', () => {
+  it('builds a gcode_macro section with description, rename, variables, gcode', () => {
+    const section = createGcodeMacroSection(makeMacro({
+      description: 'A test macro',
+      renameExisting: '_TEST',
+      variables: 'variable_heat: 60\nvariable_fan: 255',
+      gcode: 'M104 S{params.TEMP}\n',
+    }));
+
+    expect(section.section_type).toBe('gcode_macro');
+    expect(section.full_header).toBe('gcode_macro TEST');
+    expect(section.params.map((p) => p.key)).toEqual(['description', 'rename_existing', 'variable_heat', 'variable_fan', 'gcode']);
+    expect(section.params[0].value).toBe('A test macro');
+    expect(section.params[1].value).toBe('_TEST');
+    expect(section.params[2].value).toBe('60');
+    expect(section.params[4].value).toBe('\nM104 S{params.TEMP}');
+  });
+
+  it('normalizes the gcode body for config storage', () => {
+    const section = createGcodeMacroSection(makeMacro({ gcode: 'gcode:\n  G28\n' }));
+    expect(section.params.find((p) => p.key === 'gcode')?.value).toBe('\n  G28');
+  });
+
+  it('preserves header and trailing comments from the existing section', () => {
+    const existing = makeSection({
+      line_number: 42,
+      header_comments: ['# My print start macro', '# Used by START_PRINT'],
+      trailing_comments: ['# end of macro'],
+    });
+    const section = createGcodeMacroSection(makeMacro({ gcode: 'G28\n' }), existing);
+
+    expect(section.header_comments).toEqual(['# My print start macro', '# Used by START_PRINT']);
+    expect(section.trailing_comments).toEqual(['# end of macro']);
+    expect(section.line_number).toBe(42);
+  });
+
+  it('defaults comments to empty when no existing section', () => {
+    const section = createGcodeMacroSection(makeMacro());
+    expect(section.header_comments).toEqual([]);
+    expect(section.trailing_comments).toEqual([]);
+  });
+
+  it('sanitizes the section name from the title', () => {
+    const section = createGcodeMacroSection(makeMacro({ title: 'My Cool Macro!' }));
+    expect(section.section_name).toBe('My_Cool_Macro_');
+    expect(section.full_header).toBe('gcode_macro My_Cool_Macro_');
+  });
+});
+
+describe('findMatchingTargetMacroSection', () => {
+  function makeConfigFile(sections: ConfigSection[]): ConfigFile {
+    return { filename: 'printer.cfg', sections, includes: [], header_comments: [], raw_text: '' };
+  }
+
+  it('matches a config item by header and line number', () => {
+    const target = makeSection({ full_header: 'gcode_macro TEST', line_number: 10 });
+    const configFiles = { 'printer.cfg': makeConfigFile([
+      makeSection({ full_header: 'gcode_macro OTHER', line_number: 5 }),
+      target,
+    ]) };
+
+    const found = findMatchingTargetMacroSection(configFiles, makeMacro(), 'printer.cfg');
+    expect(found).toBe(target);
+  });
+
+  it('matches a draft item by header only (first match)', () => {
+    const first = makeSection({ full_header: 'gcode_macro TEST', line_number: 10 });
+    const second = makeSection({ full_header: 'gcode_macro TEST', line_number: 20 });
+    const configFiles = { 'printer.cfg': makeConfigFile([first, second]) };
+
+    const found = findMatchingTargetMacroSection(
+      configFiles,
+      makeMacro({ source: 'draft', key: 'draft:1', sourceFile: undefined, sourceLine: undefined }),
+      'printer.cfg',
+    );
+    expect(found).toBe(first);
+  });
+
+  it('returns null when no section matches', () => {
+    const configFiles = { 'printer.cfg': makeConfigFile([makeSection({ full_header: 'gcode_macro OTHER' })]) };
+    expect(findMatchingTargetMacroSection(configFiles, makeMacro(), 'printer.cfg')).toBeNull();
+  });
+});
+
+describe('isMacroItemUnchangedInSection', () => {
+  it('returns true when item matches the section content', () => {
+    const section = makeSection({
+      params: [
+        makeParam('gcode', '\nG28'),
+        makeParam('description', 'A test macro'),
+      ],
+    });
+    expect(isMacroItemUnchangedInSection(makeMacro({ description: 'A test macro', gcode: 'G28\n' }), section)).toBe(true);
+  });
+
+  it('returns false when gcode differs', () => {
+    const section = makeSection({ params: [makeParam('gcode', '\nG28')] });
+    expect(isMacroItemUnchangedInSection(makeMacro({ gcode: 'G28 X0\n' }), section)).toBe(false);
+  });
+
+  it('returns false for a null section', () => {
+    expect(isMacroItemUnchangedInSection(makeMacro(), null)).toBe(false);
+  });
+});
+
+describe('areEquivalentMacroItems', () => {
+  it('ignores formatting differences in gcode', () => {
+    const base = makeMacro({ gcode: 'G28\nG1 X10 Y10\n' });
+    const formatted = makeMacro({ gcode: 'gcode:\nG28\nG1 X10 Y10\n' });
+    expect(areEquivalentMacroItems(base, formatted)).toBe(true);
+  });
+
+  it('detects real differences', () => {
+    const base = makeMacro({ description: 'one' });
+    const other = makeMacro({ description: 'two' });
+    expect(areEquivalentMacroItems(base, other)).toBe(false);
+  });
+});
+
+describe('gcode normalization round-trip', () => {
+  it('parseMacroGcodeFromEditorView strips a leading gcode: directive', () => {
+    expect(parseMacroGcodeFromEditorView('gcode:\n  G28\n  M117 hi')).toBe('  G28\n  M117 hi');
+  });
+
+  it('normalizeMacroGcodeForConfig strips leading/trailing blank lines', () => {
+    expect(normalizeMacroGcodeForConfig('\n\nG28\n\n')).toBe('\nG28');
+  });
+
+  it('normalizeMacroGcodeForConfig returns empty string for blank body', () => {
+    expect(normalizeMacroGcodeForConfig('')).toBe('');
+    expect(normalizeMacroGcodeForConfig('\n')).toBe('');
+  });
+
+  it('preserves comment lines inside the gcode body', () => {
+    expect(normalizeMacroGcodeForConfig('# comment\nG28\n')).toBe('\n# comment\nG28');
+  });
+});
+
+describe('variables round-trip', () => {
+  it('serializes and parses variables with comments and blank lines', () => {
+    const params: ConfigParam[] = [
+      makeParam('variable_heat', '60'),
+      { key: '_comment_', value: '', comment: '', is_commented_out: false },
+      makeParam('variable_fan', '255', { is_commented_out: true }),
+      { key: '_comment_', value: '# a full-line comment', comment: '', is_commented_out: false },
+    ];
+    const text = serializeMacroVariables({ ...makeSection(), params });
+    expect(text).toBe('variable_heat: 60\n\n#variable_fan: 255\n# a full-line comment');
+
+    const reparsed = parseMacroVariables(text);
+    expect(reparsed.find((p) => p.key === 'variable_heat')?.value).toBe('60');
+    expect(reparsed.find((p) => p.key === 'variable_fan')?.is_commented_out).toBe(true);
+  });
+
+  it('parses = separator variables', () => {
+    const reparsed = parseMacroVariables('variable_x=1\nvariable_y: 2');
+    expect(reparsed[0].key).toBe('variable_x');
+    expect(reparsed[0].value).toBe('1');
+    expect(reparsed[0].separator).toBe('=');
+    expect(reparsed[1].key).toBe('variable_y');
+    expect(reparsed[1].separator).toBe(':');
+  });
+});
+
+describe('normalizePlainText', () => {
+  it('normalizes line endings and trims', () => {
+    expect(normalizePlainText('  hello\r\nworld\r')).toBe('hello\nworld');
+  });
+});

--- a/frontend/src/utils/__tests__/macroDesigner.test.ts
+++ b/frontend/src/utils/__tests__/macroDesigner.test.ts
@@ -187,6 +187,14 @@ describe('gcode normalization round-trip', () => {
   it('preserves comment lines inside the gcode body', () => {
     expect(normalizeMacroGcodeForConfig('# comment\nG28\n')).toBe('\n# comment\nG28');
   });
+
+  it('preserves indentation through the editor round-trip', () => {
+    const indented = '    G28\n    {% if printer.extruder.temperature > 170 %}\n        M117 hot\n    {% else %}\n        M117 cold\n    {% endif %}';
+    // Editor display value → what gets written to config
+    expect(normalizeMacroGcodeForConfig(indented)).toBe(`\n${indented}`);
+    // What the user types (with gcode: directive) → stored editor value
+    expect(parseMacroGcodeFromEditorView(`gcode:\n${indented}`)).toBe(indented);
+  });
 });
 
 describe('variables round-trip', () => {

--- a/frontend/src/utils/__tests__/macroDesignerLog.test.ts
+++ b/frontend/src/utils/__tests__/macroDesignerLog.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  flushMacroDesignerLog,
+  logMacroDesignerEvent,
+} from '@/utils/macroDesignerLog';
+
+/**
+ * The logger no-ops outside a browser (node test env), so to exercise
+ * its batching/POST logic we stub `window` + `fetch` and flush
+ * synchronously.
+ */
+describe('macroDesignerLog', () => {
+  const originalWindow = globalThis.window;
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    // Simulate a browser environment.
+    Object.defineProperty(globalThis, 'window', { value: {}, configurable: true, writable: true });
+    globalThis.fetch = vi.fn().mockResolvedValue(new Response('{"ok":true}', { status: 200 }));
+  });
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, 'window', { value: originalWindow, configurable: true, writable: true });
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('no-ops outside a browser (no window)', () => {
+    Object.defineProperty(globalThis, 'window', { value: undefined, configurable: true, writable: true });
+    const fetchSpy = vi.fn();
+    globalThis.fetch = fetchSpy;
+    logMacroDesignerEvent({ event: 'section:build', title: 'X' });
+    flushMacroDesignerLog();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('batches events and POSTs them to the backend endpoint', () => {
+    const fetchSpy = vi.mocked(globalThis.fetch);
+    logMacroDesignerEvent({ event: 'section:build', title: 'PRINT_START' });
+    logMacroDesignerEvent({ event: 'apply', title: 'PRINT_START', action: 'update' });
+    flushMacroDesignerLog();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe('/api/log/macro-designer');
+    const body = JSON.parse(String(init?.body));
+    expect(body.events).toHaveLength(2);
+    expect(body.events[0].event).toBe('section:build');
+    expect(body.events[1].event).toBe('apply');
+  });
+
+  it('includes a timestamp on each event', () => {
+    const fetchSpy = vi.mocked(globalThis.fetch);
+    logMacroDesignerEvent({ event: 'sim:plan', macro: 'PRINT_START' });
+    flushMacroDesignerLog();
+
+    const body = JSON.parse(String(fetchSpy.mock.calls[0][1]?.body));
+    expect(typeof body.events[0].ts).toBe('string');
+    expect(Number.isNaN(Date.parse(body.events[0].ts))).toBe(false);
+  });
+
+  it('never throws when the backend is unreachable', () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error('network down'));
+    expect(() => {
+      logMacroDesignerEvent({ event: 'apply', title: 'X' });
+      flushMacroDesignerLog();
+    }).not.toThrow();
+  });
+});

--- a/frontend/src/utils/__tests__/macroProbe.test.ts
+++ b/frontend/src/utils/__tests__/macroProbe.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Macro Designer probe — run the frontend gcode simulator on a macro
+ * from the command line, without opening the UI.
+ *
+ * Usage (from frontend/):
+ *   MACRO_GCODE='{% set t = params.TEMP|default(60) %}' npx vitest run src/utils/__tests__/macroProbe.test.ts
+ *   MACRO_TITLE=PRINT_START MACRO_GCODE='G28\nG1 X100 Y50 F1200' npx vitest run src/utils/__tests__/macroProbe.test.ts
+ *
+ * Prints the plan as JSON to stdout: steps (moves/probes/commands),
+ * warnings, and the final simulated toolhead state. This is the same
+ * engine the Macro Designer dialog uses (buildSimulationSteps), so a
+ * repro here is a repro in the UI. Pass the macro as a single string;
+ * use \n for newlines.
+ */
+import { describe, it } from 'vitest';
+import {
+  buildSimulationSteps,
+  createInitialRuntimeState,
+  executeSimulationStep,
+} from '@/utils/gcodeSimulator';
+import type { MachineProfile } from '@/types/macroDesigner';
+
+const gcode = process.env.MACRO_GCODE || '';
+const title = process.env.MACRO_TITLE || 'PROBE';
+
+function makeProfile(): MachineProfile {
+  return {
+    shape: 'rect',
+    kinematics: 'corexy',
+    minX: 0, maxX: 300, minY: 0, maxY: 300, minZ: 0, maxZ: 250,
+    moveMinX: -5, moveMaxX: 305, moveMinY: -5, moveMaxY: 305,
+    centerX: 150, centerY: 150, radius: null,
+    homeX: 0, homeY: 0, homeZ: 0,
+    hasProbe: false, probeOffsetX: 0, probeOffsetY: 0,
+    probeSamples: 3, probeSpeed: 5, probeLiftSpeed: 10, probeSampleRetractDist: 2,
+    horizontalMoveZ: 5, nozzleMaxTemp: 260, bedMaxTemp: 120,
+    maxExtrudeCrossSection: 1.0, maxVelocity: 500, maxAccel: 3000,
+    noGoZones: [], dockPosition: null, homingOverride: null, featurePoints: {},
+  };
+}
+
+describe('macro designer probe', () => {
+  it('simulates the provided macro and prints the plan', () => {
+    if (!gcode) {
+      console.log('No MACRO_GCODE env var set — skipping probe. Usage: MACRO_GCODE="G28\\nG1 X100" npx vitest run src/utils/__tests__/macroProbe.test.ts');
+      return;
+    }
+    const profile = makeProfile();
+    const root = {
+      key: 'probe',
+      source: 'draft' as const,
+      title,
+      renameExisting: '',
+      description: '',
+      variables: '',
+      gcode,
+    };
+
+    const plan = buildSimulationSteps(root, [root], profile);
+
+    let state = createInitialRuntimeState(profile, title);
+    const trace: Array<{ kind: string; summary: string; warnings: string[] }> = [];
+    for (const step of plan.steps) {
+      const result = executeSimulationStep(state, step, profile);
+      state = result.nextState;
+      trace.push({ kind: step.kind, summary: result.eventSummary, warnings: result.warnings });
+    }
+
+    const report = {
+      macro: title,
+      stepCount: plan.steps.length,
+      warnings: plan.warnings,
+      trace,
+      finalState: {
+        x: Math.round(state.x * 100) / 100,
+        y: Math.round(state.y * 100) / 100,
+        z: Math.round(state.z * 100) / 100,
+        e: Math.round(state.e * 100) / 100,
+        feedRate: state.feedRate,
+        homedAxes: state.homedAxes,
+        elapsedTimeS: Math.round(state.elapsedTimeS * 100) / 100,
+      },
+    };
+    console.log(`\n===== MACRO SIM PROBE: ${title} =====`);
+    console.log(JSON.stringify(report, null, 2));
+  });
+});

--- a/frontend/src/utils/__tests__/macroProbe.test.ts
+++ b/frontend/src/utils/__tests__/macroProbe.test.ts
@@ -4,24 +4,27 @@
  *
  * Usage (from frontend/):
  *   MACRO_GCODE='{% set t = params.TEMP|default(60) %}' npx vitest run src/utils/__tests__/macroProbe.test.ts
- *   MACRO_TITLE=PRINT_START MACRO_GCODE='G28\nG1 X100 Y50 F1200' npx vitest run src/utils/__tests__/macroProbe.test.ts
+ *   MACRO_TITLE=PRINT_START MACRO_GCODE='M104 S{params.TEMP}' MACRO_PARAMS='TEMP=80' npx vitest run src/utils/__tests__/macroProbe.test.ts
  *
  * Prints the plan as JSON to stdout: steps (moves/probes/commands),
  * warnings, and the final simulated toolhead state. This is the same
  * engine the Macro Designer dialog uses (buildSimulationSteps), so a
  * repro here is a repro in the UI. Pass the macro as a single string;
- * use \n for newlines.
+ * use \n for newlines. MACRO_PARAMS accepts Klipper-style space
+ * separated KEY=VALUE pairs applied to the root macro invocation.
  */
 import { describe, it } from 'vitest';
 import {
   buildSimulationSteps,
   createInitialRuntimeState,
   executeSimulationStep,
+  parseParams,
 } from '@/utils/gcodeSimulator';
 import type { MachineProfile } from '@/types/macroDesigner';
 
 const gcode = process.env.MACRO_GCODE || '';
 const title = process.env.MACRO_TITLE || 'PROBE';
+const rootParams = parseParams((process.env.MACRO_PARAMS || '').trim().split(/\s+/));
 
 function makeProfile(): MachineProfile {
   return {
@@ -56,7 +59,10 @@ describe('macro designer probe', () => {
       gcode,
     };
 
-    const plan = buildSimulationSteps(root, [root], profile);
+    const plan = buildSimulationSteps(root, [root], profile, undefined, {
+      params: rootParams,
+      rawparams: (process.env.MACRO_PARAMS || '').trim(),
+    });
 
     let state = createInitialRuntimeState(profile, title);
     const trace: Array<{ kind: string; summary: string; warnings: string[] }> = [];

--- a/frontend/src/utils/__tests__/macroScenarios.test.ts
+++ b/frontend/src/utils/__tests__/macroScenarios.test.ts
@@ -505,3 +505,119 @@ describe('machine-state template fidelity', () => {
     expect(state.y).toBeCloseTo(90, 5);
   });
 });
+
+describe('inline template segments on mixed lines (2026-08-12 fix)', () => {
+  it('directive with trailing comment executes the set (sensorless.cfg _HOME_X pattern)', () => {
+    const profile = makeProfile();
+    const macros = [
+      makeMacro(
+        [
+          '{% set HOME_CURRENT = 1 %}  ## Change this to the value you used when calibrating stallguard.',
+          'SET_TMC_CURRENT STEPPER=stepper_x CURRENT={HOME_CURRENT}',
+        ].join('\n'),
+        '_HOME_X',
+        'home_x',
+      ),
+    ];
+
+    const { plan, stepWarnings, trace } = runSimulation(macros[0], macros, profile);
+
+    expect(plan.warnings).toEqual([]);
+    expect(stepWarnings.some((w) => w.includes('Unsupported command'))).toBe(false);
+    expect(trace).toContain('SET_TMC_CURRENT');
+    // The rendered command carries the resolved CURRENT=1 from the set above.
+    const setCurrentStep = plan.steps.find((step) => step.kind === 'command' && step.command.command === 'SET_TMC_CURRENT');
+    expect(commandRaw(setCurrentStep!)).toContain('CURRENT=1');
+  });
+
+  it('multiple directives on one line all execute', () => {
+    const profile = makeProfile();
+    const macros = [
+      makeMacro(
+        [
+          '{% set a = 1 %} {% set b = 2 %}',
+          'M117 {a}-{b}',
+        ].join('\n'),
+        'MULTI_SET',
+        'multi_set',
+      ),
+    ];
+
+    const { plan, stepWarnings, trace } = runSimulation(macros[0], macros, profile);
+
+    expect(plan.warnings).toEqual([]);
+    expect(stepWarnings.some((w) => w.includes('Unsupported command'))).toBe(false);
+    expect(trace.some((entry) => entry.includes('1-2'))).toBe(true);
+  });
+
+  it('inline if/endif on one line renders conditionally', () => {
+    const profile = makeProfile();
+    const macros = [
+      makeMacro('{% if 1 == 1 %} G28 {% endif %}', 'INLINE_IF_TRUE', 'inline_if_true'),
+      makeMacro('{% if 1 == 2 %} G28 {% endif %}', 'INLINE_IF_FALSE', 'inline_if_false'),
+    ];
+
+    const runTrue = runSimulation(macros[0], macros, profile);
+    const runFalse = runSimulation(macros[1], macros, profile);
+
+    expect(runTrue.plan.warnings).toEqual([]);
+    expect(runTrue.stepWarnings.some((w) => w.includes('Unsupported command'))).toBe(false);
+    expect(runTrue.trace).toContain('Home axes');
+
+    expect(runFalse.plan.warnings).toEqual([]);
+    expect(runFalse.stepWarnings.some((w) => w.includes('Unsupported command'))).toBe(false);
+    expect(runFalse.trace).not.toContain('Home axes');
+  });
+
+  it('jinja {# #} comment lines are ignored', () => {
+    const profile = makeProfile();
+    const macros = [
+      makeMacro(
+        [
+          '{# home current note #}',
+          'G28',
+        ].join('\n'),
+        'JINJA_COMMENT',
+        'jinja_comment',
+      ),
+    ];
+
+    const { plan, stepWarnings, trace } = runSimulation(macros[0], macros, profile);
+
+    expect(plan.warnings).toEqual([]);
+    expect(stepWarnings.some((w) => w.includes('Unsupported command'))).toBe(false);
+    expect(trace).toContain('Home axes');
+  });
+
+  it('inline for loop expands into a command line (M109 override pattern)', () => {
+    const profile = makeProfile();
+    const macros = [
+      makeMacro(
+        "M104 {% for p in params %}{'%s%s' % (p, params[p])}{% endfor %}  ; Set hotend temp",
+        'M104',
+        'm104',
+      ),
+    ];
+
+    const { plan, stepWarnings, trace } = runSimulation(macros[0], macros, profile, { S: '80' }, 'S=80');
+
+    expect(plan.warnings).toEqual([]);
+    expect(stepWarnings.some((w) => w.includes('Unsupported command'))).toBe(false);
+    expect(trace).toContain('Set nozzle target 80C');
+  });
+
+  it('a bare nested macro call still sees no root params (unchanged semantics)', () => {
+    const profile = makeProfile();
+    const macros = [
+      makeMacro('MY_HEATER', 'ROOT', 'root'),
+      makeMacro('M117 {params.TEMP}', 'MY_HEATER', 'my_heater'),
+    ];
+
+    const { plan, stepWarnings } = runSimulation(macros[0], macros, profile, { TEMP: '80' }, 'TEMP=80');
+
+    expect(plan.warnings).toEqual([]);
+    // Bare call: params are NOT inherited — TEMP stays unresolved, but the
+    // sim must not crash or emit an unsupported-command warning.
+    expect(stepWarnings.some((w) => w.includes('Unsupported command'))).toBe(false);
+  });
+});

--- a/frontend/src/utils/__tests__/macroScenarios.test.ts
+++ b/frontend/src/utils/__tests__/macroScenarios.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildSimulationSteps,
+  createInitialRuntimeState,
+  executeSimulationStep,
+} from '@/utils/gcodeSimulator';
+import type { MachineProfile, MacroSourceItem, SimulationStep } from '@/types/macroDesigner';
+
+/**
+ * Scenario-level integration tests for the Macro Designer simulator.
+ *
+ * Unit tests cover individual functions; these cover realistic
+ * multi-macro flows end-to-end through the same pipeline the dialog
+ * uses (buildSimulationSteps → executeSimulationStep), with a
+ * Trident-like profile (300x300 corexy, probe, bed mesh).
+ */
+
+function makeProfile(overrides: Partial<MachineProfile> = {}): MachineProfile {
+  return {
+    shape: 'rect',
+    kinematics: 'corexy',
+    minX: 0, maxX: 300, minY: 0, maxY: 300, minZ: 0, maxZ: 250,
+    moveMinX: -5, moveMaxX: 305, moveMinY: -5, moveMaxY: 305,
+    centerX: 150, centerY: 150, radius: null,
+    homeX: 0, homeY: 0, homeZ: 0,
+    hasProbe: true, probeOffsetX: 0, probeOffsetY: 0,
+    probeSamples: 3, probeSpeed: 5, probeLiftSpeed: 10, probeSampleRetractDist: 2,
+    horizontalMoveZ: 5, nozzleMaxTemp: 260, bedMaxTemp: 120,
+    maxExtrudeCrossSection: 1.0, maxVelocity: 500, maxAccel: 3000,
+    noGoZones: [], dockPosition: null, homingOverride: null, featurePoints: {},
+    ...overrides,
+  };
+}
+
+function makeMacro(gcode: string, title: string, key: string): MacroSourceItem {
+  return {
+    key, source: 'draft', title, renameExisting: '', description: '', variables: '', gcode,
+  };
+}
+
+function runSimulation(
+  root: MacroSourceItem,
+  allMacros: MacroSourceItem[],
+  profile: MachineProfile,
+  params: Record<string, string> = {},
+  rawparams = '',
+) {
+  const plan = buildSimulationSteps(root, allMacros, profile, undefined, { params, rawparams });
+  let state = createInitialRuntimeState(profile, root.title);
+  const trace: string[] = [];
+  const stepWarnings: string[] = [];
+  for (const step of plan.steps) {
+    const result = executeSimulationStep(state, step, profile);
+    state = result.nextState;
+    trace.push(result.eventSummary);
+    stepWarnings.push(...result.warnings);
+  }
+  return { plan, state, trace, stepWarnings };
+}
+
+function commandRaw(step: SimulationStep): string | null {
+  return step.kind === 'command' ? step.command.raw : null;
+}
+
+function g1Commands(plan: { steps: SimulationStep[] }): string[] {
+  return plan.steps
+    .filter((step) => step.kind === 'command' && step.command.command === 'G1')
+    .map((step) => (step as Extract<SimulationStep, { kind: 'command' }>).command.raw);
+}
+
+describe('macro designer scenarios', () => {
+  it('PRINT_START with params: heat, home, prime, move to start', () => {
+    const profile = makeProfile();
+    const macros = [
+      makeMacro(
+        [
+          '{% set bed_temp = params.BED|default(60) %}',
+          '{% set nozzle_temp = params.TEMP|default(200) %}',
+          'M140 S{bed_temp}',
+          'M104 S{nozzle_temp}',
+          'G28',
+          'G1 X150 Y150 Z5 F3000',
+          'G92 E0',
+          'G1 E5 F600',
+          'G1 Z0.3 F300',
+        ].join('\n'),
+        'PRINT_START',
+        'print_start',
+      ),
+    ];
+
+    const { plan, state, trace } = runSimulation(
+      macros[0], macros, profile, { BED: '70', TEMP: '210' }, 'BED=70 TEMP=210',
+    );
+
+    expect(plan.warnings).toEqual([]);
+    expect(trace).toContain('Set bed target 70C');
+    expect(trace).toContain('Set nozzle target 210C');
+    expect(trace).toContain('Home axes');
+    // Final toolhead: primed then dropped to Z0.3.
+    expect(state.x).toBe(150);
+    expect(state.y).toBe(150);
+    expect(state.z).toBeCloseTo(0.3, 5);
+    expect(state.e).toBeGreaterThan(0);
+  });
+
+  it('PRINT_START without params falls back to defaults (no crash)', () => {
+    const profile = makeProfile();
+    const macros = [
+      makeMacro(
+        'M140 S{params.BED|default(60)}\nM104 S{params.TEMP|default(200)}\nG28',
+        'PRINT_START',
+        'print_start',
+      ),
+    ];
+
+    const { plan, trace } = runSimulation(macros[0], macros, profile);
+
+    expect(plan.warnings).toEqual([]);
+    expect(trace).toContain('Set bed target 60C');
+    expect(trace).toContain('Set nozzle target 200C');
+  });
+
+  it('nested macro call with params on the call line', () => {
+    const profile = makeProfile();
+    const macros = [
+      makeMacro('_HEAT TEMP=95\nG28', 'PRINT_START', 'print_start'),
+      makeMacro('M104 S{params.TEMP}', '_HEAT', 'heat'),
+    ];
+
+    const { plan, trace } = runSimulation(macros[0], macros, profile);
+
+    expect(plan.warnings).toEqual([]);
+    expect(trace).toContain('Set nozzle target 95C');
+    expect(plan.steps.some((step) => commandRaw(step)?.includes('S95'))).toBe(true);
+  });
+
+  it('loop over resolved range produces repeated steps', () => {
+    const profile = makeProfile();
+    const macros = [
+      makeMacro(
+        '{% for i in range(3) %}\nG1 X{10 + i * 50} Y50 F1200\n{% endfor %}',
+        'SWEEP',
+        'sweep',
+      ),
+    ];
+
+    const { plan, state } = runSimulation(macros[0], macros, profile);
+
+    expect(plan.warnings).toEqual([]);
+    // 3 G1 commands: X10, X60, X110 (G1 expands as command steps).
+    expect(g1Commands(plan)).toHaveLength(3);
+    expect(g1Commands(plan)[2]).toContain('X110');
+    expect(state.x).toBeCloseTo(110, 5);
+  });
+
+  it('unresolved range bound degrades to warnings, not a crash', () => {
+    const profile = makeProfile();
+    const macros = [
+      makeMacro(
+        '{% for i in range(params.COUNT) %}\nG1 X{10 + i * 50} Y50\n{% endfor %}',
+        'SWEEP',
+        'sweep',
+      ),
+    ];
+
+    const { plan } = runSimulation(macros[0], macros, profile);
+
+    // No crash; the loop body is skipped because the bound is unresolved.
+    expect(plan.steps).toHaveLength(0);
+  });
+
+  it('no-go zone move produces a warning but still executes', () => {
+    const profile = makeProfile({
+      noGoZones: [{ id: 'z1', name: 'Blocked', x: 80, y: 30, width: 40, height: 40 }],
+    });
+    const macros = [
+      makeMacro('G28\nG1 X100 Y50 F1200', 'MOVE', 'move'),
+    ];
+
+    const { plan, state, trace, stepWarnings } = runSimulation(macros[0], macros, profile);
+
+    // Zone warnings are per-execution-step (applyLinearMove), not
+    // planning-time warnings.
+    expect(stepWarnings.length).toBeGreaterThan(0);
+    expect(stepWarnings.some((w) => w.toLowerCase().includes('no-go'))).toBe(true);
+    expect(state.x).toBeCloseTo(100, 5);
+    expect(trace).toContain('Home axes');
+  });
+
+  it('probe point is recorded on a probe move', () => {
+    const profile = makeProfile();
+    const macros = [
+      makeMacro('PROBE\nPROBE\nPROBE', 'MESH', 'mesh'),
+    ];
+
+    const { plan, state } = runSimulation(macros[0], macros, profile);
+
+    // 3 PROBE commands × 3 samples each = 9 probe sample steps.
+    expect(plan.steps.filter((step) => step.kind === 'probe')).toHaveLength(9);
+    expect(state.activeProbePoint).not.toBeNull();
+  });
+});

--- a/frontend/src/utils/__tests__/macroScenarios.test.ts
+++ b/frontend/src/utils/__tests__/macroScenarios.test.ts
@@ -4,6 +4,7 @@ import {
   createInitialRuntimeState,
   executeSimulationStep,
 } from '@/utils/gcodeSimulator';
+import type { ConfigFile, ConfigParam, ConfigSection } from '@/types/config';
 import type { MachineProfile, MacroSourceItem, SimulationStep } from '@/types/macroDesigner';
 
 /**
@@ -38,14 +39,39 @@ function makeMacro(gcode: string, title: string, key: string): MacroSourceItem {
   };
 }
 
+function makeParam(key: string, value: string): ConfigParam {
+  return {
+    key, value, is_commented_out: false, comment: '', separator: ':',
+  };
+}
+
+function makeSection(overrides: Partial<ConfigSection> = {}): ConfigSection {
+  return {
+    section_type: 'printer',
+    section_name: 'printer',
+    full_header: 'printer',
+    line_number: 1,
+    params: [],
+    header_comments: [],
+    trailing_comments: [],
+    is_commented_out: false,
+    ...overrides,
+  };
+}
+
+function makeConfigFile(sections: ConfigSection[]): ConfigFile {
+  return { filename: 'printer.cfg', sections, includes: [], header_comments: [], raw_text: '' };
+}
+
 function runSimulation(
   root: MacroSourceItem,
   allMacros: MacroSourceItem[],
   profile: MachineProfile,
   params: Record<string, string> = {},
   rawparams = '',
+  configFiles?: Record<string, ConfigFile>,
 ) {
-  const plan = buildSimulationSteps(root, allMacros, profile, undefined, { params, rawparams });
+  const plan = buildSimulationSteps(root, allMacros, profile, configFiles, { params, rawparams });
   let state = createInitialRuntimeState(profile, root.title);
   const trace: string[] = [];
   const stepWarnings: string[] = [];
@@ -199,5 +225,93 @@ describe('macro designer scenarios', () => {
     // 3 PROBE commands × 3 samples each = 9 probe sample steps.
     expect(plan.steps.filter((step) => step.kind === 'probe')).toHaveLength(9);
     expect(state.activeProbePoint).not.toBeNull();
+  });
+});
+
+describe('machine-state template fidelity', () => {
+  it('resolves printer.configfile.settings.<section>.<param> (Klipper API)', () => {
+    const profile = makeProfile();
+    const configFiles = {
+      'printer.cfg': makeConfigFile([
+        makeSection({
+          params: [
+            makeParam('kinematics', 'corexy'),
+            makeParam('max_velocity', '500'),
+            makeParam('max_accel', '5000'),
+          ],
+        }),
+      ]),
+    };
+    const macros = [
+      makeMacro(
+        'RESPOND MSG={printer.configfile.settings.printer.max_velocity}',
+        'READ_VELOCITY',
+        'read_velocity',
+      ),
+    ];
+
+    const { plan, trace } = runSimulation(macros[0], macros, profile, {}, '', configFiles);
+
+    expect(plan.warnings).toEqual([]);
+    expect(trace.some((entry) => entry.includes('500'))).toBe(true);
+  });
+
+  it('resolves printer.configfile.settings with a gcode_macro variable', () => {
+    const profile = makeProfile();
+    const configFiles = {
+      'printer.cfg': makeConfigFile([
+        makeSection({
+          section_type: 'gcode_macro',
+          section_name: 'PRINT_START',
+          full_header: 'gcode_macro PRINT_START',
+          params: [makeParam('variable_heat', '60')],
+        }),
+      ]),
+    };
+    const macros = [
+      makeMacro(
+        'RESPOND MSG={printer.configfile.settings["gcode_macro PRINT_START"].variable_heat}',
+        'READ_VAR',
+        'read_var',
+      ),
+    ];
+
+    const { plan, trace } = runSimulation(macros[0], macros, profile, {}, '', configFiles);
+
+    expect(plan.warnings).toEqual([]);
+    expect(trace.some((entry) => entry.includes('60'))).toBe(true);
+  });
+
+  it('resolves printer.toolhead.axis_maximum from the machine profile', () => {
+    const profile = makeProfile({ maxX: 350, maxY: 350, maxZ: 300 });
+    const macros = [
+      makeMacro(
+        'G1 X{printer.toolhead.axis_maximum.x} Y{printer.toolhead.axis_maximum.y} F3000',
+        'READ_MAX',
+        'read_max',
+      ),
+    ];
+
+    const { plan, state } = runSimulation(macros[0], macros, profile);
+
+    expect(plan.warnings).toEqual([]);
+    expect(state.x).toBeCloseTo(350, 5);
+    expect(state.y).toBeCloseTo(350, 5);
+  });
+
+  it('resolves printer.toolhead.axis_minimum from the machine profile', () => {
+    const profile = makeProfile({ minX: -10, minY: -10 });
+    const macros = [
+      makeMacro(
+        'RESPOND MSG={printer.toolhead.axis_minimum.x}',
+        'READ_MIN',
+        'read_min',
+      ),
+    ];
+
+    const { plan, trace } = runSimulation(macros[0], macros, profile);
+
+    expect(plan.warnings).toEqual([]);
+    expect(trace.some((entry) => entry.includes('-10'))).toBe(true);
   });
 });

--- a/frontend/src/utils/__tests__/macroScenarios.test.ts
+++ b/frontend/src/utils/__tests__/macroScenarios.test.ts
@@ -3,6 +3,7 @@ import {
   buildSimulationSteps,
   createInitialRuntimeState,
   executeSimulationStep,
+  executeStandaloneCommand,
 } from '@/utils/gcodeSimulator';
 import type { ConfigFile, ConfigParam, ConfigSection } from '@/types/config';
 import type { MachineProfile, MacroSourceItem, SimulationStep } from '@/types/macroDesigner';
@@ -105,6 +106,8 @@ describe('macro designer scenarios', () => {
           'M140 S{bed_temp}',
           'M104 S{nozzle_temp}',
           'G28',
+          'M190 S{bed_temp}',
+          'M109 S{nozzle_temp}',
           'G1 X150 Y150 Z5 F3000',
           'G92 E0',
           'G1 E5 F600',
@@ -165,7 +168,7 @@ describe('macro designer scenarios', () => {
     const profile = makeProfile();
     const macros = [
       makeMacro(
-        '{% for i in range(3) %}\nG1 X{10 + i * 50} Y50 F1200\n{% endfor %}',
+        'G28\n{% for i in range(3) %}\nG1 X{10 + i * 50} Y50 F1200\n{% endfor %}',
         'SWEEP',
         'sweep',
       ),
@@ -286,7 +289,7 @@ describe('machine-state template fidelity', () => {
     const profile = makeProfile({ maxX: 350, maxY: 350, maxZ: 300 });
     const macros = [
       makeMacro(
-        'G1 X{printer.toolhead.axis_maximum.x} Y{printer.toolhead.axis_maximum.y} F3000',
+        'G28\nG1 X{printer.toolhead.axis_maximum.x} Y{printer.toolhead.axis_maximum.y} F3000',
         'READ_MAX',
         'read_max',
       ),
@@ -319,7 +322,7 @@ describe('machine-state template fidelity', () => {
     const profile = makeProfile();
     const macros = [
       makeMacro(
-        'G1 X100 Y50 F3000\nRESPOND MSG={printer.toolhead.position.x}',
+        'G28\nG1 X100 Y50 F3000\nRESPOND MSG={printer.toolhead.position.x}',
         'READ_POS',
         'read_pos',
       ),
@@ -394,5 +397,111 @@ describe('machine-state template fidelity', () => {
 
     expect(plan.warnings).toEqual([]);
     expect(trace.some((entry) => entry.includes('idle'))).toBe(true);
+  });
+
+  it('initial machine state is dead: centered, unhomed, heaters off', () => {
+    const profile = makeProfile();
+    const state = createInitialRuntimeState(profile, 'ANY');
+
+    expect(state.x).toBe(profile.centerX);
+    expect(state.y).toBe(profile.centerY);
+    expect(state.homedAxes).toEqual([]);
+    expect(state.bed.target).toBe(0);
+    expect(state.nozzle.target).toBe(0);
+  });
+
+  it('refuses a move on unhomed axes with a warning', () => {
+    const profile = makeProfile();
+    const macros = [
+      makeMacro('G1 X100 Y50 F3000', 'MOVE_UNHOMED', 'move_unhomed'),
+    ];
+
+    const { plan, state, stepWarnings } = runSimulation(macros[0], macros, profile);
+
+    expect(plan.warnings).toEqual([]);
+    expect(stepWarnings.some((w) => w.toLowerCase().includes('homed'))).toBe(true);
+    // Klipper refuses the move: position stays at the initial center.
+    expect(state.x).toBe(profile.centerX);
+    expect(state.y).toBe(profile.centerY);
+  });
+
+  it('allows a move after G28 homes the axes', () => {
+    const profile = makeProfile();
+    const macros = [
+      makeMacro('G28\nG1 X100 Y50 F3000', 'MOVE_HOMED', 'move_homed'),
+    ];
+
+    const { plan, state, stepWarnings } = runSimulation(macros[0], macros, profile);
+
+    expect(plan.warnings).toEqual([]);
+    expect(stepWarnings.length).toBe(0);
+    expect(state.x).toBeCloseTo(100, 5);
+    expect(state.y).toBeCloseTo(50, 5);
+  });
+
+  it('refuses extrusion while the nozzle is cold', () => {
+    const profile = makeProfile();
+    const macros = [
+      makeMacro('G28\nG1 E5 F600', 'COLD_EXTRUDE', 'cold_extrude'),
+    ];
+
+    const { plan, state, stepWarnings } = runSimulation(macros[0], macros, profile);
+
+    expect(plan.warnings).toEqual([]);
+    expect(stepWarnings.some((w) => w.toLowerCase().includes('extrusion'))).toBe(true);
+    expect(state.e).toBe(0);
+  });
+
+  it('allows extrusion after the nozzle is hot (M109)', () => {
+    const profile = makeProfile();
+    const macros = [
+      makeMacro('G28\nM109 S200\nG1 E0.5 F600', 'HOT_EXTRUDE', 'hot_extrude'),
+    ];
+
+    const { plan, state, stepWarnings } = runSimulation(macros[0], macros, profile);
+
+    expect(plan.warnings).toEqual([]);
+    expect(stepWarnings.length).toBe(0);
+    expect(state.e).toBeCloseTo(0.5, 5);
+  });
+
+  it('refuses an out-of-range nozzle target and keeps the old one', () => {
+    const profile = makeProfile();
+    const macros = [
+      makeMacro('M104 S999', 'BAD_TEMP', 'bad_temp'),
+    ];
+
+    const { plan, state, trace, stepWarnings } = runSimulation(macros[0], macros, profile);
+
+    expect(plan.warnings).toEqual([]);
+    expect(stepWarnings.some((w) => w.toLowerCase().includes('exceeds'))).toBe(true);
+    expect(trace.some((entry) => entry.includes('Refuse nozzle target'))).toBe(true);
+    expect(state.nozzle.target).toBe(0);
+  });
+
+  it('standalone seeded state flows into the next simulation run', () => {
+    const profile = makeProfile();
+    const macros = [
+      makeMacro('G1 X80 Y90 F3000', 'SEEDED_MOVE', 'seeded_move'),
+    ];
+
+    // Simulate what the dialog does: seed G28 via executeStandaloneCommand,
+    // then use the resulting state as the initial state for the macro run.
+    const seedResult = executeStandaloneCommand('G28', createInitialRuntimeState(profile, macros[0].title), profile);
+    expect(seedResult.warnings).toEqual([]);
+    expect(seedResult.nextState.homedAxes).toEqual(['X', 'Y', 'Z']);
+
+    const plan = buildSimulationSteps(macros[0], macros, profile, undefined, { params: {}, rawparams: '' }, seedResult.nextState);
+    let state = seedResult.nextState;
+    const stepWarnings: string[] = [];
+    for (const step of plan.steps) {
+      const result = executeSimulationStep(state, step, profile);
+      state = result.nextState;
+      stepWarnings.push(...result.warnings);
+    }
+
+    expect(stepWarnings.length).toBe(0);
+    expect(state.x).toBeCloseTo(80, 5);
+    expect(state.y).toBeCloseTo(90, 5);
   });
 });

--- a/frontend/src/utils/__tests__/macroScenarios.test.ts
+++ b/frontend/src/utils/__tests__/macroScenarios.test.ts
@@ -314,4 +314,85 @@ describe('machine-state template fidelity', () => {
     expect(plan.warnings).toEqual([]);
     expect(trace.some((entry) => entry.includes('-10'))).toBe(true);
   });
+
+  it('tracks live toolhead position as moves execute', () => {
+    const profile = makeProfile();
+    const macros = [
+      makeMacro(
+        'G1 X100 Y50 F3000\nRESPOND MSG={printer.toolhead.position.x}',
+        'READ_POS',
+        'read_pos',
+      ),
+    ];
+
+    const { plan, trace } = runSimulation(macros[0], macros, profile);
+
+    expect(plan.warnings).toEqual([]);
+    // The RESPOND runs after the move: position.x should be 100.
+    expect(trace.some((entry) => entry.includes('100'))).toBe(true);
+  });
+
+  it('resolves printer.gcode_move.homing_origin from the profile home', () => {
+    const profile = makeProfile({ homeX: 0, homeY: 0, homeZ: 0 });
+    const macros = [
+      makeMacro(
+        '{% set origin = printer.gcode_move.homing_origin %}\nRESPOND MSG={origin.x}',
+        'READ_ORIGIN',
+        'read_origin',
+      ),
+    ];
+
+    const { plan, trace } = runSimulation(macros[0], macros, profile);
+
+    expect(plan.warnings).toEqual([]);
+    expect(trace.some((entry) => entry.includes('0'))).toBe(true);
+  });
+
+  it('resolves printer.print_stats.info.current_layer as null when not printing', () => {
+    const profile = makeProfile();
+    const macros = [
+      makeMacro(
+        '{% set layer = printer.print_stats.info.current_layer if printer.print_stats.info.current_layer is not none else -1 %}\nRESPOND MSG={layer}',
+        'READ_LAYER',
+        'read_layer',
+      ),
+    ];
+
+    const { plan, trace } = runSimulation(macros[0], macros, profile);
+
+    expect(plan.warnings).toEqual([]);
+    expect(trace.some((entry) => entry.includes('-1'))).toBe(true);
+  });
+
+  it('resolves printer.quad_gantry_level.applied as false', () => {
+    const profile = makeProfile();
+    const macros = [
+      makeMacro(
+        '{% if printer.quad_gantry_level.applied == False %}\nRESPOND MSG="not applied"\n{% endif %}',
+        'READ_QGL',
+        'read_qgl',
+      ),
+    ];
+
+    const { plan, trace } = runSimulation(macros[0], macros, profile);
+
+    expect(plan.warnings).toEqual([]);
+    expect(trace.some((entry) => entry.includes('not applied'))).toBe(true);
+  });
+
+  it('resolves printer.idle_timeout.state', () => {
+    const profile = makeProfile();
+    const macros = [
+      makeMacro(
+        '{% if printer.idle_timeout.state|upper == "IDLE" %}\nRESPOND MSG="idle"\n{% endif %}',
+        'READ_IDLE',
+        'read_idle',
+      ),
+    ];
+
+    const { plan, trace } = runSimulation(macros[0], macros, profile);
+
+    expect(plan.warnings).toEqual([]);
+    expect(trace.some((entry) => entry.includes('idle'))).toBe(true);
+  });
 });

--- a/frontend/src/utils/__tests__/macroScenarios.test.ts
+++ b/frontend/src/utils/__tests__/macroScenarios.test.ts
@@ -77,7 +77,7 @@ function runSimulation(
   const trace: string[] = [];
   const stepWarnings: string[] = [];
   for (const step of plan.steps) {
-    const result = executeSimulationStep(state, step, profile);
+    const result = executeSimulationStep(state, step, profile, configFiles);
     state = result.nextState;
     trace.push(result.eventSummary);
     stepWarnings.push(...result.warnings);
@@ -619,5 +619,66 @@ describe('inline template segments on mixed lines (2026-08-12 fix)', () => {
     // Bare call: params are NOT inherited — TEMP stays unresolved, but the
     // sim must not crash or emit an unsupported-command warning.
     expect(stepWarnings.some((w) => w.includes('Unsupported command'))).toBe(false);
+  });
+
+  it('honors a configured [extruder] min_extrude_temp above the default', () => {
+    const profile = makeProfile();
+    // Machine overrides min_extrude_temp to 200C (Klipper default is 170).
+    const configFiles = {
+      'printer.cfg': makeConfigFile([
+        makeSection({
+          section_type: 'extruder',
+          section_name: 'extruder',
+          full_header: 'extruder',
+          params: [makeParam('min_extrude_temp', '200')],
+        }),
+      ]),
+    };
+    const macros = [
+      makeMacro(
+        [
+          'G28',
+          'M109 S180', // nozzle hot but below the configured 200C floor
+          'G1 E5 F600',
+        ].join('\n'),
+        'EXTRUDE_COLD',
+        'extrude_cold',
+      ),
+    ];
+
+    const { state, stepWarnings } = runSimulation(macros[0], macros, profile, {}, '', configFiles);
+
+    expect(stepWarnings.some((w) => w.includes('above 200C'))).toBe(true);
+    expect(state.e).toBe(0); // move refused — no extrusion happened
+  });
+
+  it('allows extrusion between default and configured min_extrude_temp', () => {
+    const profile = makeProfile();
+    const configFiles = {
+      'printer.cfg': makeConfigFile([
+        makeSection({
+          section_type: 'extruder',
+          section_name: 'extruder',
+          full_header: 'extruder',
+          params: [makeParam('min_extrude_temp', '200')],
+        }),
+      ]),
+    };
+    const macros = [
+      makeMacro(
+        [
+          'G28',
+          'M109 S210', // above the configured 200C floor
+          'G1 E5 F600',
+        ].join('\n'),
+        'EXTRUDE_HOT',
+        'extrude_hot',
+      ),
+    ];
+
+    const { state, stepWarnings } = runSimulation(macros[0], macros, profile, {}, '', configFiles);
+
+    expect(stepWarnings.some((w) => w.includes('above 200C'))).toBe(false);
+    expect(state.e).toBeGreaterThan(0); // extrusion succeeded
   });
 });

--- a/frontend/src/utils/__tests__/quoteParams.test.ts
+++ b/frontend/src/utils/__tests__/quoteParams.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { parseGcodeLine, parseParams } from '@/utils/gcodeSimulator';
+
+describe('quote-aware param parsing', () => {
+  it('keeps single-quoted MSG values intact', () => {
+    const parsed = parseGcodeLine("RESPOND TYPE=echo MSG='Printer not homed'", 1, 'test');
+    expect(parsed?.command).toBe('RESPOND');
+    expect(parsed?.params.MSG).toBe('Printer not homed');
+  });
+
+  it('keeps double-quoted MSG values intact', () => {
+    const parsed = parseGcodeLine('RESPOND MSG="hello world"', 1, 'test');
+    expect(parsed?.params.MSG).toBe('hello world');
+  });
+
+  it('parseParams strips both quote styles', () => {
+    expect(parseParams(["MSG='hello world'"])).toEqual({ MSG: 'hello world' });
+    expect(parseParams(['MSG="hello world"'])).toEqual({ MSG: 'hello world' });
+  });
+
+  it('still parses plain KEY=VALUE and positional params', () => {
+    expect(parseParams(['TEMP=80', 'FAN=255'])).toEqual({ TEMP: '80', FAN: '255' });
+    expect(parseParams(['X100', 'Y50'])).toEqual({ X: '100', Y: '50' });
+  });
+});

--- a/frontend/src/utils/__tests__/seedState.test.ts
+++ b/frontend/src/utils/__tests__/seedState.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildSimulationSteps,
+  createInitialRuntimeState,
+  executeSimulationStep,
+  executeStandaloneCommand,
+} from '@/utils/gcodeSimulator';
+import type { MachineProfile, MacroSourceItem } from '@/types/macroDesigner';
+
+/**
+ * Verifies the seeded-machine-state flow: user seeds commands (G28, M104)
+ * through the execution output box, then runs a macro that assumes that
+ * state — without needing its own homing/heating lines.
+ */
+function makeProfile(): MachineProfile {
+  return {
+    shape: 'rect',
+    kinematics: 'corexy',
+    minX: 0, maxX: 300, minY: 0, maxY: 300, minZ: 0, maxZ: 250,
+    moveMinX: -5, moveMaxX: 305, moveMinY: -5, moveMaxY: 305,
+    centerX: 150, centerY: 150, radius: null,
+    homeX: 0, homeY: 0, homeZ: 0,
+    hasProbe: true, probeOffsetX: 0, probeOffsetY: 0,
+    probeSamples: 3, probeSpeed: 5, probeLiftSpeed: 10, probeSampleRetractDist: 2,
+    horizontalMoveZ: 5, nozzleMaxTemp: 260, bedMaxTemp: 120,
+    maxExtrudeCrossSection: 1.0, maxVelocity: 500, maxAccel: 3000,
+    noGoZones: [], dockPosition: null, homingOverride: null, featurePoints: {},
+  };
+}
+
+function makeMacro(gcode: string, title: string, key: string): MacroSourceItem {
+  return { key, source: 'draft', title, renameExisting: '', description: '', variables: '', gcode };
+}
+
+describe('seeded machine state flow', () => {
+  it('dead printer refuses G1 until the user seeds G28', () => {
+    const profile = makeProfile();
+    const macro = makeMacro('G1 X100 Y50 F3000', 'MOVE', 'move');
+
+    // No seed: refused.
+    const state0 = createInitialRuntimeState(profile, macro.title);
+    const refused = executeStandaloneCommand('G1 X100 Y50 F3000', state0, profile);
+    expect(refused.warnings.some((w) => w.toLowerCase().includes('homed'))).toBe(true);
+    expect(refused.nextState.x).toBe(profile.centerX);
+
+    // Seed G28 through the box, then the same command works.
+    const seeded = executeStandaloneCommand('G28', state0, profile);
+    expect(seeded.warnings).toEqual([]);
+    const accepted = executeStandaloneCommand('G1 X100 Y50 F3000', seeded.nextState, profile);
+    expect(accepted.warnings).toEqual([]);
+    expect(accepted.nextState.x).toBeCloseTo(100, 5);
+  });
+
+  it('seeded state carries through buildSimulationSteps as the macro start', () => {
+    const profile = makeProfile();
+    const macro = makeMacro('G1 X80 Y90 F3000', 'SEEDED_MOVE', 'seeded_move');
+
+    const seeded = executeStandaloneCommand('G28', createInitialRuntimeState(profile, macro.title), profile);
+    const plan = buildSimulationSteps(macro, [macro], profile, undefined, { params: {}, rawparams: '' }, seeded.nextState);
+    let state = seeded.nextState;
+    const stepWarnings: string[] = [];
+    for (const step of plan.steps) {
+      const result = executeSimulationStep(state, step, profile);
+      state = result.nextState;
+      stepWarnings.push(...result.warnings);
+    }
+    expect(stepWarnings).toEqual([]);
+    expect(state.x).toBeCloseTo(80, 5);
+    expect(state.y).toBeCloseTo(90, 5);
+  });
+
+  it('seeded temp target is visible to later M104-less macros', () => {
+    const profile = makeProfile();
+    const macro = makeMacro('RESPOND MSG={printer.heater_bed.target}', 'READ_BED', 'read_bed');
+
+    const seeded = executeStandaloneCommand('M140 S70', createInitialRuntimeState(profile, macro.title), profile);
+    expect(seeded.warnings).toEqual([]);
+    expect(seeded.nextState.bed.target).toBe(70);
+
+    const plan = buildSimulationSteps(macro, [macro], profile, undefined, { params: {}, rawparams: '' }, seeded.nextState);
+    let state = seeded.nextState;
+    const trace: string[] = [];
+    for (const step of plan.steps) {
+      const result = executeSimulationStep(state, step, profile);
+      state = result.nextState;
+      trace.push(result.eventSummary);
+    }
+    expect(trace.some((entry) => entry.includes('70'))).toBe(true);
+  });
+});

--- a/frontend/src/utils/gcodeSimulator.ts
+++ b/frontend/src/utils/gcodeSimulator.ts
@@ -14,7 +14,7 @@ import type {
 import { logMacroDesignerEvent } from './macroDesignerLog';
 import { findPathZoneHit, findZoneHit, isPointInBounds, isPointInMoveBounds, parseMacroVariables } from './macroDesigner';
 
-function parseParams(tokens: string[]): Record<string, string> {
+export function parseParams(tokens: string[]): Record<string, string> {
   const params: Record<string, string> = {};
   for (const token of tokens) {
     if (!token) continue;
@@ -2307,6 +2307,7 @@ export function buildSimulationSteps(
   allMacros: MacroSourceItem[],
   profile: MachineProfile,
   configFiles?: Record<string, ConfigFile>,
+  rootInvocation?: { params?: Record<string, string>; rawparams?: string },
 ): SimulationBuildResult {
   const macroLookup = buildMacroLookup(allMacros);
   const warnings: string[] = [];
@@ -2545,13 +2546,18 @@ export function buildSimulationSteps(
     stack.pop();
   };
 
-  visit(root, true, { params: {}, rawparams: '', locals: {} });
+  visit(root, true, {
+    params: rootInvocation?.params ?? {},
+    rawparams: rootInvocation?.rawparams ?? '',
+    locals: {},
+  });
   logMacroDesignerEvent({
     event: 'sim:plan',
     macro: root.title,
     stepCount: steps.length,
     warningCount: warnings.length,
     warnings: warnings.slice(0, 10),
+    rootParams: rootInvocation?.params ?? {},
     nestedMacros: stack.length > 0 ? stack : undefined,
   });
   return { steps, warnings };

--- a/frontend/src/utils/gcodeSimulator.ts
+++ b/frontend/src/utils/gcodeSimulator.ts
@@ -853,6 +853,31 @@ const HOMING_AXES: Array<'X' | 'Y' | 'Z'> = ['X', 'Y', 'Z'];
 // Klipper's default [extruder] min_extrude_temp.
 const DEFAULT_MIN_EXTRUDE_TEMP = 170;
 
+/**
+ * Resolve the [extruder] min_extrude_temp for the simulated machine.
+ *
+ * Klipper refuses extrusion while the nozzle is below the configured
+ * min_extrude_temp (default 170C). Read it from the actual config so a
+ * machine that overrides it simulates faithfully, instead of always
+ * assuming the default.
+ */
+function getMinExtrudeTemp(configFiles?: Record<string, ConfigFile>): number {
+  if (configFiles) {
+    for (const configFile of Object.values(configFiles)) {
+      const extruder = configFile.sections.find((section) => section.section_type === 'extruder');
+      if (!extruder) {
+        continue;
+      }
+      const param = extruder.params.find((p) => p.key === 'min_extrude_temp' && !p.is_commented_out);
+      const parsed = param ? asNumber(param.value) : null;
+      if (parsed !== null && Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+  }
+  return DEFAULT_MIN_EXTRUDE_TEMP;
+}
+
 function getHomedAxesString(homedAxes: Set<'X' | 'Y' | 'Z'>): string {
   return HOMING_AXES.filter((axis) => homedAxes.has(axis)).map((axis) => axis.toLowerCase()).join('');
 }
@@ -2909,15 +2934,17 @@ function applyLinearMove(
     warnings.push(`Move requires homed ${unhomedAxes.join(', ')} axis (must home first).`);
   }
 
-  // Klipper refuses extrusion below min_extrude_temp (default 170C).
+  // Klipper refuses extrusion below min_extrude_temp (default 170C,
+  // overridable via [extruder] min_extrude_temp).
+  const minExtrudeTemp = getMinExtrudeTemp(configFiles);
   const extrudeDelta = nextE - state.e;
-  if (extrudeDelta > 0 && state.nozzle.current < DEFAULT_MIN_EXTRUDE_TEMP) {
+  if (extrudeDelta > 0 && state.nozzle.current < minExtrudeTemp) {
     warnings.push(
-      `Extrusion requires nozzle temperature above ${DEFAULT_MIN_EXTRUDE_TEMP}C (currently ${state.nozzle.current.toFixed(0)}C).`,
+      `Extrusion requires nozzle temperature above ${minExtrudeTemp}C (currently ${state.nozzle.current.toFixed(0)}C).`,
     );
   }
 
-  if (unhomedAxes.length > 0 || (extrudeDelta > 0 && state.nozzle.current < DEFAULT_MIN_EXTRUDE_TEMP)) {
+  if (unhomedAxes.length > 0 || (extrudeDelta > 0 && state.nozzle.current < minExtrudeTemp)) {
     // Klipper raises an error and the move does not execute.
     return {
       nextState: {

--- a/frontend/src/utils/gcodeSimulator.ts
+++ b/frontend/src/utils/gcodeSimulator.ts
@@ -583,6 +583,10 @@ type ProbeSamplingPlan = {
 type TemplateStaticContext = {
   printerObjects: Record<string, unknown>;
   configSections: Record<string, unknown>;
+  machineBounds?: {
+    axis_minimum: Record<string, number>;
+    axis_maximum: Record<string, number>;
+  };
 };
 
 type TemplateLineSegment =
@@ -735,9 +739,17 @@ function buildConfigSectionContext(section: ConfigFile['sections'][number]): Rec
 function buildTemplateStaticContext(
   allMacros: MacroSourceItem[],
   configFiles?: Record<string, ConfigFile>,
+  profile?: MachineProfile,
 ): TemplateStaticContext {
   const printerObjects: Record<string, unknown> = {};
   const configSections: Record<string, unknown> = {};
+
+  const machineBounds = profile
+    ? {
+        axis_minimum: { x: profile.minX, y: profile.minY, z: profile.minZ },
+        axis_maximum: { x: profile.maxX, y: profile.maxY, z: profile.maxZ },
+      }
+    : undefined;
 
   if (configFiles) {
     Object.values(configFiles).forEach((configFile) => {
@@ -765,7 +777,7 @@ function buildTemplateStaticContext(
     });
   });
 
-  return { printerObjects, configSections };
+  return { printerObjects, configSections, machineBounds };
 }
 
 function createInitialPlannerState(allMacros: MacroSourceItem[]): PlannerState {
@@ -1321,6 +1333,12 @@ function buildTemplatePrinterContext(
     homed_axes: getHomedAxesString(plannerState.homedAxes),
     home_axes: getHomedAxesString(plannerState.homedAxes),
     extruder: plannerState.activeExtruder,
+    ...(staticContext.machineBounds
+      ? {
+          axis_minimum: staticContext.machineBounds.axis_minimum,
+          axis_maximum: staticContext.machineBounds.axis_maximum,
+        }
+      : {}),
   });
   setContextVariants(printer, 'gcode_move', {
     ...asRecord(printer.gcode_move),
@@ -1350,6 +1368,9 @@ function buildTemplatePrinterContext(
   setContextVariants(printer, 'configfile', {
     ...asRecord(printer.configfile),
     config: staticContext.configSections,
+    // Real Klipper exposes settings via printer.configfile.settings
+    // (e.g. printer.configfile.settings.printer.max_velocity).
+    settings: staticContext.configSections,
   });
 
   if (plannerState.activeExtruder) {
@@ -2315,7 +2336,7 @@ export function buildSimulationSteps(
   const stack: string[] = [];
   const plannerState = createInitialPlannerState(allMacros);
   let previewState = createInitialRuntimeState(profile, root.title);
-  const staticContext = buildTemplateStaticContext(allMacros, configFiles);
+  const staticContext = buildTemplateStaticContext(allMacros, configFiles, profile);
   let visit: (macro: MacroSourceItem, allowHomingOverride?: boolean, invocation?: MacroInvocationContext) => void;
 
   const appendSimulationSteps = (nextSteps: SimulationStep[]) => {

--- a/frontend/src/utils/gcodeSimulator.ts
+++ b/frontend/src/utils/gcodeSimulator.ts
@@ -1975,7 +1975,7 @@ function evaluateTemplateCall(
 
   switch (name.toLowerCase()) {
     case 'range': {
-      const numericArgs = args.map((arg) => Number(arg));
+      const numericArgs = args.map((arg) => (isUnresolved(arg) ? NaN : Number(arg)));
       if (numericArgs.length === 0 || numericArgs.some((arg) => !Number.isFinite(arg)) || numericArgs.length > 3) {
         return TEMPLATE_UNRESOLVED;
       }
@@ -2005,12 +2005,13 @@ function evaluateTemplateCall(
 }
 
 function formatPrintfValue(specifier: string, precision: number | null, value: unknown): string {
+  const numericValue = isUnresolved(value) ? NaN : value;
   switch (specifier) {
     case 'd':
     case 'i':
-      return `${Math.trunc(Number(value) || 0)}`;
+      return `${Math.trunc(Number(numericValue) || 0)}`;
     case 'f': {
-      const numeric = Number(value);
+      const numeric = Number(numericValue);
       if (!Number.isFinite(numeric)) {
         return '0';
       }

--- a/frontend/src/utils/gcodeSimulator.ts
+++ b/frontend/src/utils/gcodeSimulator.ts
@@ -625,6 +625,8 @@ type TemplateStaticContext = {
     axis_minimum: Record<string, number>;
     axis_maximum: Record<string, number>;
   };
+  homePosition?: Record<string, number>;
+  livePosition?: () => { x: number; y: number; z: number; e: number };
 };
 
 type TemplateLineSegment =
@@ -778,6 +780,7 @@ function buildTemplateStaticContext(
   allMacros: MacroSourceItem[],
   configFiles?: Record<string, ConfigFile>,
   profile?: MachineProfile,
+  livePosition?: () => { x: number; y: number; z: number; e: number },
 ): TemplateStaticContext {
   const printerObjects: Record<string, unknown> = {};
   const configSections: Record<string, unknown> = {};
@@ -787,6 +790,9 @@ function buildTemplateStaticContext(
         axis_minimum: { x: profile.minX, y: profile.minY, z: profile.minZ },
         axis_maximum: { x: profile.maxX, y: profile.maxY, z: profile.maxZ },
       }
+    : undefined;
+  const homePosition = profile
+    ? { x: profile.homeX, y: profile.homeY, z: profile.homeZ }
     : undefined;
 
   if (configFiles) {
@@ -815,7 +821,7 @@ function buildTemplateStaticContext(
     });
   });
 
-  return { printerObjects, configSections, machineBounds };
+  return { printerObjects, configSections, machineBounds, homePosition, livePosition };
 }
 
 function createInitialPlannerState(allMacros: MacroSourceItem[]): PlannerState {
@@ -1056,7 +1062,7 @@ function stripEnclosingParens(expression: string): string {
   return trimmed;
 }
 
-function splitTopLevelByKeyword(expression: string, keyword: 'and' | 'or'): string[] {
+function splitTopLevelByKeyword(expression: string, keyword: 'and' | 'or' | 'else' | 'if'): string[] {
   const parts: string[] = [];
   let start = 0;
   let depthParen = 0;
@@ -1371,6 +1377,7 @@ function buildTemplatePrinterContext(
     homed_axes: getHomedAxesString(plannerState.homedAxes),
     home_axes: getHomedAxesString(plannerState.homedAxes),
     extruder: plannerState.activeExtruder,
+    ...(staticContext.livePosition ? { position: staticContext.livePosition() } : {}),
     ...(staticContext.machineBounds
       ? {
           axis_minimum: staticContext.machineBounds.axis_minimum,
@@ -1382,6 +1389,24 @@ function buildTemplatePrinterContext(
     ...asRecord(printer.gcode_move),
     absolute_coordinates: plannerState.absoluteMoves,
     absolute_extrude: plannerState.absoluteExtrusion,
+    ...(staticContext.homePosition ? { homing_origin: staticContext.homePosition } : {}),
+  });
+  setContextVariants(printer, 'print_stats', {
+    ...asRecord(printer.print_stats),
+    state: 'standby',
+    info: {
+      ...asRecord(asRecord(printer.print_stats).info),
+      current_layer: null,
+      current_speed: 0,
+    },
+  });
+  setContextVariants(printer, 'idle_timeout', {
+    ...asRecord(printer.idle_timeout),
+    state: 'Idle',
+  });
+  setContextVariants(printer, 'quad_gantry_level', {
+    ...asRecord(printer.quad_gantry_level),
+    applied: false,
   });
   setContextVariants(printer, 'fan', {
     ...asRecord(printer.fan),
@@ -1631,6 +1656,28 @@ function evaluateTemplateExpression(
     return TEMPLATE_UNRESOLVED;
   }
 
+  // Inline ternary: <true> if <cond> else <false> — split on a top-level
+  // 'else' first (shortest match so nested ternaries keep their own), then
+  // find the top-level 'if' in the true-branch.
+  const elseParts = splitTopLevelByKeyword(trimmed, 'else');
+  if (elseParts.length > 1) {
+    const trueExpression = elseParts[0];
+    const falseExpression = elseParts.slice(1).join(' else ');
+    const ifParts = splitTopLevelByKeyword(trueExpression, 'if');
+    if (ifParts.length > 1) {
+      const condition = ifParts[ifParts.length - 1];
+      const trueValueExpression = ifParts.slice(0, ifParts.length - 1).join(' if ');
+      const conditionValue = evaluateTemplateExpression(condition, invocation, plannerState, staticContext);
+      const conditionBoolean = coerceBoolean(conditionValue);
+      if (conditionBoolean === null) {
+        return TEMPLATE_UNRESOLVED;
+      }
+      return conditionBoolean
+        ? evaluateTemplateExpression(trueValueExpression, invocation, plannerState, staticContext)
+        : evaluateTemplateExpression(falseExpression, invocation, plannerState, staticContext);
+    }
+  }
+
   const orParts = splitTopLevelByKeyword(trimmed, 'or');
   if (orParts.length > 1) {
     let hasUnresolvedBranch = false;
@@ -1668,6 +1715,13 @@ function evaluateTemplateExpression(
     const left = evaluateValueExpression(trimmed.slice(0, definedOperator.index).trim(), invocation, plannerState, staticContext);
     const isDefined = !isUnresolved(left);
     return definedOperator.operator.includes('not') ? !isDefined : isDefined;
+  }
+
+  const noneOperator = findTopLevelOperator(trimmed, [' is not none', ' is none']);
+  if (noneOperator) {
+    const left = evaluateValueExpression(trimmed.slice(0, noneOperator.index).trim(), invocation, plannerState, staticContext);
+    const isNone = left === null || isUnresolved(left);
+    return noneOperator.operator.includes('not') ? !isNone : isNone;
   }
 
   const membershipOperator = findTopLevelOperator(trimmed, [' not in ', ' in ']);
@@ -2374,7 +2428,12 @@ export function buildSimulationSteps(
   const stack: string[] = [];
   const plannerState = createInitialPlannerState(allMacros);
   let previewState = createInitialRuntimeState(profile, root.title);
-  const staticContext = buildTemplateStaticContext(allMacros, configFiles, profile);
+  const staticContext = buildTemplateStaticContext(
+    allMacros,
+    configFiles,
+    profile,
+    () => ({ x: previewState.x, y: previewState.y, z: previewState.z, e: previewState.e }),
+  );
   let visit: (macro: MacroSourceItem, allowHomingOverride?: boolean, invocation?: MacroInvocationContext) => void;
 
   const appendSimulationSteps = (nextSteps: SimulationStep[]) => {

--- a/frontend/src/utils/gcodeSimulator.ts
+++ b/frontend/src/utils/gcodeSimulator.ts
@@ -21,7 +21,7 @@ export function parseParams(tokens: string[]): Record<string, string> {
     const eqIndex = token.indexOf('=');
     if (eqIndex !== -1) {
       const key = token.slice(0, eqIndex).trim().toUpperCase();
-      const value = token.slice(eqIndex + 1).trim().replace(/^"|"$/g, '');
+      const value = token.slice(eqIndex + 1).trim().replace(/^["']|["']$/g, '');
       if (key) params[key] = value;
       continue;
     }
@@ -32,6 +32,44 @@ export function parseParams(tokens: string[]): Record<string, string> {
     }
   }
   return params;
+}
+
+/**
+ * Split a command line into tokens the way Klipper's shlex parser does:
+ * whitespace-separated, but quote groups (single or double) stay intact
+ * even when embedded mid-token (e.g. MSG='hello world' is one token).
+ */
+function splitCommandTokens(line: string): string[] {
+  const tokens: string[] = [];
+  let current = '';
+  let quote: string | null = null;
+  for (let i = 0; i < line.length; i += 1) {
+    const char = line[i];
+    if (quote) {
+      current += char;
+      if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+      current += char;
+      continue;
+    }
+    if (/\s/.test(char)) {
+      if (current) {
+        tokens.push(current);
+        current = '';
+      }
+      continue;
+    }
+    current += char;
+  }
+  if (current) {
+    tokens.push(current);
+  }
+  return tokens;
 }
 
 function isTemplateDirective(line: string): boolean {
@@ -63,7 +101,7 @@ export function parseGcodeLine(line: string, lineNumber: number, sourceName: str
   // the real Y value.
   const withoutComment = line.replace(/;.*$/, '').replace(/\s*#.*$/, '').trim();
   if (!withoutComment) return null;
-  const tokens = withoutComment.match(/(?:"[^"]*"|\S+)/g) || [];
+  const tokens = splitCommandTokens(withoutComment);
   const [commandToken, ...paramTokens] = tokens;
   if (!commandToken) return null;
   return {

--- a/frontend/src/utils/gcodeSimulator.ts
+++ b/frontend/src/utils/gcodeSimulator.ts
@@ -849,6 +849,9 @@ function createInitialPlannerState(allMacros: MacroSourceItem[]): PlannerState {
 
 const HOMING_AXES: Array<'X' | 'Y' | 'Z'> = ['X', 'Y', 'Z'];
 
+// Klipper's default [extruder] min_extrude_temp.
+const DEFAULT_MIN_EXTRUDE_TEMP = 170;
+
 function getHomedAxesString(homedAxes: Set<'X' | 'Y' | 'Z'>): string {
   return HOMING_AXES.filter((axis) => homedAxes.has(axis)).map((axis) => axis.toLowerCase()).join('');
 }
@@ -2421,13 +2424,24 @@ export function buildSimulationSteps(
   profile: MachineProfile,
   configFiles?: Record<string, ConfigFile>,
   rootInvocation?: { params?: Record<string, string>; rawparams?: string },
+  initialState?: MacroRuntimeState,
 ): SimulationBuildResult {
   const macroLookup = buildMacroLookup(allMacros);
   const warnings: string[] = [];
   const steps: SimulationStep[] = [];
   const stack: string[] = [];
   const plannerState = createInitialPlannerState(allMacros);
-  let previewState = createInitialRuntimeState(profile, root.title);
+  if (initialState) {
+    plannerState.homedAxes = new Set(initialState.homedAxes.map((axis) => axis.toUpperCase() as 'X' | 'Y' | 'Z'));
+    plannerState.bedCurrent = initialState.bed.current;
+    plannerState.bedTarget = initialState.bed.target;
+    plannerState.nozzleCurrent = initialState.nozzle.current;
+    plannerState.nozzleTarget = initialState.nozzle.target;
+    plannerState.fanSpeed = initialState.fanSpeed;
+    plannerState.absoluteMoves = initialState.absoluteMoves;
+    plannerState.absoluteExtrusion = initialState.absoluteExtrusion;
+  }
+  let previewState = initialState ?? createInitialRuntimeState(profile, root.title);
   const staticContext = buildTemplateStaticContext(
     allMacros,
     configFiles,
@@ -2692,6 +2706,7 @@ function applyLinearMove(
   state: MacroRuntimeState,
   params: Record<string, string>,
   profile: MachineProfile,
+  configFiles?: Record<string, ConfigFile>,
 ): SimulationTickResult {
   const xValue = asNumber(params.X);
   const yValue = asNumber(params.Y);
@@ -2728,6 +2743,43 @@ function applyLinearMove(
     };
   }
 
+  // Klipper refuses moves on axes that have not been homed yet ("Must home
+  // axis first"). Only axes explicitly requested in this move are checked.
+  const movedAxes = [
+    xValue !== null ? 'X' : null,
+    yValue !== null ? 'Y' : null,
+    zValue !== null ? 'Z' : null,
+  ].filter((axis): axis is 'X' | 'Y' | 'Z' => axis !== null);
+  const homedSet = new Set(state.homedAxes.map((axis) => axis.toUpperCase()));
+  const unhomedAxes = movedAxes.filter((axis) => !homedSet.has(axis));
+  if (unhomedAxes.length > 0) {
+    warnings.push(`Move requires homed ${unhomedAxes.join(', ')} axis (must home first).`);
+  }
+
+  // Klipper refuses extrusion below min_extrude_temp (default 170C).
+  const extrudeDelta = nextE - state.e;
+  if (extrudeDelta > 0 && state.nozzle.current < DEFAULT_MIN_EXTRUDE_TEMP) {
+    warnings.push(
+      `Extrusion requires nozzle temperature above ${DEFAULT_MIN_EXTRUDE_TEMP}C (currently ${state.nozzle.current.toFixed(0)}C).`,
+    );
+  }
+
+  if (unhomedAxes.length > 0 || (extrudeDelta > 0 && state.nozzle.current < DEFAULT_MIN_EXTRUDE_TEMP)) {
+    // Klipper raises an error and the move does not execute.
+    return {
+      nextState: {
+        ...state,
+        feedRate: fValue ?? state.feedRate,
+        nozzle: { ...state.nozzle, current: updateTargetTemperature(state.nozzle.current, state.nozzle.target) },
+        bed: { ...state.bed, current: updateTargetTemperature(state.bed.current, state.bed.target) },
+        activeProbePoint: null,
+        activeBuiltInCommand: null,
+      },
+      warnings,
+      eventSummary: 'Move refused',
+    };
+  }
+
   if (!isPointInMoveBounds(profile, nextX, nextY)) {
     warnings.push(`Move to X${nextX.toFixed(2)} Y${nextY.toFixed(2)} exceeds the moveable area.`);
   }
@@ -2740,7 +2792,6 @@ function applyLinearMove(
   }
 
   const distance = Math.sqrt((nextX - state.x) ** 2 + (nextY - state.y) ** 2 + (nextZ - state.z) ** 2);
-  const extrudeDelta = nextE - state.e;
   if (distance < 1e-6 && extrudeDelta > profile.maxExtrudeCrossSection) {
     warnings.push(
       `Extrude-only move E${extrudeDelta.toFixed(2)} exceeds max_extrude_cross_section ${profile.maxExtrudeCrossSection.toFixed(2)}.`,
@@ -2786,6 +2837,29 @@ function setLedState(state: MacroRuntimeState, params: Record<string, string>): 
       [ledName]: next,
     },
   };
+}
+
+export function executeStandaloneCommand(
+  line: string,
+  state: MacroRuntimeState,
+  profile: MachineProfile,
+  configFiles?: Record<string, ConfigFile>,
+): { nextState: MacroRuntimeState; warnings: string[]; eventSummary: string } {
+  const parsed = parseGcodeLine(line, 0, 'seed');
+  if (!parsed) {
+    return { nextState: state, warnings: [], eventSummary: 'No command recognized' };
+  }
+  const steps = expandCommandToSteps(parsed, profile, configFiles, state);
+  let current = state;
+  const warnings: string[] = [];
+  let lastSummary = parsed.raw;
+  for (const step of steps) {
+    const result = executeSimulationStep(current, step, profile, configFiles);
+    current = result.nextState;
+    warnings.push(...result.warnings);
+    lastSummary = result.eventSummary || lastSummary;
+  }
+  return { nextState: current, warnings, eventSummary: lastSummary };
 }
 
 export function executeSimulationStep(
@@ -2853,7 +2927,7 @@ export function executeSimulationStep(
   switch (command.command) {
     case 'G0':
     case 'G1':
-      return applyLinearMove(state, command.params, profile);
+      return applyLinearMove(state, command.params, profile, configFiles);
     case 'G28': {
       const requestedAxes = Object.keys(command.params).map((key) => key.toUpperCase());
       const homeAllAxes = requestedAxes.length === 0;
@@ -2908,6 +2982,8 @@ export function executeSimulationStep(
       const target = asNumber(command.params.S) ?? nextState.nozzle.target;
       if (target < 0 || target > profile.nozzleMaxTemp) {
         warnings.push(`Requested nozzle temperature ${target} exceeds the configured range.`);
+        eventSummary = `Refuse nozzle target ${target}C (out of range)`;
+        break;
       }
       nextState = {
         ...nextState,
@@ -2928,6 +3004,8 @@ export function executeSimulationStep(
       const target = asNumber(command.params.S) ?? nextState.bed.target;
       if (target < 0 || target > profile.bedMaxTemp) {
         warnings.push(`Requested bed temperature ${target} exceeds the configured range.`);
+        eventSummary = `Refuse bed target ${target}C (out of range)`;
+        break;
       }
       nextState = {
         ...nextState,

--- a/frontend/src/utils/gcodeSimulator.ts
+++ b/frontend/src/utils/gcodeSimulator.ts
@@ -631,7 +631,8 @@ type TemplateStaticContext = {
 
 type TemplateLineSegment =
   | { kind: 'text'; text: string }
-  | { kind: 'directive'; directive: string };
+  | { kind: 'directive'; directive: string }
+  | { kind: 'comment'; comment: string };
 
 type NumberedTemplateLine = {
   text: string;
@@ -1850,7 +1851,7 @@ function tokenizeTemplateLine(line: string): TemplateLineSegment[] {
   }
 
   const segments: TemplateLineSegment[] = [];
-  const pattern = /\{%([\s\S]*?)%\}/g;
+  const pattern = /\{%([\s\S]*?)%\}|{#([\s\S]*?)#}/g;
   let lastIndex = 0;
   let match: RegExpExecArray | null;
 
@@ -1858,7 +1859,11 @@ function tokenizeTemplateLine(line: string): TemplateLineSegment[] {
     if (match.index > lastIndex) {
       segments.push({ kind: 'text', text: line.slice(lastIndex, match.index) });
     }
-    segments.push({ kind: 'directive', directive: match[1] });
+    if (match[1] !== undefined) {
+      segments.push({ kind: 'directive', directive: match[1] });
+    } else {
+      segments.push({ kind: 'comment', comment: match[2] });
+    }
     lastIndex = pattern.lastIndex;
   }
 
@@ -1895,6 +1900,132 @@ function collectTemplateLoopBody(lines: NumberedTemplateLine[], startIndex: numb
   }
 
   return { body, endIndex: lines.length };
+}
+
+function collectInlineLoopBodySegments(segments: TemplateLineSegment[], startIndex: number): { body: TemplateLineSegment[]; endIndex: number } {
+  const body: TemplateLineSegment[] = [];
+  let depth = 0;
+
+  for (let index = startIndex + 1; index < segments.length; index += 1) {
+    const segment = segments[index];
+    if (segment.kind === 'directive') {
+      const trimmed = segment.directive.trim();
+      if (/^for\b/i.test(trimmed)) {
+        depth += 1;
+      } else if (/^endfor$/i.test(trimmed)) {
+        if (depth === 0) {
+          return { body, endIndex: index };
+        }
+        depth -= 1;
+      }
+    }
+    body.push(segment);
+  }
+
+  return { body, endIndex: segments.length };
+}
+
+/**
+ * Render a template line that mixes directives/comments with gcode text
+ * (e.g. `{% set HOME_CURRENT = 1 %}  ## comment` or
+ * `M104 {% for p in params %}{'%s%s' % (p, params[p])}{% endfor %}`).
+ * Mirrors the line-level control-flow switch on the same conditionalStack,
+ * so inline if/endif/for/endfor balance just like whole-line directives.
+ * Text segments only render while the branch is active; directives always
+ * execute so the stack stays balanced.
+ */
+function renderInlineTemplateSegments(
+  segments: TemplateLineSegment[],
+  invocation: MacroInvocationContext,
+  plannerState: PlannerState,
+  staticContext: TemplateStaticContext,
+  conditionalStack: Array<{ parentActive: boolean; branchTaken: boolean; active: boolean }>,
+): string {
+  let rendered = '';
+  const isBranchActive = () => conditionalStack.every((entry) => entry.active);
+
+  for (let index = 0; index < segments.length; index += 1) {
+    const segment = segments[index];
+    if (segment.kind === 'comment') {
+      continue;
+    }
+    if (segment.kind === 'text') {
+      if (isBranchActive()) {
+        rendered += renderInlineTemplateExpressions(segment.text, invocation, plannerState, staticContext);
+      }
+      continue;
+    }
+
+    const templateControl = parseTemplateDirective(segment.directive, invocation, plannerState, staticContext);
+    if (!templateControl) {
+      continue;
+    }
+
+    switch (templateControl.kind) {
+      case 'set':
+        if (isBranchActive() && templateControl.name && !isUnresolved(templateControl.value)) {
+          invocation.locals[templateControl.name] = templateControl.value;
+        }
+        break;
+      case 'if': {
+        const parentActive = isBranchActive();
+        const conditionMatched = templateControl.result !== false;
+        conditionalStack.push({ parentActive, branchTaken: conditionMatched, active: parentActive && conditionMatched });
+        break;
+      }
+      case 'elif': {
+        const current = conditionalStack[conditionalStack.length - 1];
+        if (!current) {
+          break;
+        }
+        const conditionMatched = templateControl.result !== false;
+        current.active = current.parentActive && !current.branchTaken && conditionMatched;
+        current.branchTaken = current.branchTaken || conditionMatched;
+        break;
+      }
+      case 'else': {
+        const current = conditionalStack[conditionalStack.length - 1];
+        if (!current) {
+          break;
+        }
+        current.active = current.parentActive && !current.branchTaken;
+        current.branchTaken = true;
+        break;
+      }
+      case 'endif':
+        conditionalStack.pop();
+        break;
+      case 'for': {
+        const { body, endIndex } = collectInlineLoopBodySegments(segments, index);
+        if (isBranchActive()) {
+          const iterable = coerceTemplateIterable(templateControl.iterable);
+          const loopVariables = templateControl.loopVariables || [];
+          const savedValues = loopVariables.map((name) => ({
+            name,
+            hasValue: Object.prototype.hasOwnProperty.call(invocation.locals, name),
+            value: invocation.locals[name],
+          }));
+          iterable.forEach((entry) => {
+            assignLoopVariables(invocation.locals, loopVariables, entry);
+            rendered += renderInlineTemplateSegments(body, invocation, plannerState, staticContext, conditionalStack);
+          });
+          savedValues.forEach(({ name, hasValue, value }) => {
+            if (hasValue) {
+              invocation.locals[name] = value;
+            } else {
+              delete invocation.locals[name];
+            }
+          });
+        }
+        index = endIndex;
+        break;
+      }
+      case 'endfor':
+        break;
+    }
+  }
+
+  return rendered;
 }
 
 function coerceTemplateIterable(value: unknown): unknown[] {
@@ -2588,9 +2719,14 @@ export function buildSimulationSteps(
     const visitLines = (templateLines: NumberedTemplateLine[]) => {
       for (let lineIndex = 0; lineIndex < templateLines.length; lineIndex += 1) {
         const line = templateLines[lineIndex];
-        const wholeLineDirective = extractWholeLineTemplateDirective(line.text);
-        if (wholeLineDirective) {
-          const templateControl = parseTemplateDirective(wholeLineDirective, invocation, plannerState, staticContext);
+        const segments = tokenizeTemplateLine(line.text);
+        const directiveSegments = segments.filter((segment) => segment.kind === 'directive');
+        const hasMeaningfulText = segments.some((segment) => segment.kind === 'text' && segment.text.trim() !== '');
+        const hasTemplateSegments = segments.some((segment) => segment.kind !== 'text');
+        const isWholeLineDirective = directiveSegments.length === 1 && !hasMeaningfulText;
+
+        if (isWholeLineDirective) {
+          const templateControl = parseTemplateDirective(directiveSegments[0].directive, invocation, plannerState, staticContext);
           if (!templateControl) {
             continue;
           }
@@ -2660,6 +2796,23 @@ export function buildSimulationSteps(
             case 'endfor':
               continue;
           }
+        }
+
+        // A line mixing template directives/comments with text (e.g.
+        // `{% set HOME_CURRENT = 1 %}  ## comment` or a M104 line with an
+        // inline `{% for %}`): execute directives in order, render text
+        // through the same expression evaluator, then run the result like
+        // Klipper does — the rendered line is the gcode.
+        if (hasTemplateSegments) {
+          const rendered = renderInlineTemplateSegments(segments, invocation, plannerState, staticContext, conditionalStack);
+          const trimmed = rendered.trim();
+          if (trimmed && !trimmed.startsWith('#') && !trimmed.startsWith(';')) {
+            const parsed = parseGcodeLine(trimmed, line.lineNumber, macro.title);
+            if (parsed) {
+              appendParsedCommand(parsed, macro, allowHomingOverride);
+            }
+          }
+          continue;
         }
 
         if (!isBranchActive()) {

--- a/frontend/src/utils/gcodeSimulator.ts
+++ b/frontend/src/utils/gcodeSimulator.ts
@@ -11,6 +11,7 @@ import type {
   SimulationStep,
   SimulationTickResult,
 } from '../types/macroDesigner';
+import { logMacroDesignerEvent } from './macroDesignerLog';
 import { findPathZoneHit, findZoneHit, isPointInBounds, isPointInMoveBounds, parseMacroVariables } from './macroDesigner';
 
 function parseParams(tokens: string[]): Record<string, string> {
@@ -2544,6 +2545,14 @@ export function buildSimulationSteps(
   };
 
   visit(root, true, { params: {}, rawparams: '', locals: {} });
+  logMacroDesignerEvent({
+    event: 'sim:plan',
+    macro: root.title,
+    stepCount: steps.length,
+    warningCount: warnings.length,
+    warnings: warnings.slice(0, 10),
+    nestedMacros: stack.length > 0 ? stack : undefined,
+  });
   return { steps, warnings };
 }
 

--- a/frontend/src/utils/macroDesigner.ts
+++ b/frontend/src/utils/macroDesigner.ts
@@ -7,6 +7,7 @@ import type {
   NoGoZone,
   SimulationPoint,
 } from '../types/macroDesigner';
+import { logMacroDesignerEvent } from './macroDesignerLog';
 
 const DELTA_KINEMATICS = new Set(['delta', 'rotary_delta']);
 const SPECIAL_MACRO_PARAM_KEYS = new Set(['gcode', 'rename_existing', 'description']);
@@ -589,7 +590,7 @@ export function createGcodeMacroSection(
     is_commented_out: false,
     separator: ':',
   });
-  return {
+  const section = {
     section_type: 'gcode_macro',
     section_name: sanitizeMacroName(item.title),
     full_header: `gcode_macro ${sanitizeMacroName(item.title)}`,
@@ -599,6 +600,16 @@ export function createGcodeMacroSection(
     trailing_comments: existingSection?.trailing_comments ?? [],
     is_commented_out: false,
   };
+  logMacroDesignerEvent({
+    event: 'section:build',
+    title: item.title,
+    targetFile: item.sourceFile,
+    carriedComments: Boolean(existingSection?.header_comments?.length || existingSection?.trailing_comments?.length),
+    headerComments: section.header_comments.length,
+    trailingComments: section.trailing_comments.length,
+    lineNumber: section.line_number,
+  });
+  return section;
 }
 
 export function areEquivalentMacroItems(left: MacroSourceItem, right: MacroSourceItem): boolean {
@@ -619,15 +630,28 @@ export function findMatchingTargetMacroSection(
   const macroSection = createGcodeMacroSection(item);
   const sections = configFiles[targetFile]?.sections || [];
 
-  return sections.find((candidate) => {
+  let matchedByLine = false;
+  const match = sections.find((candidate) => {
     if (candidate.full_header !== macroSection.full_header) {
       return false;
     }
     if (item.source === 'config' && item.sourceFile === targetFile && macroSection.line_number > 0) {
-      return candidate.line_number === macroSection.line_number;
+      matchedByLine = candidate.line_number === macroSection.line_number;
+      return matchedByLine;
     }
     return true;
   }) || null;
+
+  logMacroDesignerEvent({
+    event: 'section:match',
+    title: item.title,
+    targetFile,
+    matched: Boolean(match),
+    byLine: matchedByLine,
+    headerOnly: Boolean(match) && !matchedByLine,
+    candidateCount: sections.filter((s) => s.full_header === macroSection.full_header).length,
+  });
+  return match;
 }
 
 export function isMacroItemUnchangedInSection(item: MacroSourceItem, section: ConfigSection | null): boolean {
@@ -638,10 +662,19 @@ export function isMacroItemUnchangedInSection(item: MacroSourceItem, section: Co
   const existingGcode = normalizeMacroGcodeForConfig(getSectionParamValue(section, 'gcode'));
   const selectedGcode = normalizeMacroGcodeForConfig(item.gcode);
 
-  return (
+  const unchanged = (
     existingGcode === selectedGcode
     && normalizePlainText(getSectionParamValue(section, 'rename_existing')) === normalizePlainText(item.renameExisting)
     && normalizePlainText(getSectionParamValue(section, 'description')) === normalizePlainText(item.description)
     && normalizePlainText(serializeMacroVariables(section)) === normalizePlainText(item.variables)
   );
+
+  if (unchanged) {
+    logMacroDesignerEvent({
+      event: 'section:unchanged',
+      title: item.title,
+      targetFile: item.sourceFile,
+    });
+  }
+  return unchanged;
 }

--- a/frontend/src/utils/macroDesigner.ts
+++ b/frontend/src/utils/macroDesigner.ts
@@ -553,3 +553,95 @@ export function findPathZoneHit(
     lineSegmentIntersectsRect(x1, y1, x2, y2, zone.x, zone.y, zone.width, zone.height)
   ) || null;
 }
+
+export function getSectionParamValue(section: ConfigSection | undefined, key: string): string {
+  return section?.params.find((param) => param.key === key && !param.is_commented_out)?.value || '';
+}
+
+export function normalizePlainText(value: string): string {
+  return value.replace(/\r\n?/g, '\n').trim();
+}
+
+/**
+ * Build a [gcode_macro X] ConfigSection from a MacroSourceItem.
+ *
+ * When `existingSection` is supplied (the section this item will replace),
+ * its header/trailing comments and line number are carried over so Apply
+ * does not wipe comments above/below the macro or move the section to the
+ * end of the file.
+ */
+export function createGcodeMacroSection(
+  item: MacroSourceItem,
+  existingSection?: ConfigSection | null,
+): ConfigSection {
+  const params = [];
+  if (item.description.trim()) {
+    params.push({ key: 'description', value: item.description.trim(), comment: '', is_commented_out: false, separator: ':' });
+  }
+  if (item.renameExisting.trim()) {
+    params.push({ key: 'rename_existing', value: item.renameExisting.trim(), comment: '', is_commented_out: false, separator: ':' });
+  }
+  params.push(...parseMacroVariables(item.variables));
+  params.push({
+    key: 'gcode',
+    value: normalizeMacroGcodeForConfig(item.gcode) || '\n',
+    comment: '',
+    is_commented_out: false,
+    separator: ':',
+  });
+  return {
+    section_type: 'gcode_macro',
+    section_name: sanitizeMacroName(item.title),
+    full_header: `gcode_macro ${sanitizeMacroName(item.title)}`,
+    line_number: item.sourceLine ?? existingSection?.line_number ?? 0,
+    params,
+    header_comments: existingSection?.header_comments ?? [],
+    trailing_comments: existingSection?.trailing_comments ?? [],
+    is_commented_out: false,
+  };
+}
+
+export function areEquivalentMacroItems(left: MacroSourceItem, right: MacroSourceItem): boolean {
+  return (
+    sanitizeMacroName(left.title) === sanitizeMacroName(right.title)
+    && normalizePlainText(left.renameExisting) === normalizePlainText(right.renameExisting)
+    && normalizePlainText(left.description) === normalizePlainText(right.description)
+    && normalizePlainText(left.variables) === normalizePlainText(right.variables)
+    && normalizeMacroGcodeForConfig(left.gcode) === normalizeMacroGcodeForConfig(right.gcode)
+  );
+}
+
+export function findMatchingTargetMacroSection(
+  configFiles: Record<string, ConfigFile>,
+  item: MacroSourceItem,
+  targetFile: string,
+): ConfigSection | null {
+  const macroSection = createGcodeMacroSection(item);
+  const sections = configFiles[targetFile]?.sections || [];
+
+  return sections.find((candidate) => {
+    if (candidate.full_header !== macroSection.full_header) {
+      return false;
+    }
+    if (item.source === 'config' && item.sourceFile === targetFile && macroSection.line_number > 0) {
+      return candidate.line_number === macroSection.line_number;
+    }
+    return true;
+  }) || null;
+}
+
+export function isMacroItemUnchangedInSection(item: MacroSourceItem, section: ConfigSection | null): boolean {
+  if (!section) {
+    return false;
+  }
+
+  const existingGcode = normalizeMacroGcodeForConfig(getSectionParamValue(section, 'gcode'));
+  const selectedGcode = normalizeMacroGcodeForConfig(item.gcode);
+
+  return (
+    existingGcode === selectedGcode
+    && normalizePlainText(getSectionParamValue(section, 'rename_existing')) === normalizePlainText(item.renameExisting)
+    && normalizePlainText(getSectionParamValue(section, 'description')) === normalizePlainText(item.description)
+    && normalizePlainText(serializeMacroVariables(section)) === normalizePlainText(item.variables)
+  );
+}

--- a/frontend/src/utils/macroDesignerLog.ts
+++ b/frontend/src/utils/macroDesignerLog.ts
@@ -1,0 +1,78 @@
+/**
+ * Macro Designer trace logging.
+ *
+ * Posts structured events to the backend `/api/log/macro-designer`
+ * endpoint, which appends them as timestamped JSON lines to
+ * `backend/macro_designer.log` — a durable, grep-able trace that
+ * survives browser reloads and can be read/tailed without asking the
+ * user to copy anything (companion to ai_chat.log).
+ *
+ * Design constraints:
+ * - Import-safe in node (vitest runs in `environment: 'node'`): never
+ *   touches `window`/`fetch` at module load, and no-ops outside a
+ *   browser so pure util tests don't need mocks.
+ * - Fire-and-forget: batching + silent failure, logging must never
+ *   throw or block the caller.
+ */
+type MacroDesignerLogEvent = Record<string, unknown>;
+
+const API_BASE = (import.meta.env.VITE_API_URL as string | undefined) || '/api';
+const LOG_URL = `${API_BASE}/log/macro-designer`;
+const FLUSH_INTERVAL_MS = 500;
+const MAX_BATCH = 50;
+
+let pending: MacroDesignerLogEvent[] = [];
+let flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+function isBrowser(): boolean {
+  return typeof window !== 'undefined' && typeof fetch === 'function';
+}
+
+function flush(): void {
+  if (flushTimer !== null) {
+    clearTimeout(flushTimer);
+    flushTimer = null;
+  }
+  if (pending.length === 0) {
+    return;
+  }
+  const batch = pending;
+  pending = [];
+  try {
+    void fetch(LOG_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ events: batch }),
+    }).catch(() => {
+      // Backend absent/offline — drop silently; logging never blocks.
+    });
+  } catch {
+    // Never throw from logging.
+  }
+}
+
+/** Record a macro-designer event (browser only; no-op elsewhere). */
+export function logMacroDesignerEvent(event: MacroDesignerLogEvent): void {
+  if (!isBrowser()) {
+    return;
+  }
+  if (import.meta.env.DEV) {
+    // Live mirror in DevTools while working.
+    console.debug('[MacroDesigner]', event);
+  }
+  pending.push({ ts: new Date().toISOString(), ...event });
+  if (pending.length >= MAX_BATCH) {
+    flush();
+    return;
+  }
+  if (flushTimer === null) {
+    flushTimer = setTimeout(flush, FLUSH_INTERVAL_MS);
+  }
+}
+
+/** Flush any buffered events immediately (e.g. before dialog close). */
+export function flushMacroDesignerLog(): void {
+  if (isBrowser()) {
+    flush();
+  }
+}

--- a/tests/test_indentation_roundtrip.py
+++ b/tests/test_indentation_roundtrip.py
@@ -1,0 +1,106 @@
+"""Indentation round-trip tests for gcode macro bodies and multi-line params.
+
+The parser must preserve leading whitespace on continuation lines (gcode
+bodies are conventionally indented with Jinja blocks), and the writer must
+not stack an extra prefix on top of lines that already carry indentation.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'backend'))
+
+from parser.config_parser import parse_config  # noqa: E402
+from parser.config_writer import smart_export, write_section  # noqa: E402
+
+
+INDENTED_MACRO = """# Header
+[gcode_macro TEST_MACRO]
+description: Test
+gcode:
+    G28
+    {% if printer.extruder.temperature > 170 %}
+        M117 Nozzle hot
+    {% else %}
+        M117 Nozzle cold
+    {% endif %}
+"""
+
+
+def get_gcode_param(config, name='TEST_MACRO'):
+    section = next(s for s in config.sections if s.section_type == 'gcode_macro' and s.section_name == name)
+    return next(p for p in section.params if p.key == 'gcode')
+
+
+def test_parser_preserves_leading_whitespace_in_multiline_values():
+    config = parse_config(INDENTED_MACRO, 'printer.cfg')
+    value = get_gcode_param(config).value
+    assert '\n    G28' in value
+    assert '\n        M117 Nozzle hot' in value
+    assert '\n    {% endif %}' in value
+
+
+def test_smart_export_unchanged_is_byte_identical():
+    config = parse_config(INDENTED_MACRO, 'printer.cfg')
+    assert smart_export(config) == INDENTED_MACRO
+
+
+def test_write_section_edited_line_keeps_its_own_indentation():
+    """A changed line keeps the indentation of the line it replaced."""
+    original = parse_config(INDENTED_MACRO, 'printer.cfg')
+    edited = parse_config(INDENTED_MACRO, 'printer.cfg')
+    param = get_gcode_param(edited)
+    param.value = param.value.replace('M117 Nozzle hot', 'M117 Hot!')
+
+    rendered = write_section(edited.sections[0], original.sections[0])
+    assert '        M117 Hot!' in rendered
+    assert '    G28' in rendered
+    # No doubled indentation anywhere
+    assert '\n            ' not in rendered
+
+
+def test_write_section_frontend_value_with_indentation_is_not_doubled():
+    """Simulates the frontend textarea value (already indented) round-tripping."""
+    original = parse_config(INDENTED_MACRO, 'printer.cfg')
+    edited = parse_config(INDENTED_MACRO, 'printer.cfg')
+    param = get_gcode_param(edited)
+    param.value = (
+        '\n    G28\n'
+        '    {% if printer.extruder.temperature > 170 %}\n'
+        '        M117 Hot!  # user edited this line\n'
+        '    {% else %}\n'
+        '        M117 Nozzle cold\n'
+        '    {% endif %}'
+    )
+
+    rendered = write_section(edited.sections[0], original.sections[0])
+    assert '    G28' in rendered
+    assert '        M117 Hot!  # user edited this line' in rendered
+    assert '    {% if printer.extruder.temperature > 170 %}' in rendered
+    assert '        M117 Nozzle cold' in rendered
+    # The old bug produced 8/16-space doubled indent — ensure it doesn't
+    assert '            M117' not in rendered
+
+
+def test_tab_indented_body_round_trips():
+    cfg = """[gcode_macro TABS]
+gcode:
+\tG28
+\t{% for i in range(2) %}
+\t\tG1 X{i} F3000
+\t{% endfor %}
+"""
+    config = parse_config(cfg, 'printer.cfg')
+    assert smart_export(config) == cfg
+    assert '\t\tG1 X{i} F3000' in get_gcode_param(config, 'TABS').value
+
+
+def test_blank_lines_inside_body_are_kept():
+    cfg = """[gcode_macro BLANKY]
+gcode:
+    G28
+
+    G1 X10 F3000
+"""
+    config = parse_config(cfg, 'printer.cfg')
+    assert smart_export(config) == cfg
+    assert get_gcode_param(config, 'BLANKY').value == '\n    G28\n\n    G1 X10 F3000'

--- a/tests/test_indentation_roundtrip.py
+++ b/tests/test_indentation_roundtrip.py
@@ -81,6 +81,49 @@ def test_write_section_frontend_value_with_indentation_is_not_doubled():
     assert '            M117' not in rendered
 
 
+def test_new_command_typed_at_column_0_inherits_block_indent():
+    """A line inserted at column 0 (textarea Enter drops there) must be
+    written with the surrounding block's indentation — a column-0 gcode
+    line inside a section is a parse error in real Klipper."""
+    original = parse_config(INDENTED_MACRO, 'printer.cfg')
+    edited = parse_config(INDENTED_MACRO, 'printer.cfg')
+    param = get_gcode_param(edited)
+    param.value = (
+        '\n    G28\n'
+        'G1 X50\n'  # user typed at column 0
+        '    {% if printer.extruder.temperature > 170 %}\n'
+        '        M117 Nozzle hot\n'
+        '    {% else %}\n'
+        '        M117 Nozzle cold\n'
+        '    {% endif %}'
+    )
+
+    rendered = write_section(edited.sections[0], original.sections[0])
+    assert '    G1 X50' in rendered
+    assert '\nG1 X50\n' not in rendered  # never left at column 0
+    # Re-parse the rendered output: value must keep the new command
+    reparsed = parse_config(rendered, 'printer.cfg')
+    assert '    G1 X50' in get_gcode_param(reparsed).value
+
+
+def test_flat_body_stays_flat_when_edited():
+    """A macro whose body is intentionally unindented must not gain
+    indentation on edit."""
+    flat = """[gcode_macro FLAT]
+gcode:
+G28
+M117 hi
+"""
+    original = parse_config(flat, 'printer.cfg')
+    edited = parse_config(flat, 'printer.cfg')
+    get_gcode_param(edited, 'FLAT').value = '\nG28\nM117 changed'
+    rendered = write_section(edited.sections[0], original.sections[0])
+    assert 'G28' in rendered
+    assert 'M117 changed' in rendered
+    assert '\n    G28' not in rendered  # no indent added to flat body
+    assert '\nG28\n' in rendered
+
+
 def test_tab_indented_body_round_trips():
     cfg = """[gcode_macro TABS]
 gcode:

--- a/tests/test_macro_log_routes.py
+++ b/tests/test_macro_log_routes.py
@@ -1,0 +1,49 @@
+"""Tests for the Macro Designer trace log endpoint (/api/log/macro-designer)."""
+import json
+import logging
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'backend'))
+
+from main import app  # noqa: E402
+from api.macro_log_routes import MACRO_DESIGNER_LOG  # noqa: E402
+
+client = TestClient(app)
+
+
+def test_macro_log_endpoint_appends_json_lines(tmp_path):
+    # Point the handler at a temp file so we don't pollute the real log.
+    logger = logging.getLogger("kwc.macro_designer")
+    for handler in list(logger.handlers):
+        logger.removeHandler(handler)
+    temp_log = tmp_path / "macro_designer.log"
+    handler = logging.FileHandler(temp_log, mode="a", encoding="utf-8")
+    handler.setFormatter(logging.Formatter("%(asctime)s | %(message)s"))
+    logger.addHandler(handler)
+
+    resp = client.post("/api/log/macro-designer", json={
+        "events": [
+            {"event": "apply", "title": "PRINT_START", "action": "update"},
+            {"event": "sim:plan", "macro": "PRINT_START", "stepCount": 3},
+        ],
+    })
+
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True, "count": 2}
+
+    lines = temp_log.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 2
+    for line in lines:
+        assert "EVENT " in line
+        # Each line carries the full JSON event payload.
+        payload = json.loads(line.split("EVENT ", 1)[1])
+        assert "event" in payload
+
+
+def test_macro_log_endpoint_handles_empty_batch(tmp_path):
+    resp = client.post("/api/log/macro-designer", json={"events": []})
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True, "count": 0}


### PR DESCRIPTION
## Summary

17 commits of Macro Designer + parser hardening from the `fix/macro-designer-comment-preservation` branch. Core work: comment preservation on Apply, indentation round-trip fixes, and a large simulation-fidelity pass.

## Highlights

- **Comment preservation**: comments above/below macros survive Apply
- **Parser indent fixes**: col-0 commands inherit block indent; Enter auto-indent; multi-line values no longer double indentation
- **Simulation fidelity**: printer state reset on macro switch + Reset button, dead-printer seed state, Klipper-faithful guards, inline jinja directive execution on mixed gcode lines, quote-aware tokenizer for RESPOND MSG, `printer.configfile.settings` resolution, toolhead axis bounds, inline ternary + is-none support
- **Root macro params input** for simulation; Number() guarded against unresolved template symbols
- **Durable trace log** + CLI simulation probe (macro_log_routes)
- Removed redundant Canvas selection panel; canvas usable on small displays/zoom levels
- **CI**: tests now run on `fix/*` branches; new macro designer scenario suite

## Test Plan

- [x] Backend pytest: 376 passed
- [x] Frontend vitest: 419 passed (30 files)
- [x] `tsc -b`: clean
- [x] Regression tests added (indentation round-trip, macro log routes, quote params, seed state, symbol-crash branches)

## Risk

Medium — touches parser + macro designer core, but covered by the new scenario suite and existing round-trip tests.