### PR TITLE
feat(graph): graph view Phase 1-5 — undoable edits, primary-swap refactor, layout persistence

### DIFF
--- a/backend/api/native_routes.py
+++ b/backend/api/native_routes.py
@@ -218,6 +218,7 @@ async def read_config_files(data: dict):
 class ApplyRequest(BaseModel):
     config_path: str | None = None
     files: dict[str, str]  # filename → config text
+    deleted: list[str] = []  # filenames to remove from the config dir
 
 
 @router.post("/apply")
@@ -246,10 +247,24 @@ async def apply_config(data: ApplyRequest):
         except OSError as e:
             errors.append(f"{filename}: {e}")
 
-    if errors and not written:
+    removed = []
+    for filename in data.deleted:
+        if '..' in filename or filename.startswith('/'):
+            raise HTTPException(status_code=400, detail=f"Invalid filename: {filename}")
+        target = base / filename
+        try:
+            if target.is_file():
+                target.unlink()
+                removed.append(filename)
+        except PermissionError:
+            errors.append(f"Permission denied: {filename}")
+        except OSError as e:
+            errors.append(f"{filename}: {e}")
+
+    if errors and not written and not removed:
         raise HTTPException(status_code=500, detail="Failed to write files: " + "; ".join(errors))
 
-    result = {"status": "applied", "files": written, "config_path": config_path}
+    result = {"status": "applied", "files": written, "removed": removed, "config_path": config_path}
     if errors:
         result["warnings"] = errors
     return result

--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -505,17 +505,19 @@ async def save_configs(data: dict):
 
     Accepts a dict of filename → config text, persists each file to
     CONFIG_STORAGE_DIR. Used by non-native mode to persist changes
-    made after import.
+    made after import. Accepts an optional ``deleted`` list of
+    filenames to remove from storage (a file deleted from the model).
     """
     files: dict[str, str] = data.get("files", {})
-    if not files:
+    deleted: list[str] = data.get("deleted", []) or []
+    if not files and not deleted:
         raise HTTPException(status_code=400, detail="No files provided")
 
     saved = []
     errors = []
     for filename, text in files.items():
         # Validate filename (no path traversal)
-        if ".." in filename or filename.startswith("/") or filename.startswith("\\"):
+        if ".." in filename or filename.startswith("/") or filename.startswith("\\\\"):
             errors.append(f"Invalid filename: {filename}")
             continue
         try:
@@ -524,10 +526,23 @@ async def save_configs(data: dict):
         except OSError as e:
             errors.append(f"{filename}: {e}")
 
-    result: dict[str, object] = {"saved": saved, "file_count": len(saved)}
+    removed = []
+    for filename in deleted:
+        if ".." in filename or filename.startswith("/") or filename.startswith("\\\\"):
+            errors.append(f"Invalid filename: {filename}")
+            continue
+        target = CONFIG_STORAGE_DIR / filename
+        try:
+            if target.is_file():
+                target.unlink()
+                removed.append(filename)
+        except OSError as e:
+            errors.append(f"{filename}: {e}")
+
+    result: dict[str, object] = {"saved": saved, "removed": removed, "file_count": len(saved)}
     if errors:
         result["errors"] = errors
-        if not saved:
+        if not saved and not removed:
             raise HTTPException(status_code=500, detail="Failed to save files: " + "; ".join(errors))
     return result
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "klipper-wire-configurator",
   "private": true,
-  "version": "2.3.0",
+  "version": "2.4.0",
   "type": "module",
   "scripts": {
     "prepare:reference": "node scripts/generate-examples.js",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -613,7 +613,11 @@ export default function App() {
       setSelectedEdge(null);
       const data = node.data as Record<string, unknown>;
       if (data?.sectionHeader) {
-        setSelectedSection(data.sectionHeader as string);
+        setSelectedSection(
+          data.sectionHeader as string,
+          data.configFile as string | undefined,
+          typeof data.sectionLineNumber === 'number' ? data.sectionLineNumber as number : null,
+        );
       } else {
         setSelectedSection(null);
       }
@@ -649,7 +653,11 @@ export default function App() {
       const data = draggedNode.data as Record<string, unknown>;
       setSelectedNode(draggedNode.id);
       setSelectedEdge(null);
-      setSelectedSection(typeof data.sectionHeader === 'string' ? data.sectionHeader : null);
+      setSelectedSection(
+        typeof data.sectionHeader === 'string' ? data.sectionHeader : null,
+        data.configFile as string | undefined,
+        typeof data.sectionLineNumber === 'number' ? data.sectionLineNumber as number : null,
+      );
 
       useGraphStore.setState((s) => ({
         nodes: s.nodes.map((node) => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -117,6 +117,53 @@ function computeHardwareDragPreviewSize(nodes: Node[], hardwareId: string) {
   };
 }
 
+/** Saved edge layout entry (id may differ from rebuilt edges — pair-match). */
+interface SavedEdgeLayout {
+  id: string;
+  source?: string;
+  target?: string;
+  data?: Record<string, unknown>;
+  sourceHandle?: string;
+  targetHandle?: string;
+}
+
+/**
+ * Overlay saved edge routing (custom bend points + connection sides) onto the
+ * freshly rebuilt graph. Matches by PAIR (source+target+edgeType), falling back
+ * to id: edge ids come from a module-level counter, so a line drawn at runtime
+ * (edge_7) gets a different id after the config rebuild than the one the save
+ * captured. The source/target/type triple is stable across rebuilds, and comm
+ * edges are matched direction-agnostically (the rebuild always emits SBC →
+ * hardware but the user may have drawn the opposite way).
+ */
+function applySavedEdgeLayout(saved: SavedEdgeLayout[] | undefined, graphStore: ReturnType<typeof useGraphStore.getState>) {
+  if (!saved || saved.length === 0) return;
+  const pairKey = (e: { source?: string; target?: string; data?: Record<string, unknown> }) => {
+    const t = (e.data as Record<string, unknown> | undefined)?.edgeType as string | undefined;
+    const [a, b] = [e.source ?? '', e.target ?? ''].sort();
+    return [a, b, t ?? ''].join('|');
+  };
+  const savedByPair = new Map(saved.map((e) => [pairKey(e), e]));
+  const savedById = new Map(saved.map((e) => [e.id, e]));
+  const currentEdges = useGraphStore.getState().edges;
+  const updatedEdges = currentEdges.map((edge) => {
+    const found = savedByPair.get(pairKey(edge)) ?? savedById.get(edge.id);
+    if (!found) return edge;
+    const next: Record<string, unknown> = { ...edge };
+    if (found.data) {
+      next.data = {
+        ...edge.data,
+        ...found.data,
+        customMiddlePoints: (found.data as Record<string, unknown>).customMiddlePoints,
+      } as unknown as import('./types/graph').AppEdge['data'];
+    }
+    if (found.sourceHandle) next.sourceHandle = found.sourceHandle;
+    if (found.targetHandle) next.targetHandle = found.targetHandle;
+    return next as import('./types/graph').AppEdge;
+  });
+  graphStore.setEdges(updatedEdges);
+}
+
 /** Sits inside <ReactFlow> and calls fitView whenever trigger increments. */
 function AutoFitController({ trigger }: { trigger: number }) {
   const { fitView } = useReactFlow();
@@ -257,7 +304,7 @@ export default function App() {
               if (layoutResult.layout) {
                 const layout = layoutResult.layout as {
                   graphNodes?: Array<{ id: string; position: { x: number; y: number } }>;
-                  graphEdges?: Array<{ id: string; data?: Record<string, unknown> }>;
+                  graphEdges?: SavedEdgeLayout[];
                   macroDesigner?: MacroDesignerPersistedState;
                 };
                 if (layout.macroDesigner) {
@@ -278,6 +325,9 @@ export default function App() {
                   });
                   graphStore.setNodes(updatedNodes);
                 }
+                // Restore edge routing the same way as the browser-mode path
+                // (pair-matched, direction-agnostic — see applySavedEdgeLayout).
+                applySavedEdgeLayout(layout.graphEdges as SavedEdgeLayout[] | undefined, graphStore);
               }
             } catch { /* no saved layout — use auto-arranged positions */ }
 
@@ -385,28 +435,7 @@ export default function App() {
             // node the line connects to. Without this, a refresh resets every
             // trace to default top/bottom routing even though card positions
             // survived.
-            if (layout.graphEdges) {
-              const savedEdges = new Map(
-                layout.graphEdges.map((e) => [e.id, e]),
-              );
-              const currentEdges = useGraphStore.getState().edges;
-              const updatedEdges = currentEdges.map((edge) => {
-                const saved = savedEdges.get(edge.id);
-                if (!saved) return edge;
-                const next: Record<string, unknown> = { ...edge };
-                if (saved.data) {
-                  next.data = {
-                    ...edge.data,
-                    ...saved.data,
-                    customMiddlePoints: (saved.data as Record<string, unknown>).customMiddlePoints,
-                  } as unknown as import('./types/graph').AppEdge['data'];
-                }
-                if (saved.sourceHandle) next.sourceHandle = saved.sourceHandle;
-                if (saved.targetHandle) next.targetHandle = saved.targetHandle;
-                return next as import('./types/graph').AppEdge;
-              });
-              graphStore.setEdges(updatedEdges);
-            }
+            applySavedEdgeLayout(layout.graphEdges, graphStore);
           }
         } catch { /* malformed/absent layout — keep auto-arranged positions */ }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -449,33 +449,36 @@ export default function App() {
   // Auto-save layout (debounced). Native mode persists via the backend;
   // browser mode falls back to localStorage so arrangements survive refresh.
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  useEffect(() => {
+  const saveLayoutNow = useCallback((n: typeof nodes, e: typeof edges) => {
+    if (n.length === 0) return;
+    const macroDesigner = useMacroDesignerStore.getState().exportPersistedState();
     const isNative = useNativeStore.getState().isNative;
+    if (isNative) {
+      api.saveNativeLayout({
+        graphNodes: n,
+        graphEdges: e,
+        macroDesigner,
+      }).catch(() => { /* ignore save errors */ });
+    } else {
+      try {
+        localStorage.setItem('kwc.graphLayout', JSON.stringify({
+          graphNodes: n.map((node) => ({ id: node.id, position: node.position })),
+          graphEdges: e.map((edge) => ({
+            id: edge.id,
+            data: edge.data,
+            sourceHandle: edge.sourceHandle ?? undefined,
+            targetHandle: edge.targetHandle ?? undefined,
+          })),
+          macroDesigner,
+        }));
+      } catch { /* ignore quota / privacy-mode errors */ }
+    }
+  }, []);
 
+  useEffect(() => {
     if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
     saveTimerRef.current = setTimeout(() => {
-      if (nodes.length === 0) return;
-      const macroDesigner = useMacroDesignerStore.getState().exportPersistedState();
-      if (isNative) {
-        api.saveNativeLayout({
-          graphNodes: nodes,
-          graphEdges: edges,
-          macroDesigner,
-        }).catch(() => { /* ignore save errors */ });
-      } else {
-        try {
-          localStorage.setItem('kwc.graphLayout', JSON.stringify({
-            graphNodes: nodes.map((n) => ({ id: n.id, position: n.position })),
-            graphEdges: edges.map((e) => ({
-              id: e.id,
-              data: e.data,
-              sourceHandle: e.sourceHandle ?? undefined,
-              targetHandle: e.targetHandle ?? undefined,
-            })),
-            macroDesigner,
-          }));
-        } catch { /* ignore quota / privacy-mode errors */ }
-      }
+      saveLayoutNow(nodes, edges);
     }, 3000);
 
     return () => {
@@ -488,7 +491,27 @@ export default function App() {
     macroDesignerNoGoZones,
     macroDesignerDockPosition,
     macroDesignerRotation,
+    saveLayoutNow,
   ]);
+
+  // Flush any pending layout save when the page is being unloaded (refresh,
+  // close, navigate away). The debounced save races a quick refresh — the
+  // last card move / trace bend never reaches disk, which is why positions
+  // and pathing only "stuck" when a config save happened to give the timer
+  // time to fire. The browser's synchronous path covers unload for
+  // localStorage; the backend POST is fire-and-forget but usually completes.
+  useEffect(() => {
+    const onUnload = () => {
+      const graph = useGraphStore.getState();
+      saveLayoutNow(graph.nodes, graph.edges);
+    };
+    window.addEventListener('pagehide', onUnload);
+    window.addEventListener('beforeunload', onUnload);
+    return () => {
+      window.removeEventListener('pagehide', onUnload);
+      window.removeEventListener('beforeunload', onUnload);
+    };
+  }, [saveLayoutNow]);
 
   useEffect(() => {
     const sectionStatuses = new Map<string, ValidationStatus>();

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -356,7 +356,12 @@ export default function App() {
           if (saved) {
             const layout = JSON.parse(saved) as {
               graphNodes?: Array<{ id: string; position: { x: number; y: number } }>;
-              graphEdges?: Array<{ id: string; data?: Record<string, unknown> }>;
+              graphEdges?: Array<{
+                id: string;
+                data?: Record<string, unknown>;
+                sourceHandle?: string;
+                targetHandle?: string;
+              }>;
               macroDesigner?: MacroDesignerPersistedState;
             };
             if (layout.macroDesigner) {
@@ -375,6 +380,32 @@ export default function App() {
                 return node;
               });
               graphStore.setNodes(updatedNodes);
+            }
+            // Restore edge routing: custom bend points + which side of each
+            // node the line connects to. Without this, a refresh resets every
+            // trace to default top/bottom routing even though card positions
+            // survived.
+            if (layout.graphEdges) {
+              const savedEdges = new Map(
+                layout.graphEdges.map((e) => [e.id, e]),
+              );
+              const currentEdges = useGraphStore.getState().edges;
+              const updatedEdges = currentEdges.map((edge) => {
+                const saved = savedEdges.get(edge.id);
+                if (!saved) return edge;
+                const next: Record<string, unknown> = { ...edge };
+                if (saved.data) {
+                  next.data = {
+                    ...edge.data,
+                    ...saved.data,
+                    customMiddlePoints: (saved.data as Record<string, unknown>).customMiddlePoints,
+                  } as unknown as import('./types/graph').AppEdge['data'];
+                }
+                if (saved.sourceHandle) next.sourceHandle = saved.sourceHandle;
+                if (saved.targetHandle) next.targetHandle = saved.targetHandle;
+                return next as import('./types/graph').AppEdge;
+              });
+              graphStore.setEdges(updatedEdges);
             }
           }
         } catch { /* malformed/absent layout — keep auto-arranged positions */ }
@@ -406,7 +437,12 @@ export default function App() {
         try {
           localStorage.setItem('kwc.graphLayout', JSON.stringify({
             graphNodes: nodes.map((n) => ({ id: n.id, position: n.position })),
-            graphEdges: edges.map((e) => ({ id: e.id, data: e.data })),
+            graphEdges: edges.map((e) => ({
+              id: e.id,
+              data: e.data,
+              sourceHandle: e.sourceHandle ?? undefined,
+              targetHandle: e.targetHandle ?? undefined,
+            })),
             macroDesigner,
           }));
         } catch { /* ignore quota / privacy-mode errors */ }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -943,17 +943,10 @@ export default function App() {
               onToggleAddMenu={() => setShowAddMenu(!showAddMenu)}
               onOpenMacroDesigner={() => setShowMacroDesigner(true)}
               onToggleTextView={() => {
-                if (showTextView) {
-                  // Text edits apply to the model live, so switching views is
-                  // always safe — nothing to apply, nothing to lose.
-                  setShowTextView(false);
-                } else {
-                  // Switching TO text view — close the settings panel
-                  setSelectedNode(null);
-                  setSelectedEdge(null);
-                  setSelectedSection(null);
-                  setShowTextView(true);
-                }
+                // Text edits apply to the model live, so switching views is
+                // always safe — nothing to apply, nothing to lose.
+                // Both views stay mounted; ReactFlow keeps viewport + selection.
+                setShowTextView(!showTextView);
               }}
             />
           </div>
@@ -962,11 +955,10 @@ export default function App() {
 
       {/* Main content */}
       <div className="flex flex-1 overflow-hidden">
-        {/* Graph or Text view */}
+        {/* Graph or Text view — both stay mounted so ReactFlow keeps its
+            viewport/zoom/selection across toggles; only visibility flips. */}
         <div className="flex-1 relative">
-          {showTextView ? (
-            <TextEditor />
-          ) : (
+          <div className={showTextView ? 'hidden' : 'h-full w-full'}>
             <ReactFlow
               nodes={nodes}
               edges={edges}
@@ -1036,7 +1028,10 @@ export default function App() {
                 </button>
               </Panel>
             </ReactFlow>
-          )}
+          </div>
+          <div className={showTextView ? 'h-full w-full' : 'hidden'}>
+            <TextEditor />
+          </div>
 
           {/* Add Menu Overlay */}
           {showAddMenu && (

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,14 @@ import '@xyflow/react/dist/style.css';
 import { useGraphStore } from './stores/graphStore';
 import { useConfigStore } from './stores/configStore';
 import { useNativeStore } from './stores/nativeStore';
+import {
+  CONTAINER_WIDTH,
+  CONTAINER_HEADER_HEIGHT,
+  CHILD_SLOT_HEIGHT,
+  CONTAINER_PADDING_BOTTOM,
+  COLLAPSED_HEIGHT,
+  COLLAPSED_WIDTH,
+} from './constants/graphLayout';
 import * as api from './services/api';
 import HardwareNode from './components/nodes/HardwareNode';
 import SubComponentNode from './components/nodes/SubComponentNode';
@@ -90,12 +98,12 @@ const edgeTypes: EdgeTypes = {
   configuration: ConfigurationEdge,
 };
 
-const HARDWARE_DRAG_PREVIEW_WIDTH = 400;
-const HARDWARE_DRAG_PREVIEW_HEADER_HEIGHT = 110;
-const HARDWARE_DRAG_PREVIEW_SLOT_HEIGHT = 40;
-const HARDWARE_DRAG_PREVIEW_PADDING_BOTTOM = 16;
-const HARDWARE_DRAG_PREVIEW_COLLAPSED_HEIGHT = 56;
-const HARDWARE_DRAG_PREVIEW_COLLAPSED_WIDTH = 200;
+const HARDWARE_DRAG_PREVIEW_WIDTH = CONTAINER_WIDTH;
+const HARDWARE_DRAG_PREVIEW_HEADER_HEIGHT = CONTAINER_HEADER_HEIGHT;
+const HARDWARE_DRAG_PREVIEW_SLOT_HEIGHT = CHILD_SLOT_HEIGHT;
+const HARDWARE_DRAG_PREVIEW_PADDING_BOTTOM = CONTAINER_PADDING_BOTTOM;
+const HARDWARE_DRAG_PREVIEW_COLLAPSED_HEIGHT = COLLAPSED_HEIGHT;
+const HARDWARE_DRAG_PREVIEW_COLLAPSED_WIDTH = COLLAPSED_WIDTH;
 
 function computeHardwareDragPreviewSize(nodes: Node[], hardwareId: string) {
   const children = nodes.filter((node) => node.parentId === hardwareId);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1106,7 +1106,7 @@ export default function App() {
             </ReactFlow>
           </div>
           <div className={showTextView ? 'h-full w-full' : 'hidden'}>
-            <TextEditor />
+            <TextEditor isActive={showTextView} />
           </div>
 
           {/* Add Menu Overlay */}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -350,6 +350,35 @@ export default function App() {
         const { buildProjectGraph } = await import('./utils/graphBuilder');
         buildProjectGraph(allConfigs, graphStore, schemas, allValidations);
 
+        // Browser mode: restore saved layout from localStorage (if any)
+        try {
+          const saved = localStorage.getItem('kwc.graphLayout');
+          if (saved) {
+            const layout = JSON.parse(saved) as {
+              graphNodes?: Array<{ id: string; position: { x: number; y: number } }>;
+              graphEdges?: Array<{ id: string; data?: Record<string, unknown> }>;
+              macroDesigner?: MacroDesignerPersistedState;
+            };
+            if (layout.macroDesigner) {
+              useMacroDesignerStore.getState().hydratePersistedState(layout.macroDesigner);
+            }
+            if (layout.graphNodes) {
+              const positionMap = new Map(
+                layout.graphNodes.map((n) => [n.id, n.position]),
+              );
+              const currentNodes = useGraphStore.getState().nodes;
+              const updatedNodes = currentNodes.map((node) => {
+                const savedPos = positionMap.get(node.id);
+                if (savedPos) {
+                  return { ...node, position: savedPos } as import('./types/graph').AppNode;
+                }
+                return node;
+              });
+              graphStore.setNodes(updatedNodes);
+            }
+          }
+        } catch { /* malformed/absent layout — keep auto-arranged positions */ }
+
         configStore.markClean();
       } catch {
         // No saved configs — that's fine, start empty
@@ -357,20 +386,31 @@ export default function App() {
     })();
   }, []);
 
-  // Auto-save layout (debounced) in native mode
+  // Auto-save layout (debounced). Native mode persists via the backend;
+  // browser mode falls back to localStorage so arrangements survive refresh.
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => {
     const isNative = useNativeStore.getState().isNative;
-    if (!isNative) return;
 
     if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
     saveTimerRef.current = setTimeout(() => {
       if (nodes.length === 0) return;
-      api.saveNativeLayout({
-        graphNodes: nodes,
-        graphEdges: edges,
-        macroDesigner: useMacroDesignerStore.getState().exportPersistedState(),
-      }).catch(() => { /* ignore save errors */ });
+      const macroDesigner = useMacroDesignerStore.getState().exportPersistedState();
+      if (isNative) {
+        api.saveNativeLayout({
+          graphNodes: nodes,
+          graphEdges: edges,
+          macroDesigner,
+        }).catch(() => { /* ignore save errors */ });
+      } else {
+        try {
+          localStorage.setItem('kwc.graphLayout', JSON.stringify({
+            graphNodes: nodes.map((n) => ({ id: n.id, position: n.position })),
+            graphEdges: edges.map((e) => ({ id: e.id, data: e.data })),
+            macroDesigner,
+          }));
+        } catch { /* ignore quota / privacy-mode errors */ }
+      }
     }, 3000);
 
     return () => {

--- a/frontend/src/components/AddMenu.tsx
+++ b/frontend/src/components/AddMenu.tsx
@@ -4,6 +4,7 @@ import { useGraphStore } from '../stores/graphStore';
 import * as api from '../services/api';
 import { applyBoardTypeMarkerToMcuSections, buildBoardTypeMarker } from '../utils/boardTypeMarker';
 import { buildUniqueSectionDraft } from '../utils/sectionNaming';
+import { hasFeatureSectionType as hasFeatureSectionTypeInFiles } from '../utils/featureSections';
 import type { ConfigSection, CommunicationType, ExampleConfig, HardwareType } from '../types/config';
 import McuNameDialog from './dialogs/McuNameDialog';
 
@@ -108,9 +109,7 @@ export default function AddMenu({ onClose }: AddMenuProps) {
     const data = n.data as Record<string, unknown>;
     return data.hardwareType !== 'sbc' || !!data.isMcu;
   });
-  const hasFeatureSectionType = (sectionType: string) => sectionType !== 'gcode_macro' && Object.values(configFiles).some(
-    (configFile) => configFile.sections.some((section) => section.section_type === sectionType),
-  );
+  const hasFeatureSectionType = (sectionType: string) => hasFeatureSectionTypeInFiles(configFiles, sectionType);
 
   // Derive kinematics from the selected parent's config file (fall back to all files)
   const kinematics = (() => {

--- a/frontend/src/components/AddMenu.tsx
+++ b/frontend/src/components/AddMenu.tsx
@@ -241,9 +241,9 @@ export default function AddMenu({ onClose }: AddMenuProps) {
       : `${effectiveLabel.toLowerCase().replace(/\s+/g, '_')}.cfg`;
 
     // Ensure the config file exists in configStore
-    const { setConfigFile } = useConfigStore.getState();
+    const { updateConfigFile } = useConfigStore.getState();
     if (!configFiles[configFile]) {
-      setConfigFile(configFile, {
+      updateConfigFile(configFile, {
         filename: configFile,
         sections: [],
         includes: [],
@@ -312,7 +312,7 @@ export default function AddMenu({ onClose }: AddMenuProps) {
         }
 
         // Set config file with the parsed sections
-        setConfigFile(configFile, {
+        updateConfigFile(configFile, {
           filename: configFile,
           sections: applyBoardTypeMarkerToMcuSections(config.sections, hwType, finalMcuName),
           includes: config.includes || [],

--- a/frontend/src/components/AddMenu.tsx
+++ b/frontend/src/components/AddMenu.tsx
@@ -90,6 +90,7 @@ export default function AddMenu({ onClose }: AddMenuProps) {
   const [templateSearch, setTemplateSearch] = useState('');
   const [templates, setTemplates] = useState<ExampleConfig[]>([]);
   const [templateLoading, setTemplateLoading] = useState(false);
+  const [templateError, setTemplateError] = useState<string | null>(null);
 
   // MCU name prompt state
   const [mcuNamePrompt, setMcuNamePrompt] = useState<{
@@ -288,6 +289,7 @@ export default function AddMenu({ onClose }: AddMenuProps) {
     // If a template was selected, load it and populate sections/graph
     if (templateFilename) {
       setTemplateLoading(true);
+      setTemplateError(null);
       api.getExample(templateFilename).then((res) => {
         const config = res.config;
 
@@ -341,7 +343,13 @@ export default function AddMenu({ onClose }: AddMenuProps) {
       }).catch((err) => {
         console.error('Template load error:', err);
         setTemplateLoading(false);
-        onClose();
+        // Surface the failure instead of silently closing. The node/file
+        // created optimistically above is removed so a retry starts clean.
+        try {
+          useGraphStore.getState().removeNode(nodeId);
+          useConfigStore.getState().removeConfigFile(configFile);
+        } catch { /* best-effort cleanup */ }
+        setTemplateError(`Failed to load template "${templateFilename}": ${(err as Error)?.message || 'unknown error'}`);
       });
     } else {
       // Add communication edge from SBC to this hardware node (blank config)
@@ -502,6 +510,7 @@ export default function AddMenu({ onClose }: AddMenuProps) {
                     setHwPickerStep(null);
                     setTemplateSearch('');
                     setTemplates([]);
+                    setTemplateError(null);
                   }}
                   className="px-2.5 py-1.5 rounded-lg text-xs font-medium bg-[var(--color-bg-primary)] border border-[var(--color-bg-tertiary)] text-[var(--color-text-primary)] hover:border-[var(--color-accent)]"
                 >
@@ -533,6 +542,11 @@ export default function AddMenu({ onClose }: AddMenuProps) {
               </div>
 
               <div className="space-y-1 max-h-72 overflow-y-auto pr-1">
+                {templateError && (
+                  <div className="px-3 py-2.5 rounded-lg border border-red-500/30 bg-red-500/10 text-xs text-red-400 mb-2">
+                    {templateError}
+                  </div>
+                )}
                 {templateLoading && (
                   <div className="px-3 py-2 text-xs text-[var(--color-text-secondary)]">
                     Loading templates...

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -445,6 +445,7 @@ export default function SettingsPanel() {
   // Toggle primary MCU - handles pin prefix updates, MCU section renaming, and config file renaming
   const handleTogglePrimary = useCallback(() => {
     if (!selectedNodeId) return;
+    useGraphStore.getState().pushHistory();
     const currentIsPrimary = (hwData as Record<string, unknown>)?.isPrimary as boolean;
     const { renameConfigFile } = useConfigStore.getState();
 
@@ -599,27 +600,14 @@ export default function SettingsPanel() {
     setMcuNamePrompt(null);
   }, [mcuNamePrompt, applyMcuNameChange, nodes, updateNodeData]);
 
-  // Handle MCU name dialog cancel — revert the primary toggle
+  // Handle MCU name dialog cancel — revert the primary toggle losslessly.
+  // handleTogglePrimary pushed history before any mutation, so undo() restores
+  // isPrimary flags, mcuName, file names, and pin prefixes in one step.
   const handleMcuNameCancel = useCallback(() => {
     if (!mcuNamePrompt) return;
-    if (mcuNamePrompt.purpose === 'demote') {
-      // Revert: re-promote if it was a swap, or re-promote if simple demote
-      updateNodeData(mcuNamePrompt.nodeId, { isPrimary: true } as Partial<AppNode['data']>);
-      // If there was a newly promoted node, demote it back
-      const currentPrimary = nodes.find(
-        (n) => n.type === 'hardware' && n.id !== mcuNamePrompt.nodeId &&
-          !!(n.data as Record<string, unknown>).isPrimary,
-      );
-      if (currentPrimary) {
-        // Revert its MCU prefix strip
-        const itsOldMcuName = (currentPrimary.data as Record<string, unknown>).mcuName as string || '';
-        // If it was just promoted and had its name stripped, it's now '' — we can't easily revert
-        // For now, just toggle the flags back
-        updateNodeData(currentPrimary.id, { isPrimary: false } as Partial<AppNode['data']>);
-      }
-    }
+    useGraphStore.getState().undo();
     setMcuNamePrompt(null);
-  }, [mcuNamePrompt, nodes, updateNodeData]);
+  }, [mcuNamePrompt]);
 
   // Toggle MCU mode for SBC
   const handleToggleMcu = useCallback(() => {
@@ -652,6 +640,7 @@ export default function SettingsPanel() {
   }, [isSuppressable, selectedNode, selectedSection]);
   const handleToggleSuppress = useCallback(() => {
     if (!selectedNodeId || !isSuppressable) return;
+    useGraphStore.getState().pushHistory();
     const newSuppressed = !nodeIsSuppressed;
 
     if (selectedNode?.type === 'subComponent' || selectedNode?.type === 'feature') {
@@ -720,6 +709,7 @@ export default function SettingsPanel() {
   // Apply section text edits back to config
   const handleApplySectionText = useCallback(async () => {
     if (!sectionHeader) return;
+    useGraphStore.getState().pushHistory();
     try {
       const filename = sectionConfigFile || Object.entries(configFiles).find(([_, cf]) =>
         cf.sections.some((s) => s.full_header === sectionHeader && (effectiveSectionLineNumber == null || effectiveSectionLineNumber === 0 || s.line_number === effectiveSectionLineNumber))
@@ -854,6 +844,7 @@ export default function SettingsPanel() {
                   <button
                     key={type}
                     onClick={() => {
+                      useGraphStore.getState().pushHistory();
                       updateEdgeData(selectedEdgeId, { commType: type } as Partial<AppEdge['data']>);
                       // Toggle MCU params: comment/uncomment based on selected comm type
                       if (mcuSection && targetConfigFile) {

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -9,6 +9,7 @@ import { updateAllSectionPins } from '../utils/pinUtils';
 import { buildUniqueSectionDraft } from '../utils/sectionNaming';
 import { getValidationStatusColor } from '../utils/validationStatus';
 import { resolveSection } from '../utils/sectionResolver';
+import { hasFeatureSectionType as hasFeatureSectionTypeInFiles } from '../utils/featureSections';
 import { acknowledgeWarning } from '../services/api';
 import WarningBadge from './nodes/WarningBadge';
 import McuNameDialog from './dialogs/McuNameDialog';
@@ -310,8 +311,8 @@ export default function SettingsPanel() {
     return configFiles[filename]?.sections || [];
   }, [hwData?.configFile, sectionConfigFile, nodeConfigFile, activeFile, configFiles]);
 
-  const hasFeatureSectionType = useCallback((sectionType: string) => sectionType !== 'gcode_macro' && Object.values(configFiles).some(
-    (configFile) => configFile.sections.some((section) => section.section_type === sectionType),
+  const hasFeatureSectionType = useCallback((sectionType: string) => (
+    hasFeatureSectionTypeInFiles(configFiles, sectionType)
   ), [configFiles]);
 
   const handleAddSubComponent = useCallback((sectionType: string) => {

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -962,16 +962,42 @@ export default function SettingsPanel() {
           </div>
           <div className="flex-1 overflow-y-auto p-3 space-y-3">
             <div className="rounded-lg border border-[var(--color-bg-tertiary)] bg-[var(--color-bg-primary)] p-3 space-y-2">
-              <div className="text-xs">
-                <span className="text-[var(--color-text-secondary)]">Source:</span>{' '}
-                <span className="font-mono text-[var(--color-text-primary)]">{srcNode?.data?.label as string ?? configEdge.source}</span>
+              <label className="block text-xs">
+                <span className="text-[var(--color-text-secondary)]">Source (included file):</span>
+                <select
+                  className="mt-1 w-full rounded-md border border-[var(--color-bg-tertiary)] bg-[var(--color-bg-secondary)] px-2 py-1.5 text-xs text-[var(--color-text-primary)]"
+                  value={configEdge.source}
+                  onChange={(e) => {
+                    const newTarget = e.target.value === configEdge.target ? configEdge.source : configEdge.target;
+                    useGraphStore.getState().repointConfigEdge(configEdge.id, e.target.value, newTarget);
+                  }}
+                >
+                  {nodes.filter((n) => n.type === 'hardware').map((n) => (
+                    <option key={n.id} value={n.id}>
+                      {(n.data as Record<string, unknown>).label as string ?? n.id}
+                    </option>
+                  ))}
+                </select>
                 <div className="text-[10px] text-[var(--color-text-secondary)] mt-0.5">{srcFile || 'unknown file'}</div>
-              </div>
-              <div className="text-xs">
-                <span className="text-[var(--color-text-secondary)]">Target:</span>{' '}
-                <span className="font-mono text-[var(--color-text-primary)]">{tgtNode?.data?.label as string ?? configEdge.target}</span>
+              </label>
+              <label className="block text-xs">
+                <span className="text-[var(--color-text-secondary)]">Target (including file):</span>
+                <select
+                  className="mt-1 w-full rounded-md border border-[var(--color-bg-tertiary)] bg-[var(--color-bg-secondary)] px-2 py-1.5 text-xs text-[var(--color-text-primary)]"
+                  value={configEdge.target}
+                  onChange={(e) => {
+                    const newSource = e.target.value === configEdge.source ? configEdge.target : configEdge.source;
+                    useGraphStore.getState().repointConfigEdge(configEdge.id, newSource, e.target.value);
+                  }}
+                >
+                  {nodes.filter((n) => n.type === 'hardware').map((n) => (
+                    <option key={n.id} value={n.id}>
+                      {(n.data as Record<string, unknown>).label as string ?? n.id}
+                    </option>
+                  ))}
+                </select>
                 <div className="text-[10px] text-[var(--color-text-secondary)] mt-0.5">{tgtFile || 'unknown file'}</div>
-              </div>
+              </label>
               {includingFile && includedFile && includingFile !== includedFile && (
                 <div className="pt-2 border-t border-[var(--color-bg-tertiary)] text-xs">
                   <span className="text-[var(--color-text-secondary)]">Include:</span>{' '}

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -813,8 +813,17 @@ export default function SettingsPanel() {
     const edgeData = edge?.data as Record<string, unknown> | undefined;
     if (edge && edgeData?.edgeType === 'communication') {
       const commType = (edgeData.commType as string) || 'usb';
-      // Find the target hardware node's MCU section for editing
-      const targetNode = nodes.find((n) => n.id === edge.target);
+      // Find the target hardware node's MCU section for editing. Comm edges
+      // connect SBC ↔ hardware and can be drawn in either direction, so the
+      // MCU to edit is ALWAYS the non-SBC endpoint (the SBC's host_mcu isn't
+      // the one carrying serial/canbus config for the peripheral).
+      const srcNode = nodes.find((n) => n.id === edge.source);
+      const srcData = srcNode?.data as Record<string, unknown> | undefined;
+      const tgtNode = nodes.find((n) => n.id === edge.target);
+      const tgtData = tgtNode?.data as Record<string, unknown> | undefined;
+      const srcIsSbc = srcData?.hardwareType === 'sbc';
+      const tgtIsSbc = tgtData?.hardwareType === 'sbc';
+      const targetNode = srcIsSbc && !tgtIsSbc ? tgtNode : srcNode;
       const targetData = targetNode?.data as Record<string, unknown> | undefined;
       const targetConfigFile = targetData?.configFile as string | undefined;
       const targetMcuName = (targetData?.mcuName as string) ?? '';
@@ -887,24 +896,6 @@ export default function SettingsPanel() {
                             addParam(targetConfigFile, mcuSection.full_header, {
                               key: 'canbus_interface', value: 'can0', is_commented_out: false, comment: '',
                             });
-                          }
-                        }
-                        // USB and UART share the serial field — the comm type is
-                        // inferred from the serial VALUE format, so switching the
-                        // label without rewriting the value leaves the config
-                        // disagreeing (and the next rebuild snaps back). Rewrite
-                        // the value to the selected transport's canonical format;
-                        // the user fine-tunes the exact path below (native mode
-                        // offers detected-device dropdowns).
-                        const serialParam = mcuSection.params.find((p) => p.key === 'serial');
-                        if (serialParam) {
-                          const val = serialParam.value;
-                          const isUsbPath = val.includes('/dev/serial/by-id/usb-') || val.includes('/tmp/klipper_host_mcu');
-                          const isTtyPath = /\/dev\/tty(S|AMA|ACM|USB)/.test(val);
-                          if (type === 'uart' && isUsbPath) {
-                            updateSectionParam(targetConfigFile, mcuSection.full_header, 'serial', '/dev/ttyACM0');
-                          } else if (type === 'usb' && isTtyPath) {
-                            updateSectionParam(targetConfigFile, mcuSection.full_header, 'serial', '/dev/serial/by-id/usb-klipper');
                           }
                         }
                       }

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -855,24 +855,36 @@ export default function SettingsPanel() {
                     onClick={() => {
                       useGraphStore.getState().pushHistory();
                       updateEdgeData(selectedEdgeId, { commType: type } as Partial<AppEdge['data']>);
-                      // Toggle MCU params: comment/uncomment based on selected comm type
+                      // Toggle MCU params: comment/uncomment based on selected comm type.
+                      // USB and UART share the serial field — the edge label and
+                      // detect field are the only visible difference between them.
+                      // Serial params are only touched when the selected type
+                      // actually differs (CAN ⇄ serial-family): switching to CAN
+                      // comments serials; switching back restores ONE serial only
+                      // if none is active — never uncomment a second serial, which
+                      // would silently swap which device is in use.
                       if (mcuSection && targetConfigFile) {
                         const wantSerial = type === 'usb' || type === 'uart';
                         const wantCanbus = type === 'canbus';
+                        const serialParams = mcuSection.params.filter((p) => SERIAL_PARAMS.includes(p.key) && p.key !== '_comment_');
+                        const activeSerialCount = serialParams.filter((p) => !p.is_commented_out).length;
                         for (const param of mcuSection.params) {
                           if (param.key === '_comment_') continue;
-                          if (SERIAL_PARAMS.includes(param.key)) {
-                            // Ensure serial/baud params exist and are uncommented for USB/UART
-                            if (wantSerial && param.is_commented_out) {
-                              toggleParamCommented(targetConfigFile, mcuSection.full_header, param.key);
-                            } else if (!wantSerial && !param.is_commented_out) {
-                              toggleParamCommented(targetConfigFile, mcuSection.full_header, param.key);
-                            }
-                          } else if (CANBUS_PARAMS.includes(param.key)) {
+                          if (CANBUS_PARAMS.includes(param.key)) {
                             // Ensure canbus params exist and are uncommented for CAN
                             if (wantCanbus && param.is_commented_out) {
                               toggleParamCommented(targetConfigFile, mcuSection.full_header, param.key);
                             } else if (!wantCanbus && !param.is_commented_out) {
+                              toggleParamCommented(targetConfigFile, mcuSection.full_header, param.key);
+                            }
+                          } else if (SERIAL_PARAMS.includes(param.key)) {
+                            // CAN: comment every serial/baud param.
+                            if (wantCanbus && !param.is_commented_out) {
+                              toggleParamCommented(targetConfigFile, mcuSection.full_header, param.key);
+                            } else if (wantSerial && activeSerialCount === 0 && param.is_commented_out) {
+                              // Back from CAN with no active serial: restore the
+                              // first commented one only. If a serial is already
+                              // active, leave everything untouched.
                               toggleParamCommented(targetConfigFile, mcuSection.full_header, param.key);
                             }
                           }

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -5,12 +5,12 @@ import { useNativeStore } from '../stores/nativeStore';
 import type { ParamSchema, ConfigParam, ConfigSection, HardwareType, SectionSchema } from '../types/config';
 import type { HardwareNodeData, SubComponentNodeData, FeatureNodeData, GroupChildItem, AppNode, AppEdge, ValidationStatus } from '../types/graph';
 import { applyBoardTypeMarkerToMcuSections } from '../utils/boardTypeMarker';
-import { updateAllSectionPins } from '../utils/pinUtils';
 import { buildUniqueSectionDraft } from '../utils/sectionNaming';
 import { getValidationStatusColor } from '../utils/validationStatus';
 import { resolveSection } from '../utils/sectionResolver';
 import { hasFeatureSectionType as hasFeatureSectionTypeInFiles } from '../utils/featureSections';
 import { toggleSectionSuppressed } from '../utils/sectionSuppress';
+import { applyMcuRenameToFiles, planPrimarySwap } from '../utils/mcuPrimary';
 import { acknowledgeWarning } from '../services/api';
 import WarningBadge from './nodes/WarningBadge';
 import McuNameDialog from './dialogs/McuNameDialog';
@@ -383,26 +383,7 @@ export default function SettingsPanel() {
     if (!cf) return;
     const allSchemas = configState.schemas;
 
-    // Rename MCU section header: [mcu oldName] → [mcu newName] (or [mcu] ↔ [mcu name])
-    const oldMcuHeader = oldMcuName ? `mcu ${oldMcuName}` : 'mcu';
-    const newMcuHeader = newMcuName ? `mcu ${newMcuName}` : 'mcu';
-    const updatedSections = cf.sections.map((sec) => {
-      if (sec.full_header === oldMcuHeader) {
-        return {
-          ...sec,
-          section_name: newMcuName,
-          full_header: newMcuHeader,
-        };
-      }
-      return sec;
-    });
-
-    // Update pin prefixes on non-MCU sections
-    const finalSections = updateAllSectionPins(updatedSections, oldMcuName, newMcuName, allSchemas);
-    configState.updateConfigFile(cfName, { ...cf, sections: finalSections });
-    void configState.revalidateFile(cfName);
-
-    // Also update pins in any other config files referenced by child nodes
+    // Update pins in any other config files referenced by child nodes
     const childConfigFiles = new Set<string>();
     for (const child of nodes) {
       if (child.parentId !== nodeId) continue;
@@ -415,12 +396,20 @@ export default function SettingsPanel() {
         }
       }
     }
-    for (const otherCfName of childConfigFiles) {
-      const otherCf = configState.configFiles[otherCfName];
-      if (!otherCf) continue;
-      const updatedOther = updateAllSectionPins(otherCf.sections, oldMcuName, newMcuName, allSchemas);
-      configState.updateConfigFile(otherCfName, { ...otherCf, sections: updatedOther });
-      void configState.revalidateFile(otherCfName);
+
+    // Rename MCU section + rewrite pin prefixes across affected files (pure)
+    const updatedFiles = applyMcuRenameToFiles(
+      configState.configFiles,
+      cfName,
+      [...childConfigFiles],
+      oldMcuName,
+      newMcuName,
+      allSchemas,
+    );
+    for (const filename of Object.keys(updatedFiles)) {
+      if (updatedFiles[filename] === configState.configFiles[filename]) continue;
+      configState.updateConfigFile(filename, updatedFiles[filename]);
+      void configState.revalidateFile(filename);
     }
 
     // Update node data
@@ -451,36 +440,20 @@ export default function SettingsPanel() {
     const currentIsPrimary = (hwData as Record<string, unknown>)?.isPrimary as boolean;
     const { renameConfigFile } = useConfigStore.getState();
 
-    // Helper to swap config files: old primary's printer.cfg → {mcuName}.cfg, new primary's file → printer.cfg
+    // Helper to swap config files via the pure plan: old primary's
+    // printer.cfg → {mcuName}.cfg, new primary's file → printer.cfg, and
+    // repoint every affected hardware + child node.
     const swapConfigFiles = (oldPrimaryNodeId: string | null, oldMcuName: string, newPrimaryNodeId: string, newConfigFile: string) => {
-      // Rename old primary's printer.cfg to {oldMcuName}.cfg
-      if (oldPrimaryNodeId && oldMcuName) {
-        const demotedFileName = `${oldMcuName.toLowerCase().replace(/\s+/g, '_')}.cfg`;
-        renameConfigFile('printer.cfg', demotedFileName);
-        updateNodeData(oldPrimaryNodeId, { configFile: demotedFileName } as Partial<AppNode['data']>);
-        // Update child nodes referencing printer.cfg
-        for (const child of nodes) {
-          if (child.parentId === oldPrimaryNodeId) {
-            const cd = child.data as Record<string, unknown>;
-            if (cd.configFile === 'printer.cfg') {
-              updateNodeData(child.id, { configFile: demotedFileName } as Partial<AppNode['data']>);
-            }
-          }
-        }
-      }
-      // Rename new primary's config file to printer.cfg
-      if (newConfigFile && newConfigFile !== 'printer.cfg') {
-        renameConfigFile(newConfigFile, 'printer.cfg');
-        updateNodeData(newPrimaryNodeId, { configFile: 'printer.cfg' } as Partial<AppNode['data']>);
-        // Update child nodes referencing the old file
-        for (const child of nodes) {
-          if (child.parentId === newPrimaryNodeId) {
-            const cd = child.data as Record<string, unknown>;
-            if (cd.configFile === newConfigFile) {
-              updateNodeData(child.id, { configFile: 'printer.cfg' } as Partial<AppNode['data']>);
-            }
-          }
-        }
+      const plan = planPrimarySwap({
+        oldPrimaryId: oldPrimaryNodeId,
+        oldMcuName,
+        newPrimaryId: newPrimaryNodeId,
+        newConfigFile,
+        nodes,
+      });
+      for (const r of plan.renames) renameConfigFile(r.from, r.to);
+      for (const u of plan.nodeUpdates) {
+        updateNodeData(u.nodeId, { configFile: u.configFile } as Partial<AppNode['data']>);
       }
     };
 
@@ -519,15 +492,16 @@ export default function SettingsPanel() {
         swapConfigFiles(oldPrimary.id, oldMcuName, selectedNodeId, newConfigFile);
       } else if (newConfigFile && newConfigFile !== 'printer.cfg') {
         // No old primary — just rename new primary's file to printer.cfg
-        renameConfigFile(newConfigFile, 'printer.cfg');
-        updateNodeData(selectedNodeId, { configFile: 'printer.cfg' } as Partial<AppNode['data']>);
-        for (const child of nodes) {
-          if (child.parentId === selectedNodeId) {
-            const cd = child.data as Record<string, unknown>;
-            if (cd.configFile === newConfigFile) {
-              updateNodeData(child.id, { configFile: 'printer.cfg' } as Partial<AppNode['data']>);
-            }
-          }
+        const plan = planPrimarySwap({
+          oldPrimaryId: null,
+          oldMcuName: '',
+          newPrimaryId: selectedNodeId,
+          newConfigFile,
+          nodes,
+        });
+        for (const r of plan.renames) renameConfigFile(r.from, r.to);
+        for (const u of plan.nodeUpdates) {
+          updateNodeData(u.nodeId, { configFile: u.configFile } as Partial<AppNode['data']>);
         }
       }
 
@@ -558,44 +532,29 @@ export default function SettingsPanel() {
     // Handle file rename when demoting: printer.cfg → {mcuName}.cfg
     if (mcuNamePrompt.purpose === 'demote') {
       const { renameConfigFile } = useConfigStore.getState();
-      const demotedFileName = `${mcuName.toLowerCase().replace(/\s+/g, '_')}.cfg`;
-      const ndData = nd?.data as Record<string, unknown>;
-      const currentFile = (ndData?.configFile as string) || 'printer.cfg';
-
-      if (currentFile === 'printer.cfg') {
-        renameConfigFile('printer.cfg', demotedFileName);
-        updateNodeData(mcuNamePrompt.nodeId, { configFile: demotedFileName } as Partial<AppNode['data']>);
-        // Update child nodes
-        for (const child of nodes) {
-          if (child.parentId === mcuNamePrompt.nodeId) {
-            const cd = child.data as Record<string, unknown>;
-            if (cd.configFile === 'printer.cfg') {
-              updateNodeData(child.id, { configFile: demotedFileName } as Partial<AppNode['data']>);
-            }
-          }
-        }
-      }
 
       // Now rename the new primary's file to printer.cfg
       const newPrimary = nodes.find(
         (n) => n.type === 'hardware' && n.id !== mcuNamePrompt.nodeId &&
           !!(n.data as Record<string, unknown>).isPrimary,
       );
-      if (newPrimary) {
-        const newPData = newPrimary.data as Record<string, unknown>;
-        const newPFile = (newPData.configFile as string) || '';
-        if (newPFile && newPFile !== 'printer.cfg') {
-          renameConfigFile(newPFile, 'printer.cfg');
-          updateNodeData(newPrimary.id, { configFile: 'printer.cfg' } as Partial<AppNode['data']>);
-          for (const child of nodes) {
-            if (child.parentId === newPrimary.id) {
-              const cd = child.data as Record<string, unknown>;
-              if (cd.configFile === newPFile) {
-                updateNodeData(child.id, { configFile: 'printer.cfg' } as Partial<AppNode['data']>);
-              }
-            }
-          }
-        }
+
+      // Demote the old primary (printer.cfg → {name}.cfg) and promote the new
+      // primary ({file} → printer.cfg) in one pure plan. renameConfigFile
+      // no-ops when the source file doesn't exist, so the stale-state guard
+      // from the old inline code is unnecessary.
+      const plan = planPrimarySwap({
+        oldPrimaryId: mcuNamePrompt.nodeId,
+        oldMcuName: mcuName,
+        newPrimaryId: newPrimary?.id ?? '',
+        newConfigFile: newPrimary
+          ? ((newPrimary.data as Record<string, unknown>).configFile as string) || ''
+          : '',
+        nodes,
+      });
+      for (const r of plan.renames) renameConfigFile(r.from, r.to);
+      for (const u of plan.nodeUpdates) {
+        updateNodeData(u.nodeId, { configFile: u.configFile } as Partial<AppNode['data']>);
       }
     }
 

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -1079,7 +1079,7 @@ export default function SettingsPanel() {
       const parentNode = parentId ? nodes.find((n) => n.id === parentId) : null;
       return (
         <>{mcuNameDialog}
-        <div className="w-80 border-l border-[var(--color-bg-tertiary)] bg-[var(--color-bg-secondary)] flex flex-col overflow-hidden">
+        <div className="w-96 border-l border-[var(--color-bg-tertiary)] bg-[var(--color-bg-secondary)] flex flex-col overflow-hidden">
           {parentNode && (
             <button
               onClick={() => { setSelectedNode(parentId!); setSelectedSection(null); }}
@@ -1119,7 +1119,7 @@ export default function SettingsPanel() {
     }
     return (
       <>{mcuNameDialog}
-      <div className="w-80 border-l border-[var(--color-bg-tertiary)] bg-[var(--color-bg-secondary)] p-4">
+      <div className="w-96 border-l border-[var(--color-bg-tertiary)] bg-[var(--color-bg-secondary)] p-4">
         <p className="text-sm text-[var(--color-text-secondary)]">
           Select a component to edit its settings.
         </p>

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -889,6 +889,24 @@ export default function SettingsPanel() {
                             });
                           }
                         }
+                        // USB and UART share the serial field — the comm type is
+                        // inferred from the serial VALUE format, so switching the
+                        // label without rewriting the value leaves the config
+                        // disagreeing (and the next rebuild snaps back). Rewrite
+                        // the value to the selected transport's canonical format;
+                        // the user fine-tunes the exact path below (native mode
+                        // offers detected-device dropdowns).
+                        const serialParam = mcuSection.params.find((p) => p.key === 'serial');
+                        if (serialParam) {
+                          const val = serialParam.value;
+                          const isUsbPath = val.includes('/dev/serial/by-id/usb-') || val.includes('/tmp/klipper_host_mcu');
+                          const isTtyPath = /\/dev\/tty(S|AMA|ACM|USB)/.test(val);
+                          if (type === 'uart' && isUsbPath) {
+                            updateSectionParam(targetConfigFile, mcuSection.full_header, 'serial', '/dev/ttyACM0');
+                          } else if (type === 'usb' && isTtyPath) {
+                            updateSectionParam(targetConfigFile, mcuSection.full_header, 'serial', '/dev/serial/by-id/usb-klipper');
+                          }
+                        }
                       }
                     }}
                     className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-lg border transition-all ${

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -8,6 +8,7 @@ import { applyBoardTypeMarkerToMcuSections } from '../utils/boardTypeMarker';
 import { updateAllSectionPins } from '../utils/pinUtils';
 import { buildUniqueSectionDraft } from '../utils/sectionNaming';
 import { getValidationStatusColor } from '../utils/validationStatus';
+import { resolveSection } from '../utils/sectionResolver';
 import { acknowledgeWarning } from '../services/api';
 import WarningBadge from './nodes/WarningBadge';
 import McuNameDialog from './dialogs/McuNameDialog';
@@ -92,6 +93,8 @@ function isAllowedSharedPin(users: PinUse[]): boolean {
 export default function SettingsPanel() {
   const {
     selectedSection,
+    selectedSectionFile,
+    selectedSectionLine,
     setSelectedSection,
     configFiles,
     activeFile,
@@ -138,6 +141,11 @@ export default function SettingsPanel() {
     return typeof data?.sectionLineNumber === 'number' ? data.sectionLineNumber as number : null;
   }, [selectedNode]);
 
+  // Prefer the line carried with the section selection (sidebar rows carry
+  // the exact (file, line) of the section they open); fall back to the
+  // selected node's line for direct node clicks.
+  const effectiveSectionLineNumber = selectedSectionLine ?? nodeSectionLineNumber;
+
   // Resolve the config file this node belongs to
   const nodeConfigFile = useMemo(() => {
     if (!selectedNode) return null;
@@ -157,21 +165,8 @@ export default function SettingsPanel() {
 
   const resolvedSectionInfo = useMemo(() => {
     if (!sectionHeader) return null;
-    // If we know the config file, look there first
-    if (nodeConfigFile) {
-      const cf = configFiles[nodeConfigFile];
-      if (cf) {
-        const found = cf.sections.find((s) => s.full_header === sectionHeader && (nodeSectionLineNumber == null || nodeSectionLineNumber === 0 || s.line_number === nodeSectionLineNumber));
-        if (found) return { section: found, filename: nodeConfigFile };
-      }
-    }
-    // Fallback: search across all config files
-    for (const [filename, cf] of Object.entries(configFiles)) {
-      const found = cf.sections.find((s) => s.full_header === sectionHeader && (nodeSectionLineNumber == null || nodeSectionLineNumber === 0 || s.line_number === nodeSectionLineNumber));
-      if (found) return { section: found, filename };
-    }
-    return null;
-  }, [sectionHeader, nodeConfigFile, configFiles, nodeSectionLineNumber]);
+    return resolveSection(configFiles, sectionHeader, selectedSectionFile, selectedSectionLine);
+  }, [sectionHeader, selectedSectionFile, selectedSectionLine, configFiles]);
 
   const section = resolvedSectionInfo?.section || null;
   const sectionConfigFile = resolvedSectionInfo?.filename || null;
@@ -266,9 +261,9 @@ export default function SettingsPanel() {
   const handleParamChange = useCallback(
     (key: string, value: string) => {
       if (!sectionHeader) return;
-      updateSectionParam(resolveFilename(), sectionHeader, key, value, nodeSectionLineNumber ?? undefined);
+      updateSectionParam(resolveFilename(), sectionHeader, key, value, effectiveSectionLineNumber ?? undefined);
     },
-    [sectionHeader, resolveFilename, updateSectionParam, nodeSectionLineNumber],
+    [sectionHeader, resolveFilename, updateSectionParam, effectiveSectionLineNumber],
   );
 
   const handleParamCommit = useCallback(() => {
@@ -284,17 +279,17 @@ export default function SettingsPanel() {
         value: paramSchema.default || '',
         comment: '',
         is_commented_out: false,
-      }, nodeSectionLineNumber ?? undefined);
+      }, effectiveSectionLineNumber ?? undefined);
     },
-    [sectionHeader, resolveFilename, addParam, nodeSectionLineNumber],
+    [sectionHeader, resolveFilename, addParam, effectiveSectionLineNumber],
   );
 
   const handleRemoveParam = useCallback(
     (key: string) => {
       if (!sectionHeader) return;
-      removeParam(resolveFilename(), sectionHeader, key, nodeSectionLineNumber ?? undefined);
+      removeParam(resolveFilename(), sectionHeader, key, effectiveSectionLineNumber ?? undefined);
     },
-    [sectionHeader, resolveFilename, removeParam, nodeSectionLineNumber],
+    [sectionHeader, resolveFilename, removeParam, effectiveSectionLineNumber],
   );
 
   // For hardware nodes: show overview with add buttons
@@ -727,7 +722,7 @@ export default function SettingsPanel() {
     if (!sectionHeader) return;
     try {
       const filename = sectionConfigFile || Object.entries(configFiles).find(([_, cf]) =>
-        cf.sections.some((s) => s.full_header === sectionHeader && (nodeSectionLineNumber == null || nodeSectionLineNumber === 0 || s.line_number === nodeSectionLineNumber))
+        cf.sections.some((s) => s.full_header === sectionHeader && (effectiveSectionLineNumber == null || effectiveSectionLineNumber === 0 || s.line_number === effectiveSectionLineNumber))
       )?.[0] || activeFile;
       const currentConfig = configFiles[filename];
       if (!currentConfig) return;
@@ -738,7 +733,7 @@ export default function SettingsPanel() {
 
       const targetIndex = currentConfig.sections.findIndex((s) =>
         s.full_header === sectionHeader
-        && (nodeSectionLineNumber == null || nodeSectionLineNumber === 0 || s.line_number === nodeSectionLineNumber),
+        && (effectiveSectionLineNumber == null || effectiveSectionLineNumber === 0 || s.line_number === effectiveSectionLineNumber),
       );
       if (targetIndex === -1) return;
 
@@ -795,14 +790,14 @@ export default function SettingsPanel() {
         }
       }
 
-      setSelectedSection(nextSection.full_header);
+      setSelectedSection(nextSection.full_header, filename ?? null, nextSection.line_number ?? null);
       setSectionEditText(sectionToText(nextSection));
       setSectionTextDirty(false);
       void revalidateFile(filename);
     } catch (err) {
       console.error('Parse error:', err);
     }
-  }, [sectionEditText, activeFile, sectionHeader, sectionConfigFile, configFiles, nodeSectionLineNumber, updateConfigFile, selectedNodeId, selectedNode, selectedSection, schemas, updateNodeData, setSelectedSection, revalidateFile]);
+  }, [sectionEditText, activeFile, sectionHeader, sectionConfigFile, configFiles, effectiveSectionLineNumber, updateConfigFile, selectedNodeId, selectedNode, selectedSection, schemas, updateNodeData, setSelectedSection, revalidateFile]);
 
   const handleAcknowledgeWarning = useCallback(async () => {
     if (!section || !sectionConfigFile) return;
@@ -969,7 +964,7 @@ export default function SettingsPanel() {
         setAddingType={setAddingType}
         onAddSubComponent={handleAddSubComponent}
         onAddFeature={handleAddFeature}
-        onSelectSection={(header: string) => setSelectedSection(header)}
+        onSelectSection={(header: string, cf?: string | null, ln?: number | null) => setSelectedSection(header, cf ?? null, ln ?? null)}
         onSelectNode={(nodeId: string) => { setSelectedNode(nodeId); setSelectedSection(null); }}
         onOpenCommunication={() => {
           if (!selectedNodeId) return;
@@ -985,7 +980,7 @@ export default function SettingsPanel() {
           }
           const mcuHeader = hwData?.mcuName ? `mcu ${hwData.mcuName}` : 'mcu';
           setSelectedEdge(null);
-          setSelectedSection(mcuHeader);
+          setSelectedSection(mcuHeader, hwData?.configFile ?? null, null);
         }}
         onTogglePrimary={handleTogglePrimary}
         onToggleMcu={handleToggleMcu}
@@ -1017,7 +1012,7 @@ export default function SettingsPanel() {
     // GroupNode selected — show its children for editing
     if (selectedNode?.type === 'group') {
       const groupData = selectedNode.data as Record<string, unknown>;
-      const children = (groupData.children as Array<{ label: string; sectionHeader: string; params?: Array<{ key: string; value: string }>; validationStatus?: ValidationStatus }>) || [];
+      const children = (groupData.children as Array<{ label: string; sectionHeader: string; configFile?: string; sectionLineNumber?: number; params?: Array<{ key: string; value: string }>; validationStatus?: ValidationStatus }>) || [];
       const groupLabel = groupData.label as string;
       const parentId = groupData.parentHardwareId as string | undefined;
       const parentNode = parentId ? nodes.find((n) => n.id === parentId) : null;
@@ -1043,7 +1038,7 @@ export default function SettingsPanel() {
             {children.map((child, idx) => (
               <button
                 key={`${child.sectionHeader}__${idx}`}
-                onClick={() => setSelectedSection(child.sectionHeader)}
+                onClick={() => setSelectedSection(child.sectionHeader, child.configFile ?? null, child.sectionLineNumber ?? null)}
                 className="flex items-center justify-between w-full px-2 py-1.5 rounded-lg text-xs text-left hover:bg-[var(--color-bg-primary)] transition-colors group"
               >
                 <span className="flex items-center gap-2 min-w-0">
@@ -1658,7 +1653,7 @@ function ChildNodesList({
   title,
 }: {
   childNodes: AppNode[];
-  onSelectSection: (header: string) => void;
+  onSelectSection: (header: string, configFile?: string | null, lineNumber?: number | null) => void;
   onSelectNode: (nodeId: string) => void;
   title?: string;
 }) {
@@ -1697,7 +1692,7 @@ function ChildNodesList({
                   key={n.id}
                   onClick={() => {
                     if (n.type === 'group') { onSelectNode(n.id); return; }
-                    if (d.sectionHeader) onSelectSection(d.sectionHeader as string);
+                    if (d.sectionHeader) onSelectSection(d.sectionHeader as string, d.configFile as string | undefined, typeof d.sectionLineNumber === 'number' ? d.sectionLineNumber as number : null);
                   }}
                   className="flex items-center gap-2 w-full px-2 py-1.5 rounded-lg text-xs text-left hover:bg-[var(--color-bg-primary)] transition-colors"
                 >
@@ -1721,7 +1716,7 @@ function ChildNodesList({
                     onSelectNode(n.id);
                     return;
                   }
-                  if (d.sectionHeader) onSelectSection(d.sectionHeader as string);
+                  if (d.sectionHeader) onSelectSection(d.sectionHeader as string, d.configFile as string | undefined, typeof d.sectionLineNumber === 'number' ? d.sectionLineNumber as number : null);
                 }}
                 className="flex items-center gap-2 w-full px-2 py-1.5 rounded-lg text-xs text-left hover:bg-[var(--color-bg-primary)] transition-colors"
               >
@@ -1776,10 +1771,10 @@ function ChildNodesList({
                             <span className="text-[10px] text-[var(--color-text-secondary)] ml-auto">open</span>
                           </button>
                           <div className="ml-3 space-y-0.5">
-                            {(d.children as Array<{ label: string; sectionHeader: string; configFile?: string; validationStatus?: ValidationStatus }>).map((child, ci) => (
+                            {(d.children as Array<{ label: string; sectionHeader: string; configFile?: string; sectionLineNumber?: number; validationStatus?: ValidationStatus }>).map((child, ci) => (
                               <button
                                 key={`${n.id}_${child.configFile || 'cfg'}_${child.sectionHeader}_${ci}`}
-                                onClick={() => onSelectSection(child.sectionHeader)}
+                                onClick={() => onSelectSection(child.sectionHeader, child.configFile ?? null, child.sectionLineNumber ?? null)}
                                 className="flex items-center gap-2 w-full px-2 py-1 rounded text-xs text-left hover:bg-[var(--color-bg-primary)] transition-colors"
                               >
                                 <span className="w-1.5 h-1.5 rounded-full" style={{ backgroundColor: getValidationStatusColor(child.validationStatus || 'valid') }} />
@@ -1794,7 +1789,7 @@ function ChildNodesList({
                       <button
                         key={n.id}
                         onClick={() => {
-                          if (d.sectionHeader) onSelectSection(d.sectionHeader as string);
+                          if (d.sectionHeader) onSelectSection(d.sectionHeader as string, d.configFile as string | undefined, typeof d.sectionLineNumber === 'number' ? d.sectionLineNumber as number : null);
                         }}
                         className="flex items-center gap-2 w-full px-2 py-1 rounded text-xs text-left hover:bg-[var(--color-bg-primary)] transition-colors"
                       >

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -938,7 +938,77 @@ export default function SettingsPanel() {
         </div>
       );
     }
-    // Config edge selected — nothing meaningful to show
+    // Config (trace) edge selected — show the include relation + delete
+    const configEdge = edges.find((e) => e.id === selectedEdgeId);
+    const configEdgeData = configEdge?.data as Record<string, unknown> | undefined;
+    if (configEdge && configEdgeData?.edgeType === 'configuration') {
+      const srcNode = nodes.find((n) => n.id === configEdge.source);
+      const tgtNode = nodes.find((n) => n.id === configEdge.target);
+      const srcFile = (srcNode?.data as Record<string, unknown> | undefined)?.configFile as string | undefined;
+      const tgtFile = (tgtNode?.data as Record<string, unknown> | undefined)?.configFile as string | undefined;
+      // Include direction: the primary file includes the non-primary one
+      const srcIsPrimary = !!(srcNode?.data as Record<string, unknown> | undefined)?.isPrimary || srcFile === 'printer.cfg';
+      const tgtIsPrimary = !!(tgtNode?.data as Record<string, unknown> | undefined)?.isPrimary || tgtFile === 'printer.cfg';
+      const includingFile = srcIsPrimary && !tgtIsPrimary ? srcFile : tgtFile;
+      const includedFile = srcIsPrimary && !tgtIsPrimary ? tgtFile : srcFile;
+      return (
+        <>{mcuNameDialog}
+        <div className="w-96 border-l border-[var(--color-bg-tertiary)] bg-[var(--color-bg-secondary)] flex flex-col overflow-hidden">
+          <div className="p-3 border-b border-[var(--color-bg-tertiary)]">
+            <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">Configuration Link</h2>
+            <p className="text-xs text-[var(--color-text-secondary)] mt-0.5">
+              Trace connection between hardware nodes
+            </p>
+          </div>
+          <div className="flex-1 overflow-y-auto p-3 space-y-3">
+            <div className="rounded-lg border border-[var(--color-bg-tertiary)] bg-[var(--color-bg-primary)] p-3 space-y-2">
+              <div className="text-xs">
+                <span className="text-[var(--color-text-secondary)]">Source:</span>{' '}
+                <span className="font-mono text-[var(--color-text-primary)]">{srcNode?.data?.label as string ?? configEdge.source}</span>
+                <div className="text-[10px] text-[var(--color-text-secondary)] mt-0.5">{srcFile || 'unknown file'}</div>
+              </div>
+              <div className="text-xs">
+                <span className="text-[var(--color-text-secondary)]">Target:</span>{' '}
+                <span className="font-mono text-[var(--color-text-primary)]">{tgtNode?.data?.label as string ?? configEdge.target}</span>
+                <div className="text-[10px] text-[var(--color-text-secondary)] mt-0.5">{tgtFile || 'unknown file'}</div>
+              </div>
+              {includingFile && includedFile && includingFile !== includedFile && (
+                <div className="pt-2 border-t border-[var(--color-bg-tertiary)] text-xs">
+                  <span className="text-[var(--color-text-secondary)]">Include:</span>{' '}
+                  <span className="font-mono text-[var(--color-text-primary)]">{includedFile}</span>
+                  <span className="text-[var(--color-text-secondary)]"> added to </span>
+                  <span className="font-mono text-[var(--color-text-primary)]">{includingFile}</span>
+                </div>
+              )}
+            </div>
+            <button
+              onClick={() => {
+                // removeEdge pushes history itself; include removal is folded
+                // into the same undo step since it happens before the next push
+                useGraphStore.getState().removeEdge(configEdge.id);
+                // Comment out the include in the primary file (direction-agnostic)
+                if (srcFile && tgtFile && srcFile !== tgtFile) {
+                  const srcIsPrimary2 = !!(srcNode?.data as Record<string, unknown> | undefined)?.isPrimary || srcFile === 'printer.cfg';
+                  if (srcIsPrimary2) {
+                    useConfigStore.getState().removeInclude(srcFile, tgtFile);
+                  } else {
+                    useConfigStore.getState().removeInclude(tgtFile, srcFile);
+                  }
+                }
+                setSelectedEdge(null);
+              }}
+              className="w-full flex items-center justify-center gap-2 px-3 py-2.5 rounded-lg border border-red-500/30 text-red-400 hover:bg-red-500/10 transition-colors text-xs font-medium"
+            >
+              <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+                <path d="M3 6h10M6.5 6V4h3v2M5 6l.5 7h5L11 6" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+              Delete link
+            </button>
+          </div>
+        </div>
+        </>
+      );
+    }
     return mcuNameDialog;
   }
 

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -10,7 +10,7 @@ import { getValidationStatusColor } from '../utils/validationStatus';
 import { resolveSection } from '../utils/sectionResolver';
 import { hasFeatureSectionType as hasFeatureSectionTypeInFiles } from '../utils/featureSections';
 import { toggleSectionSuppressed } from '../utils/sectionSuppress';
-import { applyMcuRenameToFiles, planPrimarySwap } from '../utils/mcuPrimary';
+import { applyMcuRenameToFiles, planPrimarySwap, applyNodeUpdates, applyGroupChildRenames, mcuHeaderFor } from '../utils/mcuPrimary';
 import { acknowledgeWarning } from '../services/api';
 import WarningBadge from './nodes/WarningBadge';
 import McuNameDialog from './dialogs/McuNameDialog';
@@ -415,6 +415,24 @@ export default function SettingsPanel() {
     // Update node data
     updateNodeData(nodeId, { mcuName: newMcuName } as Partial<AppNode['data']>);
 
+    // The MCU section header changed ([mcu old] → [mcu new]); any child
+    // sub-component/feature node whose sectionHeader matches the old header
+    // must be repointed or clicking it resolves null and the sidebar blanks.
+    const oldMcuHeader = mcuHeaderFor(oldMcuName);
+    const newMcuHeader = mcuHeaderFor(newMcuName);
+    for (const child of nodes) {
+      if (child.parentId !== nodeId) continue;
+      const childData = child.data as Record<string, unknown>;
+      if (childData.sectionHeader === oldMcuHeader) {
+        updateNodeData(child.id, {
+          sectionHeader: newMcuHeader,
+          label: newMcuName
+            ? `${(useConfigStore.getState().schemas?.['mcu']?.display_name) || 'MCU'}: ${newMcuName}`
+            : (useConfigStore.getState().schemas?.['mcu']?.display_name) || 'MCU',
+        } as Partial<AppNode['data']>);
+      }
+    }
+
     // Sync group node children's params with updated config store data
     const freshConfigs = useConfigStore.getState().configFiles;
     for (const child of nodes) {
@@ -425,9 +443,15 @@ export default function SettingsPanel() {
       const updatedChildren = gChildren.map((gc) => {
         const gcFile = (gc.configFile as string) || cfName;
         const gcConfig = freshConfigs[gcFile];
-        const matchedSection = gcConfig?.sections.find((s: { full_header: string }) => s.full_header === gc.sectionHeader);
+        // A group child that was the MCU section keeps its own header too.
+        const gcHeader = gc.sectionHeader === oldMcuHeader ? newMcuHeader : gc.sectionHeader;
+        const matchedSection = gcConfig?.sections.find((s: { full_header: string }) => s.full_header === gcHeader);
         if (!matchedSection) return gc;
-        return { ...gc, params: matchedSection.params.filter((p: { is_commented_out?: boolean }) => !p.is_commented_out) };
+        return {
+          ...gc,
+          sectionHeader: gcHeader,
+          params: matchedSection.params.filter((p: { is_commented_out?: boolean }) => !p.is_commented_out),
+        };
       });
       updateNodeData(child.id, { children: updatedChildren } as Partial<AppNode['data']>);
     }
@@ -452,9 +476,8 @@ export default function SettingsPanel() {
         nodes,
       });
       for (const r of plan.renames) renameConfigFile(r.from, r.to);
-      for (const u of plan.nodeUpdates) {
-        updateNodeData(u.nodeId, { configFile: u.configFile } as Partial<AppNode['data']>);
-      }
+      applyNodeUpdates(plan, (nodeId, data) => updateNodeData(nodeId, data as Partial<AppNode['data']>));
+      applyGroupChildRenames(plan, nodes, (nodeId, data) => updateNodeData(nodeId, data as Partial<AppNode['data']>));
     };
 
     if (!currentIsPrimary) {
@@ -500,9 +523,8 @@ export default function SettingsPanel() {
           nodes,
         });
         for (const r of plan.renames) renameConfigFile(r.from, r.to);
-        for (const u of plan.nodeUpdates) {
-          updateNodeData(u.nodeId, { configFile: u.configFile } as Partial<AppNode['data']>);
-        }
+        applyNodeUpdates(plan, (nodeId, data) => updateNodeData(nodeId, data as Partial<AppNode['data']>));
+        applyGroupChildRenames(plan, nodes, (nodeId, data) => updateNodeData(nodeId, data as Partial<AppNode['data']>));
       }
 
       // Promote the new primary: strip MCU prefix, rename [mcu name] → [mcu]
@@ -553,9 +575,8 @@ export default function SettingsPanel() {
         nodes,
       });
       for (const r of plan.renames) renameConfigFile(r.from, r.to);
-      for (const u of plan.nodeUpdates) {
-        updateNodeData(u.nodeId, { configFile: u.configFile } as Partial<AppNode['data']>);
-      }
+      applyNodeUpdates(plan, (nodeId, data) => updateNodeData(nodeId, data as Partial<AppNode['data']>));
+      applyGroupChildRenames(plan, nodes, (nodeId, data) => updateNodeData(nodeId, data as Partial<AppNode['data']>));
     }
 
     setMcuNamePrompt(null);

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -10,6 +10,7 @@ import { buildUniqueSectionDraft } from '../utils/sectionNaming';
 import { getValidationStatusColor } from '../utils/validationStatus';
 import { resolveSection } from '../utils/sectionResolver';
 import { hasFeatureSectionType as hasFeatureSectionTypeInFiles } from '../utils/featureSections';
+import { toggleSectionSuppressed } from '../utils/sectionSuppress';
 import { acknowledgeWarning } from '../services/api';
 import WarningBadge from './nodes/WarningBadge';
 import McuNameDialog from './dialogs/McuNameDialog';
@@ -659,13 +660,7 @@ export default function SettingsPanel() {
             ...cf,
             sections: cf.sections.map((s) => {
               if (s.full_header !== secHeader) return s;
-              return {
-                ...s,
-                is_commented_out: newSuppressed,
-                params: s.params.map((p) =>
-                  p.key === '_comment_' ? p : { ...p, is_commented_out: newSuppressed },
-                ),
-              };
+              return toggleSectionSuppressed(s, newSuppressed);
             }),
           });
           void cs.revalidateFile(cfName);
@@ -691,13 +686,7 @@ export default function SettingsPanel() {
               ...cf,
               sections: cf.sections.map((s) => {
                 if (s.full_header !== secHeader) return s;
-                return {
-                  ...s,
-                  is_commented_out: newSuppressed,
-                  params: s.params.map((p) =>
-                    p.key === '_comment_' ? p : { ...p, is_commented_out: newSuppressed },
-                  ),
-                };
+                return toggleSectionSuppressed(s, newSuppressed);
               }),
             });
             void cs.revalidateFile(cfName);

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -97,7 +97,7 @@ export default function SettingsPanel() {
     activeFile,
     schemas,
     validation,
-    setConfigFile,
+    updateConfigFile,
     updateSectionParam,
     addParam,
     removeParam,
@@ -402,7 +402,7 @@ export default function SettingsPanel() {
 
     // Update pin prefixes on non-MCU sections
     const finalSections = updateAllSectionPins(updatedSections, oldMcuName, newMcuName, allSchemas);
-    configState.setConfigFile(cfName, { ...cf, sections: finalSections });
+    configState.updateConfigFile(cfName, { ...cf, sections: finalSections });
     void configState.revalidateFile(cfName);
 
     // Also update pins in any other config files referenced by child nodes
@@ -422,7 +422,7 @@ export default function SettingsPanel() {
       const otherCf = configState.configFiles[otherCfName];
       if (!otherCf) continue;
       const updatedOther = updateAllSectionPins(otherCf.sections, oldMcuName, newMcuName, allSchemas);
-      configState.setConfigFile(otherCfName, { ...otherCf, sections: updatedOther });
+      configState.updateConfigFile(otherCfName, { ...otherCf, sections: updatedOther });
       void configState.revalidateFile(otherCfName);
     }
 
@@ -670,7 +670,7 @@ export default function SettingsPanel() {
         const cs = useConfigStore.getState();
         const cf = cs.configFiles[cfName];
         if (cf) {
-          cs.setConfigFile(cfName, {
+          cs.updateConfigFile(cfName, {
             ...cf,
             sections: cf.sections.map((s) => {
               if (s.full_header !== secHeader) return s;
@@ -702,7 +702,7 @@ export default function SettingsPanel() {
           const cs = useConfigStore.getState();
           const cf = cs.configFiles[cfName];
           if (cf) {
-            cs.setConfigFile(cfName, {
+            cs.updateConfigFile(cfName, {
               ...cf,
               sections: cf.sections.map((s) => {
                 if (s.full_header !== secHeader) return s;
@@ -752,7 +752,8 @@ export default function SettingsPanel() {
         sections: currentConfig.sections.map((candidate, index) => index === targetIndex ? nextSection : candidate),
       };
 
-      setConfigFile(filename, nextConfig);
+      updateConfigFile(filename, nextConfig);
+      void revalidateFile(filename);
 
       if (selectedNodeId && selectedNode && selectedNode.type !== 'hardware' && selectedNode.type !== 'group') {
         const displayName = schemas[nextSection.section_type]?.display_name || nextSection.section_type;
@@ -801,7 +802,7 @@ export default function SettingsPanel() {
     } catch (err) {
       console.error('Parse error:', err);
     }
-  }, [sectionEditText, activeFile, sectionHeader, sectionConfigFile, configFiles, nodeSectionLineNumber, setConfigFile, selectedNodeId, selectedNode, selectedSection, schemas, updateNodeData, setSelectedSection, revalidateFile]);
+  }, [sectionEditText, activeFile, sectionHeader, sectionConfigFile, configFiles, nodeSectionLineNumber, updateConfigFile, selectedNodeId, selectedNode, selectedSection, schemas, updateNodeData, setSelectedSection, revalidateFile]);
 
   const handleAcknowledgeWarning = useCallback(async () => {
     if (!section || !sectionConfigFile) return;
@@ -996,7 +997,7 @@ export default function SettingsPanel() {
           const configState = useConfigStore.getState();
           const configFileData = configState.configFiles[hwData.configFile];
           if (!configFileData) return;
-          configState.setConfigFile(hwData.configFile, {
+          configState.updateConfigFile(hwData.configFile, {
             ...configFileData,
             sections: applyBoardTypeMarkerToMcuSections(
               configFileData.sections,

--- a/frontend/src/components/TextEditor.tsx
+++ b/frontend/src/components/TextEditor.tsx
@@ -37,7 +37,7 @@ interface ConfigSectionEntry {
   isCommented: boolean;
 }
 
-function TextEditor() {
+function TextEditor({ isActive = true }: { isActive?: boolean }) {
   const {
     configFiles,
     activeFile,
@@ -92,7 +92,12 @@ function TextEditor() {
 
   // When config changes from OUTSIDE the text editor (undo/redo, import,
   // graph edits, file switch), re-export the model text into the textarea.
+  // Only run while the text view is actually visible: the editor stays mounted
+  // (CSS-hidden) in graph view so viewport state survives toggling, but its
+  // effects must not fire there — a panel edit would otherwise be re-exported,
+  // re-parsed and synced back into the graph (commType snap-back, undo churn).
   useEffect(() => {
+    if (!isActive) return;
     if (applyingRef.current) {
       applyingRef.current = false;
       return;
@@ -109,7 +114,7 @@ function TextEditor() {
         markFallbackExport(activeFile, usedFallback);
       }
     });
-  }, [activeFile, config, exportConfigText, markFallbackExport]);
+  }, [isActive, activeFile, config, exportConfigText, markFallbackExport]);
 
   const [showSearch, setShowSearch] = useState(false);
   const [showFileSidebar, setShowFileSidebar] = useState(true);
@@ -156,6 +161,7 @@ function TextEditor() {
   // A request-id guard drops stale responses (older text resolving after
   // newer edits or a file switch).
   useEffect(() => {
+    if (!isActive) return;
     if (liveValidateTimerRef.current) clearTimeout(liveValidateTimerRef.current);
     const requestId = ++liveValidateRequestRef.current;
     liveValidateTimerRef.current = setTimeout(async () => {
@@ -214,7 +220,7 @@ function TextEditor() {
       if (liveValidateTimerRef.current) clearTimeout(liveValidateTimerRef.current);
       liveValidateRequestRef.current++;
     };
-  }, [activeFile, editText, markDirty, setConfigFile, setTextParseError, setValidation]);
+  }, [isActive, activeFile, editText, markDirty, setConfigFile, setTextParseError, setValidation]);
 
   // Collect inline issues from live validation of the current text
   const inlineIssues = useMemo((): TextIssue[] => {

--- a/frontend/src/components/TextEditor.tsx
+++ b/frontend/src/components/TextEditor.tsx
@@ -43,6 +43,7 @@ function TextEditor() {
     activeFile,
     setActiveFile,
     setConfigFile,
+    updateConfigFile,
     setValidation,
     markDirty,
     renameConfigFile,
@@ -518,7 +519,7 @@ function TextEditor() {
       setFileError(`"${name}" already exists. Choose a different name.`);
       return;
     }
-    setConfigFile(name, {
+    updateConfigFile(name, {
       filename: name,
       sections: [],
       includes: [],
@@ -566,7 +567,7 @@ function TextEditor() {
           name = `${base}_${counter}.cfg`;
         }
       }
-      setConfigFile(name, {
+      updateConfigFile(name, {
         filename: name,
         sections: res.config.sections,
         includes: res.config.includes || [],

--- a/frontend/src/components/dialogs/ApplyDialog.tsx
+++ b/frontend/src/components/dialogs/ApplyDialog.tsx
@@ -181,7 +181,11 @@ export default function ApplyDialog({ onClose, canAnalyzeWithAi = false, onAnaly
   const isDirty = useConfigStore((s) => s.isDirty);
   const validation = useConfigStore((s) => s.validation);
   const saveButtonClass = getSaveButtonClass(isDirty, validation);
-  const filenames = Object.keys(configFiles);
+  // A file deleted since import is gone from configFiles but its original text
+  // survives in originalTexts — union both so deletions show up in the diff
+  // and are actually removed from disk on save.
+  const filenames = Array.from(new Set([...Object.keys(configFiles), ...Object.keys(originalTexts)]));
+  const deletedFilenames = filenames.filter((fn) => !(fn in configFiles) && fn in originalTexts);
 
   const [selectedFiles, setSelectedFiles] = useState<Set<string>>(new Set(filenames));
   const [status, setStatus] = useState<'idle' | 'exporting' | 'applying' | 'success' | 'error'>('idle');
@@ -319,22 +323,26 @@ export default function ApplyDialog({ onClose, canAnalyzeWithAi = false, onAnaly
         exportedFiles[fn] = text;
       }
 
+      // Files selected that exist in the model are written; files selected
+      // that were deleted from the model are removed from storage.
+      const deleted = files.filter((fn) => !(fn in configFiles));
+
       if (isLocalMode) {
         // Non-native mode: save to local config storage
         setStatus('applying');
-        setMessage(`Saving ${Object.keys(exportedFiles).length} files locally...`);
-        const result = await api.saveConfigsToLocal(exportedFiles);
+        setMessage(`Saving ${Object.keys(exportedFiles).length} file${Object.keys(exportedFiles).length !== 1 ? 's' : ''} locally...`);
+        const result = await api.saveConfigsToLocal(exportedFiles, deleted);
         setAppliedFiles(result.saved);
         setStatus('success');
-        setMessage(`Successfully saved ${result.saved.length} file${result.saved.length !== 1 ? 's' : ''} locally`);
+        setMessage(`Successfully saved ${result.saved.length} file${result.saved.length !== 1 ? 's' : ''} locally${result.removed.length ? `, removed ${result.removed.length} file${result.removed.length !== 1 ? 's' : ''}` : ''}`);
       } else {
         // Native mode: save to Pi config path
         setStatus('applying');
         setMessage(`Writing ${Object.keys(exportedFiles).length} files to ${configPath}...`);
-        const result = await api.applyNativeConfig(exportedFiles, configPath);
+        const result = await api.applyNativeConfig(exportedFiles, configPath, deleted);
         setAppliedFiles(result.files);
         setStatus('success');
-        setMessage(`Successfully saved ${result.files.length} file${result.files.length !== 1 ? 's' : ''} to ${result.config_path}`);
+        setMessage(`Successfully saved ${result.files.length} file${result.files.length !== 1 ? 's' : ''} to ${result.config_path}${result.removed.length ? `, removed ${result.removed.length} file${result.removed.length !== 1 ? 's' : ''}` : ''}`);
       }
 
       // Update originalTexts to match what was saved, so diff resets
@@ -342,6 +350,9 @@ export default function ApplyDialog({ onClose, canAnalyzeWithAi = false, onAnaly
       for (const [fn, text] of Object.entries(exportedFiles)) {
         configStore.setOriginalText(fn, text);
       }
+      // Deleted files no longer have an original — drop them so the diff
+      // doesn't keep showing them as deleted forever.
+      configStore.removeOriginalTexts(deleted);
       configStore.markClean();
     } catch (err) {
       setStatus('error');
@@ -528,31 +539,37 @@ export default function ApplyDialog({ onClose, canAnalyzeWithAi = false, onAnaly
                 </span>
               </div>
               <div className="space-y-1">
-                {filenames.map((fn) => (
-                  <label
-                    key={fn}
-                    className={`group flex items-center gap-2 px-2 py-1.5 rounded-md cursor-pointer ${
-                      appliedFiles.includes(fn) ? 'bg-green-500/10' : 'hover:bg-[var(--color-bg-primary)]'
-                    }`}
-                  >
-                    <input
-                      type="checkbox"
-                      checked={selectedFiles.has(fn)}
-                      onChange={() => toggleFile(fn)}
-                      disabled={status === 'applying' || status === 'success'}
-                      className="rounded"
-                    />
-                    <div className="kwc-marquee-shell flex-1 min-w-0">
-                      <div className="kwc-marquee-track">
-                        <span className="kwc-marquee-text text-xs font-mono text-[var(--color-text-primary)]">{fn}</span>
-                        <span aria-hidden="true" className="kwc-marquee-text text-xs font-mono text-[var(--color-text-primary)]">{fn}</span>
+                {filenames.map((fn) => {
+                  const isDeleted = fn in originalTexts && !(fn in configFiles);
+                  return (
+                    <label
+                      key={fn}
+                      className={`group flex items-center gap-2 px-2 py-1.5 rounded-md cursor-pointer ${
+                        appliedFiles.includes(fn) ? 'bg-green-500/10' : 'hover:bg-[var(--color-bg-primary)]'
+                      }`}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={selectedFiles.has(fn)}
+                        onChange={() => toggleFile(fn)}
+                        disabled={status === 'applying' || status === 'success'}
+                        className="rounded"
+                      />
+                      <div className="kwc-marquee-shell flex-1 min-w-0">
+                        <div className="kwc-marquee-track">
+                          <span className="kwc-marquee-text text-xs font-mono text-[var(--color-text-primary)]">{fn}</span>
+                          <span aria-hidden="true" className="kwc-marquee-text text-xs font-mono text-[var(--color-text-primary)]">{fn}</span>
+                        </div>
                       </div>
-                    </div>
-                    {appliedFiles.includes(fn) && (
-                      <span className="w-11 shrink-0 text-right text-xs text-green-400">Saved</span>
-                    )}
-                  </label>
-                ))}
+                      {isDeleted && (
+                        <span className="shrink-0 text-[10px] font-semibold text-[var(--color-error)]">deleted</span>
+                      )}
+                      {appliedFiles.includes(fn) && (
+                        <span className="w-11 shrink-0 text-right text-xs text-green-400">Saved</span>
+                      )}
+                    </label>
+                  );
+                })}
               </div>
             </div>
           </div>
@@ -569,11 +586,14 @@ export default function ApplyDialog({ onClose, canAnalyzeWithAi = false, onAnaly
                     const original = originalTexts[fn];
                     const current = currentTexts[fn];
                     const hasOriginal = fn in originalTexts;
+                    const isDeleted = hasOriginal && !(fn in configFiles);
 
                     let diffLines: DiffLine[] = [];
                     let hasChanges = false;
-                    if (hasOriginal && current !== undefined) {
-                      const patch = createTwoFilesPatch(fn, fn, original, current, 'saved', 'current', { context: 3 });
+                    if (hasOriginal && (current !== undefined || isDeleted)) {
+                      // Deleted files have no current text — diff against empty
+                      // so every original line shows as removed.
+                      const patch = createTwoFilesPatch(fn, fn, original, current ?? '', 'saved', isDeleted ? 'deleted' : 'current', { context: 3 });
                       diffLines = parsePatch(patch);
                       hasChanges = diffLines.some((l) => l.type === 'added' || l.type === 'removed');
                     }
@@ -582,15 +602,23 @@ export default function ApplyDialog({ onClose, canAnalyzeWithAi = false, onAnaly
                       <div key={fn}>
                         <div className="flex items-center gap-2 mb-1">
                           <span className="text-xs font-semibold text-[var(--color-text-primary)]">{fn}</span>
+                          {isDeleted && (
+                            <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-[var(--color-error)]/20 text-[var(--color-error)]">deleted</span>
+                          )}
                           {!hasOriginal && (
                             <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-[var(--color-warning)]/20 text-[var(--color-warning)]">new file</span>
                           )}
-                          {hasOriginal && !hasChanges && (
+                          {hasOriginal && !isDeleted && !hasChanges && (
                             <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-[var(--color-bg-tertiary)] text-[var(--color-text-secondary)]">unchanged</span>
                           )}
-                          {hasOriginal && hasChanges && (
+                          {hasOriginal && !isDeleted && hasChanges && (
                             <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-[var(--color-accent)]/20 text-[var(--color-accent)]">
                               {diffLines.filter((l) => l.type === 'added' || l.type === 'removed').length} lines changed
+                            </span>
+                          )}
+                          {isDeleted && (
+                            <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-[var(--color-error)]/20 text-[var(--color-error)]">
+                              {diffLines.filter((l) => l.type === 'removed').length} lines removed
                             </span>
                           )}
                         </div>

--- a/frontend/src/components/dialogs/ApplyDialog.tsx
+++ b/frontend/src/components/dialogs/ApplyDialog.tsx
@@ -590,10 +590,12 @@ export default function ApplyDialog({ onClose, canAnalyzeWithAi = false, onAnaly
 
                     let diffLines: DiffLine[] = [];
                     let hasChanges = false;
-                    if (hasOriginal && (current !== undefined || isDeleted)) {
+                    if (current !== undefined || isDeleted) {
                       // Deleted files have no current text — diff against empty
-                      // so every original line shows as removed.
-                      const patch = createTwoFilesPatch(fn, fn, original, current ?? '', 'saved', isDeleted ? 'deleted' : 'current', { context: 3 });
+                      // so every original line shows as removed. New files have
+                      // no original — diff against empty so every line shows as
+                      // added (moved sub-components/features stay visible).
+                      const patch = createTwoFilesPatch(fn, fn, original ?? '', current ?? '', 'saved', isDeleted ? 'deleted' : 'current', { context: 3 });
                       diffLines = parsePatch(patch);
                       hasChanges = diffLines.some((l) => l.type === 'added' || l.type === 'removed');
                     }
@@ -623,7 +625,7 @@ export default function ApplyDialog({ onClose, canAnalyzeWithAi = false, onAnaly
                           )}
                         </div>
 
-                        {hasOriginal && hasChanges && (
+                        {hasChanges && (
                           <div className="rounded-lg border border-[var(--color-bg-tertiary)] overflow-hidden">
                             <pre className="text-xs leading-5 font-mono overflow-x-auto">
                               {diffLines.map((line, i) => (

--- a/frontend/src/components/dialogs/DiffDialog.tsx
+++ b/frontend/src/components/dialogs/DiffDialog.tsx
@@ -51,9 +51,11 @@ export default function DiffDialog({ onClose }: DiffDialogProps) {
 
   const original = originalTexts[activeFile] || '';
   const current = currentTexts[activeFile] || '';
-  const hasOriginal = activeFile in originalTexts;
 
-  const patch = hasOriginal && !loading
+  // Diff against the original text when available; for brand-new files the
+  // original is empty so every line renders as an addition — otherwise a
+  // moved sub-component/feature inside a new file would be invisible in the diff.
+  const patch = !loading
     ? createConfigPatch(activeFile, original, current, 'imported', 'current', 3)
     : '';
   const diffLines = parsePatch(patch);
@@ -145,10 +147,6 @@ export default function DiffDialog({ onClose }: DiffDialogProps) {
               <div className="p-3 rounded-lg bg-[var(--color-error)]/10 text-xs text-[var(--color-error)]">
                 {error}
               </div>
-            ) : !hasOriginal ? (
-              <p className="text-xs text-[var(--color-text-secondary)] text-center py-8">
-                No original version available — this file was added after import.
-              </p>
             ) : !hasChanges ? (
               <p className="text-xs text-[var(--color-text-secondary)] text-center py-8">
                 No changes — identical to the imported version.

--- a/frontend/src/components/dialogs/DiffDialog.tsx
+++ b/frontend/src/components/dialogs/DiffDialog.tsx
@@ -16,7 +16,9 @@ export default function DiffDialog({ onClose }: DiffDialogProps) {
   // Snapshot store state once on mount — avoids re-running export on every Zustand update.
   const storeSnapshot = useRef(useConfigStore.getState());
   const { configFiles, originalTexts } = storeSnapshot.current;
-  const filenames = Object.keys(configFiles);
+  // A file deleted since import is gone from configFiles but its original text
+  // survives in originalTexts — include it so deletions show up in the diff.
+  const filenames = Array.from(new Set([...Object.keys(configFiles), ...Object.keys(originalTexts)]));
 
   const [activeFile, setActiveFile] = useState(filenames[0] || '');
   const [currentTexts, setCurrentTexts] = useState<Record<string, string>>({});
@@ -78,15 +80,22 @@ export default function DiffDialog({ onClose }: DiffDialogProps) {
             {filenames.map((fn) => {
               const hasCurrent = fn in currentTexts;
               const hasOrig = fn in originalTexts;
-              let badge: 'changed' | 'unchanged' | 'new' | 'loading' = 'loading';
+              const isDeleted = hasOrig && !hasCurrent;
+              let badge: 'changed' | 'unchanged' | 'new' | 'deleted' | 'loading' = 'loading';
               let changeCount = 0;
-              if (!loading && hasCurrent) {
-                if (!hasOrig) {
-                  badge = 'new';
-                } else {
-                  const p = createConfigPatch(fn, originalTexts[fn] || '', currentTexts[fn] || '', '', '', 0);
+              if (!loading) {
+                if (isDeleted) {
+                  badge = 'deleted';
+                  const p = createConfigPatch(fn, originalTexts[fn] || '', '', '', '', 0);
                   changeCount = countChangedLines(p);
-                  badge = changeCount > 0 ? 'changed' : 'unchanged';
+                } else if (hasCurrent) {
+                  if (!hasOrig) {
+                    badge = 'new';
+                  } else {
+                    const p = createConfigPatch(fn, originalTexts[fn] || '', currentTexts[fn] || '', '', '', 0);
+                    changeCount = countChangedLines(p);
+                    badge = changeCount > 0 ? 'changed' : 'unchanged';
+                  }
                 }
               }
               return (
@@ -107,6 +116,11 @@ export default function DiffDialog({ onClose }: DiffDialogProps) {
                     {badge === 'changed' && (
                       <span className="text-[10px] font-semibold text-[var(--color-accent)]">
                         {changeCount}
+                      </span>
+                    )}
+                    {badge === 'deleted' && (
+                      <span className="text-[10px] font-semibold text-[var(--color-error)]">
+                        deleted
                       </span>
                     )}
                     {badge === 'unchanged' && (

--- a/frontend/src/components/edges/CommunicationEdge.tsx
+++ b/frontend/src/components/edges/CommunicationEdge.tsx
@@ -9,24 +9,7 @@ import {
 import { type NodeRect } from '../../utils/edgeRouting';
 import { useBendPath } from '../../utils/edgeBend';
 import EdgeBendHandles from './EdgeBendHandles';
-
-const COMM_COLORS: Record<string, string> = {
-  usb: 'var(--color-usb)',
-  canbus: 'var(--color-canbus)',
-  uart: 'var(--color-uart)',
-};
-
-const COMM_LABELS: Record<string, string> = {
-  usb: 'USB',
-  canbus: 'CAN',
-  uart: 'UART',
-};
-
-const COMM_DESCRIPTIONS: Record<string, string> = {
-  usb: 'Universal Serial Bus',
-  canbus: 'Controller Area Network',
-  uart: 'Universal Async Receiver/Transmitter',
-};
+import { COMM_COLORS, COMM_LABELS, COMM_DESCRIPTIONS } from '../../constants/graphColors';
 
 function rectForNode(n: Node): NodeRect {
   return {

--- a/frontend/src/components/edges/ConfigurationEdge.tsx
+++ b/frontend/src/components/edges/ConfigurationEdge.tsx
@@ -8,17 +8,7 @@ import {
 import { type NodeRect } from '../../utils/edgeRouting';
 import { useBendPath } from '../../utils/edgeBend';
 import EdgeBendHandles from './EdgeBendHandles';
-
-const HARDWARE_COLORS: Record<string, string> = {
-  sbc: 'var(--color-sbc)',
-  mainboard: 'var(--color-mainboard)',
-  toolhead: 'var(--color-toolhead)',
-  expander: 'var(--color-expander)',
-  config_file: '#0f766e',
-  probe: 'var(--color-probe)',
-  accelerometer: 'var(--color-accelerometer)',
-  other: 'var(--color-other)',
-};
+import { HARDWARE_COLORS } from '../../constants/graphColors';
 
 function rectForNode(n: Node): NodeRect {
   return {

--- a/frontend/src/components/nodes/FeatureNode.tsx
+++ b/frontend/src/components/nodes/FeatureNode.tsx
@@ -4,29 +4,7 @@ import type { FeatureNodeData } from '../../types/graph';
 import NodeActions from './NodeActions';
 import WarningBadge from './WarningBadge';
 import type { ValidationStatus } from '../../types/graph';
-
-const FEATURE_COLORS: Record<string, string> = {
-  bed_mesh: '#8b5cf6',
-  z_tilt: '#6366f1',
-  quad_gantry_level: '#6366f1',
-  skew_correction: '#a78bfa',
-  input_shaper: '#f59e0b',
-  resonance_tester: '#f59e0b',
-  firmware_retraction: '#f97316',
-  pressure_advance: '#f97316',
-  gcode_macro: '#22c55e',
-  idle_timeout: '#64748b',
-  save_variables: '#64748b',
-  virtual_sdcard: '#64748b',
-  pause_resume: '#06b6d4',
-  respond: '#06b6d4',
-  exclude_object: '#06b6d4',
-  force_move: '#ef4444',
-  homing_override: '#ec4899',
-  safe_z_home: '#ec4899',
-  endstop_phase: '#3b82f6',
-  default: '#6b7280',
-};
+import { FEATURE_COLORS } from '../../constants/graphColors';
 
 function FeatureNode({ data, selected, id }: NodeProps) {
   const nodeData = data as unknown as FeatureNodeData;

--- a/frontend/src/components/nodes/FeatureNode.tsx
+++ b/frontend/src/components/nodes/FeatureNode.tsx
@@ -33,7 +33,8 @@ function FeatureNode({ data, selected, id }: NodeProps) {
   const color = FEATURE_COLORS[nodeData.sectionType] || FEATURE_COLORS.default;
   const isSuppressed = !!(nodeData as Record<string, unknown>).isSuppressed;
   const isEmbedded = !!(nodeData.parentId);
-  const isOrphan = !isEmbedded;
+  const isStandalone = !!(nodeData as Record<string, unknown>).isStandalone;
+  const isOrphan = !isEmbedded && !isStandalone;
   const validationStatus = (nodeData.validationStatus || 'valid') as ValidationStatus;
   const effectiveValidationStatus = isOrphan ? 'error' : validationStatus;
   const hasErrors = nodeData.hasErrors || isOrphan;

--- a/frontend/src/components/nodes/GroupNode.tsx
+++ b/frontend/src/components/nodes/GroupNode.tsx
@@ -45,7 +45,7 @@ function GroupNode({ data, selected, id }: NodeProps) {
   const handleChildClick = useCallback((e: React.MouseEvent, child: GroupChildItem) => {
     e.stopPropagation();
     setSelectedNode(id);
-    setSelectedSection(child.sectionHeader);
+    setSelectedSection(child.sectionHeader, child.configFile ?? null, child.sectionLineNumber ?? null);
   }, [id, setSelectedNode, setSelectedSection]);
 
   const handleRemoveChild = useCallback((e: React.MouseEvent, idx: number) => {

--- a/frontend/src/components/nodes/GroupNode.tsx
+++ b/frontend/src/components/nodes/GroupNode.tsx
@@ -7,30 +7,11 @@ import NodeActions from './NodeActions';
 import WarningBadge from './WarningBadge';
 import type { ValidationStatus } from '../../types/graph';
 import { getValidationStatusColor } from '../../utils/validationStatus';
-const GROUP_COLORS: Record<string, string> = {
-  stepper: '#3b82f6',
-  stepper_driver: '#6366f1',
-  extruder: '#f97316',
-  heater: '#ef4444',
-  fan: '#06b6d4',
-  probe: '#ec4899',
-  temperature: '#f59e0b',
-  accelerometer: '#84cc16',
-  led: '#a855f7',
-  servo: '#14b8a6',
-  pin: '#64748b',
-  display: '#8b5cf6',
-  filament_sensor: '#d946ef',
-  gcode_macro: '#22c55e',
-  bed_leveling: '#8b5cf6',
-  homing: '#ec4899',
-  resonance: '#f59e0b',
-  other: '#6b7280',
-};
+import { GROUP_NODE_COLORS } from '../../constants/graphColors';
 
 function GroupNode({ data, selected, id }: NodeProps) {
   const nodeData = data as unknown as GroupNodeData;
-  const color = GROUP_COLORS[nodeData.componentGroup] || GROUP_COLORS.other;
+  const color = GROUP_NODE_COLORS[nodeData.componentGroup] || GROUP_NODE_COLORS.other;
   const isFeature = nodeData.isFeature;
   const children: GroupChildItem[] = nodeData.children || [];
   const isEmbedded = !!nodeData.parentHardwareId;

--- a/frontend/src/components/nodes/GroupNode.tsx
+++ b/frontend/src/components/nodes/GroupNode.tsx
@@ -34,7 +34,8 @@ function GroupNode({ data, selected, id }: NodeProps) {
   const isFeature = nodeData.isFeature;
   const children: GroupChildItem[] = nodeData.children || [];
   const isEmbedded = !!nodeData.parentHardwareId;
-  const isOrphan = !isEmbedded;
+  const isStandalone = !!(nodeData as Record<string, unknown>).isStandalone;
+  const isOrphan = !isEmbedded && !isStandalone;
   const validationStatus = (nodeData.validationStatus || 'valid') as ValidationStatus;
   const effectiveValidationStatus = isOrphan ? 'error' : validationStatus;
   const hasErrors = nodeData.hasErrors || isOrphan;

--- a/frontend/src/components/nodes/HardwareNode.tsx
+++ b/frontend/src/components/nodes/HardwareNode.tsx
@@ -1,4 +1,5 @@
-import { memo, useEffect, useState } from 'react';
+import { memo, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { Handle, Position, type NodeProps, useConnection } from '@xyflow/react';
 import type { HardwareNodeData } from '../../types/graph';
 import { useGraphStore } from '../../stores/graphStore';
@@ -54,6 +55,10 @@ function HardwareNode({ data, selected, id }: NodeProps) {
 
   const [isHovered, setIsHovered] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  // The confirm is portaled to document.body: child cards render at z-index
+  // 200–300 inside this container's stacking context, so an in-tree popover
+  // would appear behind them.
+  const nodeRef = useRef<HTMLDivElement | null>(null);
   // Show handles on all nodes while any connection drag is in progress
   const { inProgress: isConnecting } = useConnection();
   const showHandles = isHovered || isConnecting;
@@ -89,6 +94,7 @@ function HardwareNode({ data, selected, id }: NodeProps) {
 
   return (
     <div
+      ref={nodeRef}
       className={`kwc-node kwc-hardware-container ${shape} ${selected ? 'selected' : ''} ${nodeData.hasErrors ? 'kwc-error' : ''} ${validationStatus === 'warning' ? 'kwc-warning' : ''}`}
       style={{
         borderColor: color,
@@ -103,9 +109,14 @@ function HardwareNode({ data, selected, id }: NodeProps) {
       onMouseLeave={() => setIsHovered(false)}
     >
 
-      {showDeleteConfirm && (
+      {showDeleteConfirm && createPortal(
         <div
-          className="absolute right-2 top-12 z-40 w-56 rounded-xl border border-[var(--color-bg-tertiary)] bg-[var(--color-bg-secondary)] p-3 shadow-2xl"
+          className="fixed z-[1000] w-56 rounded-xl border border-[var(--color-bg-tertiary)] bg-[var(--color-bg-secondary)] p-3 shadow-2xl"
+          style={{
+            top: (nodeRef.current?.getBoundingClientRect().top ?? 0) + 44,
+            // Anchor the popover's right edge just inside the node's right edge
+            right: Math.max(8, window.innerWidth - (nodeRef.current?.getBoundingClientRect().right ?? window.innerWidth) + 8),
+          }}
           onClick={(event) => event.stopPropagation()}
         >
           <p className="text-[11px] leading-5 text-[var(--color-text-primary)]">
@@ -128,7 +139,8 @@ function HardwareNode({ data, selected, id }: NodeProps) {
               Delete
             </button>
           </div>
-        </div>
+        </div>,
+        document.body,
       )}
 
       {previewExpanded && (

--- a/frontend/src/components/nodes/HardwareNode.tsx
+++ b/frontend/src/components/nodes/HardwareNode.tsx
@@ -10,31 +10,10 @@ import {
   CONTAINER_PADDING_BOTTOM,
   COLLAPSED_HEIGHT,
 } from '../../constants/graphLayout';
+import { HARDWARE_COLORS, HARDWARE_SHAPES } from '../../constants/graphColors';
 import NodeActions from './NodeActions';
 import WarningBadge from './WarningBadge';
 import type { ValidationStatus } from '../../types/graph';
-
-const HARDWARE_COLORS: Record<string, string> = {
-  sbc: 'var(--color-sbc)',
-  mainboard: 'var(--color-mainboard)',
-  toolhead: 'var(--color-toolhead)',
-  expander: 'var(--color-expander)',
-  config_file: '#0f766e',
-  probe: 'var(--color-probe)',
-  accelerometer: 'var(--color-accelerometer)',
-  other: 'var(--color-other)',
-};
-
-const HARDWARE_SHAPES: Record<string, string> = {
-  sbc: 'rounded-xl',
-  mainboard: 'rounded-lg',
-  toolhead: 'rounded-2xl',
-  expander: 'rounded-lg',
-  config_file: 'rounded-md',
-  probe: 'rounded-xl',
-  accelerometer: 'rounded-lg',
-  other: 'rounded-md',
-};
 
 const PREVIEW_WIDTH = CONTAINER_WIDTH;
 const PREVIEW_HEADER_HEIGHT = CONTAINER_HEADER_HEIGHT;

--- a/frontend/src/components/nodes/HardwareNode.tsx
+++ b/frontend/src/components/nodes/HardwareNode.tsx
@@ -3,6 +3,13 @@ import { createPortal } from 'react-dom';
 import { Handle, Position, type NodeProps, useConnection } from '@xyflow/react';
 import type { HardwareNodeData } from '../../types/graph';
 import { useGraphStore } from '../../stores/graphStore';
+import {
+  CONTAINER_WIDTH,
+  CONTAINER_HEADER_HEIGHT,
+  CHILD_SLOT_HEIGHT,
+  CONTAINER_PADDING_BOTTOM,
+  COLLAPSED_HEIGHT,
+} from '../../constants/graphLayout';
 import NodeActions from './NodeActions';
 import WarningBadge from './WarningBadge';
 import type { ValidationStatus } from '../../types/graph';
@@ -29,11 +36,11 @@ const HARDWARE_SHAPES: Record<string, string> = {
   other: 'rounded-md',
 };
 
-const PREVIEW_WIDTH = 400;
-const PREVIEW_HEADER_HEIGHT = 110;
-const PREVIEW_SLOT_HEIGHT = 40;
-const PREVIEW_PADDING_BOTTOM = 16;
-const PREVIEW_COLLAPSED_HEIGHT = 56;
+const PREVIEW_WIDTH = CONTAINER_WIDTH;
+const PREVIEW_HEADER_HEIGHT = CONTAINER_HEADER_HEIGHT;
+const PREVIEW_SLOT_HEIGHT = CHILD_SLOT_HEIGHT;
+const PREVIEW_PADDING_BOTTOM = CONTAINER_PADDING_BOTTOM;
+const PREVIEW_COLLAPSED_HEIGHT = COLLAPSED_HEIGHT;
 
 function HardwareNode({ data, selected, id }: NodeProps) {
   const nodeData = data as unknown as HardwareNodeData;

--- a/frontend/src/components/nodes/NodeActions.tsx
+++ b/frontend/src/components/nodes/NodeActions.tsx
@@ -1,4 +1,5 @@
-import { memo, useCallback, useState } from 'react';
+import { memo, useCallback, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useGraphStore } from '../../stores/graphStore';
 
 interface NodeActionsProps {
@@ -12,12 +13,18 @@ interface NodeActionsProps {
  * them silently is a footgun (Pattern 9e), so they confirm inline. Single-
  * section tiles delete directly. HardwareNode passes onDeleteRequested and
  * renders its own richer dialog (config file deletion).
+ *
+ * The confirm popover is portaled to document.body: child cards render at
+ * z-index 200–300 inside ReactFlow's stacking context, so an in-tree popover
+ * would appear behind them.
  */
 const MULTI_SECTION_TYPES = new Set(['group', 'customGroup']);
+const CONFIRM_Z_INDEX = 1000;
 
 function NodeActions({ nodeId, color, onDeleteRequested }: NodeActionsProps) {
   const { removeNode, duplicateNode, nodes } = useGraphStore();
   const [showConfirm, setShowConfirm] = useState(false);
+  const deleteButtonRef = useRef<HTMLButtonElement | null>(null);
 
   const nodeType = nodes.find((n) => n.id === nodeId)?.type;
 
@@ -45,8 +52,14 @@ function NodeActions({ nodeId, color, onDeleteRequested }: NodeActionsProps) {
     removeNode(nodeId);
   }, [nodeId, removeNode]);
 
+  // Position the portaled popover under the delete button's bottom-right corner
+  const rect = deleteButtonRef.current?.getBoundingClientRect();
+  const confirmStyle = rect
+    ? { top: rect.bottom + 6, left: Math.max(8, rect.right - 220), width: 220, zIndex: CONFIRM_Z_INDEX }
+    : { top: -9999, left: -9999, width: 220, zIndex: CONFIRM_Z_INDEX };
+
   return (
-    <div className="flex items-center gap-0.5 ml-auto shrink-0 relative">
+    <div className="flex items-center gap-0.5 ml-auto shrink-0">
       <button
         onClick={handleCopy}
         title="Duplicate"
@@ -59,6 +72,7 @@ function NodeActions({ nodeId, color, onDeleteRequested }: NodeActionsProps) {
         </svg>
       </button>
       <button
+        ref={deleteButtonRef}
         onClick={handleDelete}
         title="Delete"
         className="flex items-center justify-center w-5 h-5 rounded hover:bg-red-500/20 transition-colors text-red-400"
@@ -68,9 +82,10 @@ function NodeActions({ nodeId, color, onDeleteRequested }: NodeActionsProps) {
         </svg>
       </button>
 
-      {showConfirm && (
+      {showConfirm && createPortal(
         <div
-          className="absolute right-0 top-full mt-1 z-50 w-52 rounded-xl border border-[var(--color-bg-tertiary)] bg-[var(--color-bg-secondary)] p-3 shadow-2xl"
+          className="fixed rounded-xl border border-[var(--color-bg-tertiary)] bg-[var(--color-bg-secondary)] p-3 shadow-2xl"
+          style={confirmStyle}
           onClick={(event) => event.stopPropagation()}
         >
           <p className="text-[11px] leading-5 text-[var(--color-text-primary)]">
@@ -90,7 +105,8 @@ function NodeActions({ nodeId, color, onDeleteRequested }: NodeActionsProps) {
               Delete
             </button>
           </div>
-        </div>
+        </div>,
+        document.body,
       )}
     </div>
   );

--- a/frontend/src/components/nodes/NodeActions.tsx
+++ b/frontend/src/components/nodes/NodeActions.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback } from 'react';
+import { memo, useCallback, useState } from 'react';
 import { useGraphStore } from '../../stores/graphStore';
 
 interface NodeActionsProps {
@@ -7,8 +7,19 @@ interface NodeActionsProps {
   onDeleteRequested?: () => void;
 }
 
+/**
+ * Multi-section node types remove several config sections at once — deleting
+ * them silently is a footgun (Pattern 9e), so they confirm inline. Single-
+ * section tiles delete directly. HardwareNode passes onDeleteRequested and
+ * renders its own richer dialog (config file deletion).
+ */
+const MULTI_SECTION_TYPES = new Set(['group', 'customGroup']);
+
 function NodeActions({ nodeId, color, onDeleteRequested }: NodeActionsProps) {
-  const { removeNode, duplicateNode } = useGraphStore();
+  const { removeNode, duplicateNode, nodes } = useGraphStore();
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  const nodeType = nodes.find((n) => n.id === nodeId)?.type;
 
   const handleCopy = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
@@ -21,11 +32,21 @@ function NodeActions({ nodeId, color, onDeleteRequested }: NodeActionsProps) {
       onDeleteRequested();
       return;
     }
+    if (nodeType && MULTI_SECTION_TYPES.has(nodeType)) {
+      setShowConfirm(true);
+      return;
+    }
     removeNode(nodeId);
-  }, [nodeId, onDeleteRequested, removeNode]);
+  }, [nodeId, nodeType, onDeleteRequested, removeNode]);
+
+  const handleConfirmDelete = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    setShowConfirm(false);
+    removeNode(nodeId);
+  }, [nodeId, removeNode]);
 
   return (
-    <div className="flex items-center gap-0.5 ml-auto shrink-0">
+    <div className="flex items-center gap-0.5 ml-auto shrink-0 relative">
       <button
         onClick={handleCopy}
         title="Duplicate"
@@ -46,6 +67,31 @@ function NodeActions({ nodeId, color, onDeleteRequested }: NodeActionsProps) {
           <path d="M3 4h10M5.5 4V3a1 1 0 011-1h3a1 1 0 011 1v1M6 7v4M10 7v4M4 4l.8 9a1 1 0 001 .9h4.4a1 1 0 001-.9L12 4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
         </svg>
       </button>
+
+      {showConfirm && (
+        <div
+          className="absolute right-0 top-full mt-1 z-50 w-52 rounded-xl border border-[var(--color-bg-tertiary)] bg-[var(--color-bg-secondary)] p-3 shadow-2xl"
+          onClick={(event) => event.stopPropagation()}
+        >
+          <p className="text-[11px] leading-5 text-[var(--color-text-primary)]">
+            Delete this group and all its configuration sections?
+          </p>
+          <div className="mt-3 flex justify-end gap-2">
+            <button
+              onClick={() => setShowConfirm(false)}
+              className="rounded-md border border-[var(--color-bg-tertiary)] px-2.5 py-1 text-[11px] text-[var(--color-text-primary)] hover:border-[var(--color-accent)]"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleConfirmDelete}
+              className="rounded-md bg-[var(--color-error)] px-2.5 py-1 text-[11px] font-medium text-[var(--color-bg-primary)] hover:opacity-90"
+            >
+              Delete
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/nodes/SubComponentNode.tsx
+++ b/frontend/src/components/nodes/SubComponentNode.tsx
@@ -29,7 +29,8 @@ function SubComponentNode({ data, selected, id }: NodeProps) {
   const color = GROUP_COLORS[nodeData.componentGroup] || GROUP_COLORS.other;
   const isSuppressed = !!(nodeData as Record<string, unknown>).isSuppressed;
   const isEmbedded = !!nodeData.parentHardwareId;
-  const isOrphan = !isEmbedded;
+  const isStandalone = !!(nodeData as Record<string, unknown>).isStandalone;
+  const isOrphan = !isEmbedded && !isStandalone;
   const validationStatus = (nodeData.validationStatus || 'valid') as ValidationStatus;
   const effectiveValidationStatus = isOrphan ? 'error' : validationStatus;
   const hasErrors = nodeData.hasErrors || isOrphan;

--- a/frontend/src/components/nodes/SubComponentNode.tsx
+++ b/frontend/src/components/nodes/SubComponentNode.tsx
@@ -4,29 +4,11 @@ import type { SubComponentNodeData } from '../../types/graph';
 import NodeActions from './NodeActions';
 import WarningBadge from './WarningBadge';
 import type { ValidationStatus } from '../../types/graph';
-
-const GROUP_COLORS: Record<string, string> = {
-  stepper: '#3b82f6',
-  stepper_driver: '#6366f1',
-  extruder: '#f97316',
-  heater: '#ef4444',
-  fan: '#06b6d4',
-  probe: '#ec4899',
-  temperature: '#f59e0b',
-  accelerometer: '#84cc16',
-  led: '#a855f7',
-  servo: '#14b8a6',
-  pin: '#64748b',
-  display: '#8b5cf6',
-  filament_sensor: '#d946ef',
-  sensor: '#0ea5e9',
-  mcu: '#22c55e',
-  other: '#6b7280',
-};
+import { SUBCOMPONENT_COLORS } from '../../constants/graphColors';
 
 function SubComponentNode({ data, selected, id }: NodeProps) {
   const nodeData = data as unknown as SubComponentNodeData;
-  const color = GROUP_COLORS[nodeData.componentGroup] || GROUP_COLORS.other;
+  const color = SUBCOMPONENT_COLORS[nodeData.componentGroup] || SUBCOMPONENT_COLORS.other;
   const isSuppressed = !!(nodeData as Record<string, unknown>).isSuppressed;
   const isEmbedded = !!nodeData.parentHardwareId;
   const isStandalone = !!(nodeData as Record<string, unknown>).isStandalone;

--- a/frontend/src/constants/graphColors.ts
+++ b/frontend/src/constants/graphColors.ts
@@ -1,0 +1,137 @@
+/**
+ * Shared graph color maps and hardware geometry styles.
+ *
+ * Single source of truth for node/edge coloring. Previously duplicated
+ * across HardwareNode, FeatureNode, SubComponentNode, GroupNode,
+ * ConfigurationEdge, CommunicationEdge, and graphStore.
+ */
+
+/** Hardware type → node fill color (CSS variables, theme-aware) */
+export const HARDWARE_COLORS: Record<string, string> = {
+  sbc: 'var(--color-sbc)',
+  mainboard: 'var(--color-mainboard)',
+  toolhead: 'var(--color-toolhead)',
+  expander: 'var(--color-expander)',
+  config_file: '#0f766e',
+  probe: 'var(--color-probe)',
+  accelerometer: 'var(--color-accelerometer)',
+  other: 'var(--color-other)',
+};
+
+/** Hardware type → border radius shape */
+export const HARDWARE_SHAPES: Record<string, string> = {
+  sbc: 'rounded-xl',
+  mainboard: 'rounded-lg',
+  toolhead: 'rounded-2xl',
+  expander: 'rounded-lg',
+  config_file: 'rounded-md',
+  probe: 'rounded-xl',
+  accelerometer: 'rounded-lg',
+  other: 'rounded-md',
+};
+
+/** Group node component-group colors (feature-bearing groups) */
+export const GROUP_NODE_COLORS: Record<string, string> = {
+  stepper: '#3b82f6',
+  stepper_driver: '#6366f1',
+  extruder: '#f97316',
+  heater: '#ef4444',
+  fan: '#06b6d4',
+  probe: '#ec4899',
+  temperature: '#f59e0b',
+  accelerometer: '#84cc16',
+  led: '#a855f7',
+  servo: '#14b8a6',
+  pin: '#64748b',
+  display: '#8b5cf6',
+  filament_sensor: '#d946ef',
+  gcode_macro: '#22c55e',
+  bed_leveling: '#8b5cf6',
+  homing: '#ec4899',
+  resonance: '#f59e0b',
+  other: '#6b7280',
+};
+
+/** Sub-component node component-group colors (hardware child tiles) */
+export const SUBCOMPONENT_COLORS: Record<string, string> = {
+  stepper: '#3b82f6',
+  stepper_driver: '#6366f1',
+  extruder: '#f97316',
+  heater: '#ef4444',
+  fan: '#06b6d4',
+  probe: '#ec4899',
+  temperature: '#f59e0b',
+  accelerometer: '#84cc16',
+  led: '#a855f7',
+  servo: '#14b8a6',
+  pin: '#64748b',
+  display: '#8b5cf6',
+  filament_sensor: '#d946ef',
+  sensor: '#0ea5e9',
+  mcu: '#22c55e',
+  other: '#6b7280',
+};
+
+/** Feature section-type colors */
+export const FEATURE_COLORS: Record<string, string> = {
+  bed_mesh: '#8b5cf6',
+  z_tilt: '#6366f1',
+  quad_gantry_level: '#6366f1',
+  skew_correction: '#a78bfa',
+  input_shaper: '#f59e0b',
+  resonance_tester: '#f59e0b',
+  firmware_retraction: '#f97316',
+  pressure_advance: '#f97316',
+  gcode_macro: '#22c55e',
+  idle_timeout: '#64748b',
+  save_variables: '#64748b',
+  virtual_sdcard: '#64748b',
+  pause_resume: '#06b6d4',
+  respond: '#06b6d4',
+  exclude_object: '#06b6d4',
+  force_move: '#ef4444',
+  homing_override: '#ec4899',
+  safe_z_home: '#ec4899',
+  endstop_phase: '#3b82f6',
+  default: '#6b7280',
+};
+
+/** Communication type → edge color */
+export const COMM_COLORS: Record<string, string> = {
+  usb: 'var(--color-usb)',
+  canbus: 'var(--color-canbus)',
+  uart: 'var(--color-uart)',
+};
+
+/** Communication type → display label */
+export const COMM_LABELS: Record<string, string> = {
+  usb: 'USB',
+  canbus: 'CAN',
+  uart: 'UART',
+};
+
+/** Communication type → expanded description */
+export const COMM_DESCRIPTIONS: Record<string, string> = {
+  usb: 'Universal Serial Bus',
+  canbus: 'Controller Area Network',
+  uart: 'Universal Async Receiver/Transmitter',
+};
+
+/**
+ * Hardware type → fixed hex edge color (used when stamping edge data at
+ * creation time, so the color survives graph rebuilds without node lookup).
+ */
+export const HARDWARE_HEX_COLORS: Record<string, string> = {
+  sbc: '#22c55e',
+  mainboard: '#38bdf8',
+  toolhead: '#f472b6',
+  expander: '#a78bfa',
+  config_file: '#0f766e',
+  probe: '#ec4899',
+  accelerometer: '#84cc16',
+  other: '#64748b',
+};
+
+export function getHardwareHexColor(hwType: string): string {
+  return HARDWARE_HEX_COLORS[hwType] || HARDWARE_HEX_COLORS.other;
+}

--- a/frontend/src/constants/graphLayout.ts
+++ b/frontend/src/constants/graphLayout.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared graph layout geometry constants.
+ *
+ * Single source of truth for hardware-container sizing, child slot
+ * positioning, tile/group metrics, z-index layering, and canvas snap.
+ * Previously duplicated verbatim in graphStore.ts (CONTAINER_* and
+ * CHILD_* names), App.tsx (HARDWARE_DRAG_PREVIEW_*), and HardwareNode.tsx
+ * (PREVIEW_*).
+ */
+
+/** Total width of a hardware container node */
+export const CONTAINER_WIDTH = 400;
+/** Height reserved for the hardware node header/info area */
+export const CONTAINER_HEADER_HEIGHT = 110;
+/** Vertical slot size per child node (compact tiles) */
+export const CHILD_SLOT_HEIGHT = 40;
+/** Padding below last child row */
+export const CONTAINER_PADDING_BOTTOM = 16;
+/** X position (relative to parent) for left-column children (features) */
+export const CHILD_LEFT_X = 12;
+/** X position (relative to parent) for right-column children (sub-components) */
+export const CHILD_RIGHT_X = 208;
+/** Height of a hardware node when collapsed (just the header) */
+export const COLLAPSED_HEIGHT = 56;
+/** Width of a hardware node when collapsed */
+export const COLLAPSED_WIDTH = 200;
+
+/** Height of a compact tile's header row */
+export const TILE_HEADER_HEIGHT = 36;
+/** Height per item row in an expanded GroupNode body */
+export const GROUP_ITEM_HEIGHT = 22;
+/** Vertical padding inside the expanded GroupNode body (top + bottom) */
+export const GROUP_BODY_PADDING = 12;
+/** Gap between tiles in a column */
+export const TILE_GAP = 4;
+/** Base stacking for top-level hardware cards */
+export const HARDWARE_Z_INDEX = 0;
+/** Elevated stacking for the selected parent hardware card */
+export const SELECTED_PARENT_Z_INDEX = 100;
+/** Child cards should always render above major component cards */
+export const CHILD_NODE_Z_INDEX = 200;
+/** Selected child cards stay above sibling cards and action overlays */
+export const ACTIVE_CHILD_Z_INDEX = 300;
+/** Shared canvas snap size for manual placement and auto-arrange anchors */
+export const GRID_SIZE = 20;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -271,10 +271,11 @@ export async function loadProject(name: string): Promise<{
 
 export async function saveConfigsToLocal(
   files: Record<string, string>,
-): Promise<{ saved: string[]; file_count: number; errors?: string[] }> {
+  deleted: string[] = [],
+): Promise<{ saved: string[]; removed: string[]; file_count: number; errors?: string[] }> {
   return request('/configs/save', {
     method: 'POST',
-    body: JSON.stringify({ files }),
+    body: JSON.stringify({ files, deleted }),
   });
 }
 
@@ -366,10 +367,11 @@ export async function readNativeConfigFiles(
 export async function applyNativeConfig(
   files: Record<string, string>,
   configPath?: string,
-): Promise<{ status: string; files: string[]; config_path: string }> {
+  deleted: string[] = [],
+): Promise<{ status: string; files: string[]; removed: string[]; config_path: string }> {
   return request('/native/apply', {
     method: 'POST',
-    body: JSON.stringify({ files, config_path: configPath }),
+    body: JSON.stringify({ files, config_path: configPath, deleted }),
   });
 }
 

--- a/frontend/src/stores/__tests__/configStore.test.ts
+++ b/frontend/src/stores/__tests__/configStore.test.ts
@@ -132,6 +132,33 @@ describe('configStore file operations', () => {
     expect(useConfigStore.getState().configFiles['a.cfg']).toBeDefined();
   });
 
+  it('renameConfigFile remaps the selected section file so the sidebar keeps working', () => {
+    const store = useConfigStore.getState();
+    store.setConfigFile('printer.cfg', makeConfigFile());
+    store.setSelectedSection('mcu', 'printer.cfg', 3);
+
+    useConfigStore.getState().renameConfigFile('printer.cfg', 'mainboard.cfg');
+
+    const state = useConfigStore.getState();
+    // The section header + line survive; the file pointer follows the rename.
+    expect(state.selectedSection).toBe('mcu');
+    expect(state.selectedSectionFile).toBe('mainboard.cfg');
+    expect(state.selectedSectionLine).toBe(3);
+  });
+
+  it('renameConfigFile clears the selection when a DIFFERENT file is renamed', () => {
+    const store = useConfigStore.getState();
+    store.setConfigFile('printer.cfg', makeConfigFile());
+    store.setConfigFile('toolhead.cfg', makeConfigFile());
+    store.setSelectedSection('mcu toolhead', 'toolhead.cfg', 5);
+
+    useConfigStore.getState().renameConfigFile('printer.cfg', 'mainboard.cfg');
+
+    const state = useConfigStore.getState();
+    expect(state.selectedSection).toBe('mcu toolhead');
+    expect(state.selectedSectionFile).toBe('toolhead.cfg');
+  });
+
   it('copyConfigFile deep-copies sections and params', () => {
     const store = useConfigStore.getState();
     const section = makeSection({

--- a/frontend/src/stores/__tests__/configStore.test.ts
+++ b/frontend/src/stores/__tests__/configStore.test.ts
@@ -187,12 +187,18 @@ describe('configStore file operations', () => {
     store.setConfigFile('a.cfg', makeConfigFile());
     store.markDirty();
     store.setTextParseError('a.cfg', 'stale boom');
+    store.setSelectedSection('extruder', 'a.cfg', 12);
     useConfigStore.getState().loadConfigs({ 'new.cfg': makeConfigFile() });
     const state = useConfigStore.getState();
     expect(Object.keys(state.configFiles)).toEqual(['new.cfg']);
     expect(state.activeFile).toBe('new.cfg');
     expect(state.isDirty).toBe(false);
     expect(state.textParseErrors).toEqual({});
+    // The stale section selection must not survive into the new project,
+    // or it resolves against the wrong file and the sidebar shows it.
+    expect(state.selectedSection).toBeNull();
+    expect(state.selectedSectionFile).toBeNull();
+    expect(state.selectedSectionLine).toBeNull();
   });
 
   it('clearAll resets everything', () => {
@@ -200,12 +206,16 @@ describe('configStore file operations', () => {
     store.setConfigFile('a.cfg', makeConfigFile());
     store.markDirty();
     store.setTextParseError('a.cfg', 'stale boom');
+    store.setSelectedSection('extruder', 'a.cfg', 12);
     useConfigStore.getState().clearAll();
     const state = useConfigStore.getState();
     expect(state.configFiles).toEqual({});
     expect(state.activeFile).toBe('printer.cfg');
     expect(state.isDirty).toBe(false);
     expect(state.textParseErrors).toEqual({});
+    expect(state.selectedSection).toBeNull();
+    expect(state.selectedSectionFile).toBeNull();
+    expect(state.selectedSectionLine).toBeNull();
   });
 });
 

--- a/frontend/src/stores/__tests__/configStore.test.ts
+++ b/frontend/src/stores/__tests__/configStore.test.ts
@@ -317,6 +317,38 @@ describe('configStore dirty / text parse error tracking', () => {
     expect(useConfigStore.getState().textParseErrors['printer.cfg']).toBeUndefined();
   });
 
+  it('updateConfigFile sets the file, marks dirty, and preserves others', () => {
+    const store = useConfigStore.getState();
+    store.setConfigFile('a.cfg', makeConfigFile());
+    store.setConfigFile('b.cfg', makeConfigFile());
+
+    const updated = makeConfigFile();
+    updated.sections = [];
+    useConfigStore.getState().updateConfigFile('a.cfg', updated);
+
+    const state = useConfigStore.getState();
+    expect(state.configFiles['a.cfg'].sections).toEqual([]);
+    expect(state.configFiles['b.cfg']).toBeDefined();
+    expect(state.isDirty).toBe(true);
+  });
+
+  it('raw setConfigFile does NOT mark dirty (load path semantics)', () => {
+    const store = useConfigStore.getState();
+    store.setConfigFile('a.cfg', makeConfigFile());
+    expect(useConfigStore.getState().isDirty).toBe(false);
+  });
+
+  it('updateConfigFile schedules revalidation', async () => {
+    vi.useRealTimers();
+    const store = useConfigStore.getState();
+    store.setConfigFile('printer.cfg', makeConfigFile());
+    useConfigStore.getState().updateConfigFile('printer.cfg', makeConfigFile());
+    // Let the 500ms revalidation timer fire; the mocked validateConfig returns
+    // a clean result, so validation must be present after it runs.
+    await new Promise((resolve) => setTimeout(resolve, 700));
+    expect(useConfigStore.getState().validation['printer.cfg']).toBeDefined();
+  });
+
   it('markClean clears the dirty flag', () => {
     const store = useConfigStore.getState();
     store.setConfigFile('printer.cfg', makeConfigFile());

--- a/frontend/src/stores/__tests__/configStore.test.ts
+++ b/frontend/src/stores/__tests__/configStore.test.ts
@@ -59,6 +59,8 @@ beforeEach(() => {
     validation: {},
     schemas: {},
     selectedSection: null,
+    selectedSectionFile: null,
+    selectedSectionLine: null,
     originalTexts: {},
     isDirty: false,
     textParseErrors: {},
@@ -388,5 +390,22 @@ describe('configStore validation helpers', () => {
     });
     const errors = useConfigStore.getState().getSectionErrors('mcu');
     expect(errors).toEqual(['missing serial']);
+  });
+
+  it('setSelectedSection carries file + line for duplicate-header safety', () => {
+    const store = useConfigStore.getState();
+    store.setSelectedSection('gcode_macro LEVEL_BED', 'macros.cfg', 12);
+    expect(useConfigStore.getState().selectedSection).toBe('gcode_macro LEVEL_BED');
+    expect(useConfigStore.getState().selectedSectionFile).toBe('macros.cfg');
+    expect(useConfigStore.getState().selectedSectionLine).toBe(12);
+  });
+
+  it('setSelectedSection with null header clears carried context', () => {
+    const store = useConfigStore.getState();
+    store.setSelectedSection('gcode_macro LEVEL_BED', 'macros.cfg', 12);
+    store.setSelectedSection(null);
+    expect(useConfigStore.getState().selectedSection).toBeNull();
+    expect(useConfigStore.getState().selectedSectionFile).toBeNull();
+    expect(useConfigStore.getState().selectedSectionLine).toBeNull();
   });
 });

--- a/frontend/src/stores/__tests__/graphStore.test.ts
+++ b/frontend/src/stores/__tests__/graphStore.test.ts
@@ -800,4 +800,56 @@ describe('graphStore configuration edge redraw/delete', () => {
     useGraphStore.getState().syncGraphWithConfig('printer.cfg');
     expect(useGraphStore.getState().edges.filter((e) => (e.data as Record<string, unknown>)?.edgeType === 'configuration')).toHaveLength(1);
   });
+
+  it('snapChildrenToColumns respects expanded group heights (variable slots)', () => {
+    // Parent with two feature-group children. One group is selected (expanded)
+    // with 3 children, so its slot height is variable: TILE_HEADER_HEIGHT +
+    // 3*GROUP_ITEM_HEIGHT + GROUP_BODY_PADDING + TILE_GAP = 36+66+12+4 = 118.
+    // The other group is a compact tile (slot = CHILD_SLOT_HEIGHT = 40).
+    const hw = makeHwNode('hw1', { configFile: 'printer.cfg', mcuName: 'mainboard' });
+    const bigGroup: AppNode = {
+      id: 'bigGroup',
+      type: 'group',
+      position: { x: 12, y: 110 },
+      parentId: 'hw1',
+      data: {
+        label: 'Features',
+        componentGroup: 'other',
+        isFeature: true,
+        sectionHeader: 'features',
+        configFile: 'printer.cfg',
+        children: [{ sectionHeader: 'bed_mesh' }, { sectionHeader: 'z_tilt' }, { sectionHeader: 'skew' }],
+        hasErrors: false,
+      },
+    } as unknown as AppNode;
+    const smallGroup: AppNode = {
+      id: 'smallGroup',
+      type: 'group',
+      position: { x: 12, y: 230 },
+      parentId: 'hw1',
+      data: {
+        label: 'Macros',
+        componentGroup: 'other',
+        isFeature: true,
+        sectionHeader: 'macros',
+        configFile: 'printer.cfg',
+        children: [],
+        hasErrors: false,
+      },
+    } as unknown as AppNode;
+
+    useGraphStore.setState({ nodes: [hw, bigGroup, smallGroup], edges: [] });
+    useGraphStore.getState().setSelectedNode('bigGroup');
+
+    // Drag the small group below the big one; it must snap BELOW the big
+    // group's expanded height (110 + 118 = 228), not to a fixed slot.
+    useGraphStore.getState().snapChildrenToColumns('hw1', 'smallGroup', 400);
+
+    const snappedSmall = useGraphStore.getState().nodes.find((n) => n.id === 'smallGroup');
+    const snappedBig = useGraphStore.getState().nodes.find((n) => n.id === 'bigGroup');
+    expect(snappedBig?.position.y).toBe(110);
+    expect(snappedSmall?.position.y).toBeGreaterThanOrEqual(110 + 118);
+    // Big group keeps its expanded height slot (variable), not CHILD_SLOT_HEIGHT
+    expect(snappedSmall!.position.y).not.toBe(110 + 40);
+  });
 });

--- a/frontend/src/stores/__tests__/graphStore.test.ts
+++ b/frontend/src/stores/__tests__/graphStore.test.ts
@@ -416,6 +416,76 @@ describe('graphStore undo/redo', () => {
     useGraphStore.getState().undo();
     expect(useGraphStore.getState().nodes).toHaveLength(0);
   });
+
+  it('pushHistory before a sidebar config mutation makes it undoable', () => {
+    // Simulates the Phase 3 pattern: MCU rename / suppress toggle / primary
+    // toggle push history at handler start, then mutate configFiles + node data.
+    useConfigStore.getState().setConfigFile('printer.cfg', {
+      filename: 'printer.cfg',
+      sections: [
+        { section_type: 'mcu', section_name: 'mainboard', full_header: 'mcu mainboard', line_number: 1, params: [{ key: 'serial', value: '/dev/ttyACM0', comment: '', is_commented_out: false }], header_comments: [], trailing_comments: [], is_commented_out: false },
+        { section_type: 'stepper_x', section_name: '', full_header: 'stepper_x', line_number: 2, params: [{ key: 'step_pin', value: 'mainboard:PA0', comment: '', is_commented_out: false }], header_comments: [], trailing_comments: [], is_commented_out: false },
+      ],
+      includes: [],
+      header_comments: [],
+      raw_text: '',
+    });
+    useConfigStore.getState().markClean();
+    useGraphStore.getState().addNode(makeHwNode('mainboard', { mcuName: 'mainboard' }));
+    useGraphStore.getState().pushHistory();
+
+    // MCU rename: header [mcu mainboard] → [mcu], pins re-prefixed
+    const cf = useConfigStore.getState().configFiles['printer.cfg'];
+    useConfigStore.getState().updateConfigFile('printer.cfg', {
+      ...cf,
+      sections: cf.sections.map((s) =>
+        s.full_header === 'mcu mainboard'
+          ? { ...s, section_name: '', full_header: 'mcu' }
+          : s.full_header === 'stepper_x'
+            ? { ...s, params: s.params.map((p) => ({ ...p, value: 'PA0' })) }
+            : s,
+      ),
+    });
+    useGraphStore.getState().updateNodeData('mainboard', { mcuName: '' } as Partial<AppNode['data']>);
+    expect(useConfigStore.getState().isDirty).toBe(true);
+
+    // Undo restores config content AND node data
+    useGraphStore.getState().undo();
+    const restored = useConfigStore.getState().configFiles['printer.cfg'];
+    expect(restored.sections[0].full_header).toBe('mcu mainboard');
+    expect(restored.sections[1].params[0].value).toBe('mainboard:PA0');
+    expect(useGraphStore.getState().nodes[0].data.mcuName).toBe('mainboard');
+  });
+
+  it('suppress toggle is undoable (config section + node flag restored)', () => {
+    useConfigStore.getState().setConfigFile('printer.cfg', {
+      filename: 'printer.cfg',
+      sections: [
+        { section_type: 'fan', section_name: '', full_header: 'fan', line_number: 1, params: [{ key: 'pin', value: 'PA1', comment: '', is_commented_out: false }], header_comments: [], trailing_comments: [], is_commented_out: false },
+      ],
+      includes: [],
+      header_comments: [],
+      raw_text: '',
+    });
+    useConfigStore.getState().markClean();
+    useGraphStore.getState().addNode(makeChildNode('fan1', 'hw1', 'fan'));
+    useGraphStore.getState().pushHistory();
+
+    // Suppress: comment all params + set node flag
+    const cf = useConfigStore.getState().configFiles['printer.cfg'];
+    useConfigStore.getState().updateConfigFile('printer.cfg', {
+      ...cf,
+      sections: cf.sections.map((s) => ({ ...s, is_commented_out: true, params: s.params.map((p) => ({ ...p, is_commented_out: true })) })),
+    });
+    useGraphStore.getState().updateNodeData('fan1', { isSuppressed: true } as Partial<AppNode['data']>);
+
+    useGraphStore.getState().undo();
+    const restored = useConfigStore.getState().configFiles['printer.cfg'];
+    expect(restored.sections[0].is_commented_out).toBe(false);
+    expect(restored.sections[0].params[0].is_commented_out).toBe(false);
+    // Node flag restored to its pre-toggle state (absent → undefined)
+    expect(useGraphStore.getState().nodes[0].data.isSuppressed).toBeUndefined();
+  });
 });
 
 describe('graphStore auto-arrange', () => {

--- a/frontend/src/stores/__tests__/graphStore.test.ts
+++ b/frontend/src/stores/__tests__/graphStore.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest';
+import type { Connection } from '@xyflow/react';
 import type { AppNode, AppEdge } from '@/types/graph';
 import { useGraphStore } from '@/stores/graphStore';
 import { useConfigStore } from '@/stores/configStore';
@@ -529,3 +530,83 @@ describe('graphStore auto-arrange', () => {
     expect(cf).toBeDefined();
     expect(cf.sections).toHaveLength(0);
   });
+
+describe('graphStore configuration edge redraw/delete', () => {
+  function setupToolheadMainboard() {
+    useConfigStore.getState().setConfigFile('printer.cfg', {
+      filename: 'printer.cfg',
+      sections: [
+        { section_type: 'include', section_name: 'toolhead_board.cfg', full_header: 'include toolhead_board.cfg', line_number: 1, params: [], header_comments: [], trailing_comments: [], is_commented_out: false },
+        { section_type: 'mcu', section_name: '', full_header: 'mcu', line_number: 2, params: [], header_comments: [], trailing_comments: [], is_commented_out: false },
+        { section_type: 'printer', section_name: '', full_header: 'printer', line_number: 3, params: [], header_comments: [], trailing_comments: [], is_commented_out: false },
+      ],
+      includes: ['toolhead_board.cfg'],
+      header_comments: [],
+      raw_text: '[include toolhead_board.cfg]\n[mcu]\nserial: /dev/ttyACM0\n[printer]\nkinematics: cartesian\n',
+    });
+    useConfigStore.getState().setConfigFile('toolhead_board.cfg', {
+      filename: 'toolhead_board.cfg',
+      sections: [
+        { section_type: 'mcu', section_name: 'toolhead', full_header: 'mcu toolhead', line_number: 1, params: [], header_comments: [], trailing_comments: [], is_commented_out: false },
+      ],
+      includes: [],
+      header_comments: [],
+      raw_text: '[mcu toolhead]\nserial: /dev/serial/by-id/ebbtool\n',
+    });
+    useConfigStore.getState().markClean();
+    useGraphStore.getState().addNode(makeHwNode('mainboard', { configFile: 'printer.cfg' }));
+    useGraphStore.getState().addNode(makeHwNode('toolhead', { configFile: 'toolhead_board.cfg' }));
+    // Pre-existing configuration edge (built by graphBuilder on import)
+    return useGraphStore.getState().addConfigurationEdge('toolhead', 'mainboard', 'toolhead');
+  }
+
+  it('redrawing a configuration edge between an already-connected pair does not mark dirty', () => {
+    setupToolheadMainboard();
+    expect(useConfigStore.getState().isDirty).toBe(false);
+
+    // User redraws the line toolhead → mainboard (same pair, same direction)
+    useGraphStore.getState().onConnect({ source: 'toolhead', target: 'mainboard', sourceHandle: null, targetHandle: null });
+
+    // Config untouched: include still active, not dirty, diff would be blank
+    expect(useConfigStore.getState().isDirty).toBe(false);
+    const cf = useConfigStore.getState().configFiles['printer.cfg'];
+    expect(cf.includes).toEqual(['toolhead_board.cfg']);
+    expect(cf.sections[0].is_commented_out).toBe(false);
+    // Edge was replaced (new id), still one configuration edge
+    const edges = useGraphStore.getState().edges;
+    expect(edges).toHaveLength(1);
+    const redrawnSamePair = edges[0];
+    expect(redrawnSamePair?.data?.edgeType).toBe('configuration');
+  });
+
+  it('redrawing in the OPPOSITE direction then deleting still comments out the include', () => {
+    setupToolheadMainboard();
+    const originalEdgeId = useGraphStore.getState().edges[0].id;
+
+    // User redraws the line the other way: mainboard → toolhead
+    useGraphStore.getState().onConnect({ source: 'mainboard', target: 'toolhead', sourceHandle: null, targetHandle: null });
+    expect(useConfigStore.getState().isDirty).toBe(false);
+    const redrawnEdgeId = useGraphStore.getState().edges[0].id;
+    expect(redrawnEdgeId).not.toBe(originalEdgeId);
+    const redrawn = useGraphStore.getState().edges[0];
+    expect(redrawn?.source).toBe('mainboard');
+    expect(redrawn?.target).toBe('toolhead');
+
+    // Now delete the line — include must be commented out in printer.cfg
+    // (the file that owns the include), regardless of edge direction.
+    useGraphStore.getState().onEdgesChange([{ type: 'remove', id: redrawnEdgeId }]);
+    const cf = useConfigStore.getState().configFiles['printer.cfg'];
+    expect(cf.includes).toEqual([]);
+    expect(cf.sections[0].is_commented_out).toBe(true);
+    expect(useConfigStore.getState().isDirty).toBe(true);
+  });
+
+  it('deleting an edge drawn toolhead → mainboard still comments out the include', () => {
+    const edgeId = setupToolheadMainboard();
+
+    useGraphStore.getState().onEdgesChange([{ type: 'remove', id: edgeId }]);
+    const cf = useConfigStore.getState().configFiles['printer.cfg'];
+    expect(cf.includes).toEqual([]);
+    expect(cf.sections[0].is_commented_out).toBe(true);
+  });
+});

--- a/frontend/src/stores/__tests__/graphStore.test.ts
+++ b/frontend/src/stores/__tests__/graphStore.test.ts
@@ -124,6 +124,62 @@ describe('graphStore node operations', () => {
     useGraphStore.getState().duplicateNode('missing');
     expect(useGraphStore.getState().nodes).toHaveLength(0);
   });
+
+  it('duplicateNode hardware rewrites pin prefixes and drops printer/include sections', () => {
+    // Source board: mcu mainboard + stepper_x with a prefixed pin + printer + include
+    useConfigStore.getState().setConfigFile('mainboard.cfg', {
+      filename: 'mainboard.cfg',
+      sections: [
+        {
+          section_type: 'mcu', section_name: 'mainboard', full_header: 'mcu mainboard',
+          line_number: 1, params: [{ key: 'serial', value: '/dev/ttyACM0', is_commented_out: false, comment: '', separator: ':' }],
+          header_comments: [], trailing_comments: [], is_commented_out: false,
+        },
+        {
+          section_type: 'stepper_x', section_name: '', full_header: 'stepper_x',
+          line_number: 2, params: [{ key: 'step_pin', value: 'mainboard:PA0', is_commented_out: false, comment: '', separator: ':' }],
+          header_comments: [], trailing_comments: [], is_commented_out: false,
+        },
+        {
+          section_type: 'printer', section_name: '', full_header: 'printer',
+          line_number: 3, params: [], header_comments: [], trailing_comments: [], is_commented_out: false,
+        },
+        {
+          section_type: 'include', section_name: '', full_header: 'include macros.cfg',
+          line_number: 4, params: [], header_comments: [], trailing_comments: [], is_commented_out: false,
+        },
+      ],
+      includes: ['macros.cfg'],
+      header_comments: [],
+      raw_text: '',
+    });
+    useGraphStore.getState().addNode(makeHwNode('hw1', { mcuName: 'mainboard', configFile: 'mainboard.cfg' }));
+
+    useGraphStore.getState().duplicateNode('hw1');
+
+    const state = useGraphStore.getState();
+    const dup = state.nodes.find((n) => n.id !== 'hw1')!;
+    const dupData = dup.data as Record<string, unknown>;
+    const newFile = dupData.configFile as string;
+    const newMcu = dupData.mcuName as string;
+
+    // New MCU name is unique and the clone's file exists
+    expect(newMcu).toBe('mainboard_2');
+    const newCf = useConfigStore.getState().configFiles[newFile];
+    expect(newCf).toBeDefined();
+
+    const mcuSec = newCf.sections.find((s) => s.section_type === 'mcu');
+    expect(mcuSec?.full_header).toBe('mcu mainboard_2');
+
+    // Pin prefix rewritten to the NEW mcu name — no stale mainboard: refs
+    const stepper = newCf.sections.find((s) => s.full_header === 'stepper_x');
+    expect(stepper?.params[0].value).toBe('mainboard_2:PA0');
+
+    // [printer] must NOT be duplicated into the clone file
+    expect(newCf.sections.some((s) => s.section_type === 'printer')).toBe(false);
+    // [include] sections are deliberately dropped
+    expect(newCf.sections.some((s) => s.section_type === 'include')).toBe(false);
+  });
 });
 
 describe('graphStore edge operations', () => {

--- a/frontend/src/stores/__tests__/graphStore.test.ts
+++ b/frontend/src/stores/__tests__/graphStore.test.ts
@@ -511,6 +511,22 @@ describe('graphStore auto-arrange', () => {
     useGraphStore.getState().autoArrange();
     expect(useGraphStore.getState().nodes).toHaveLength(0);
   });
+
+  it('standalone sub-component is flagged isStandalone, not orphan', () => {
+    useGraphStore.getState().addSubComponentNode(null as unknown as string, 'fan', 'Fan', 'fan', 'printer.cfg');
+    const node = useGraphStore.getState().nodes[0];
+    expect(node.type).toBe('subComponent');
+    expect((node.data as Record<string, unknown>).isStandalone).toBe(true);
+    expect((node.data as Record<string, unknown>).parentHardwareId).toBeNull();
+  });
+
+  it('standalone feature is flagged isStandalone, not orphan', () => {
+    useGraphStore.getState().addFeatureNode(null as unknown as string, 'gcode_macro', 'Macro', 'gcode_macro X', 'printer.cfg');
+    const node = useGraphStore.getState().nodes[0];
+    expect(node.type).toBe('feature');
+    expect((node.data as Record<string, unknown>).isStandalone).toBe(true);
+    expect((node.data as Record<string, unknown>).parentId).toBeNull();
+  });
 });
 
   it('removes the board sections but keeps the file when a virtual SBC references it', () => {

--- a/frontend/src/stores/__tests__/graphStore.test.ts
+++ b/frontend/src/stores/__tests__/graphStore.test.ts
@@ -20,6 +20,29 @@ function makeHwNode(id: string, overrides: Record<string, unknown> = {}): AppNod
   } as AppNode;
 }
 
+function makeChildNode(id: string, parentId: string, sectionHeader: string, configFile = 'printer.cfg'): AppNode {
+  return {
+    id,
+    type: 'subComponent',
+    position: { x: 0, y: 0 },
+    parentId,
+    data: {
+      label: sectionHeader,
+      sectionType: sectionHeader.split(' ')[0],
+      sectionHeader,
+      sectionLineNumber: 1,
+      componentGroup: 'other',
+      section: {
+        section_type: sectionHeader.split(' ')[0], section_name: '', full_header: sectionHeader,
+        line_number: 1, params: [], header_comments: [], trailing_comments: [], is_commented_out: false,
+      },
+      parentHardwareId: parentId,
+      configFile,
+      hasErrors: false,
+    },
+  } as AppNode;
+}
+
 function makeEdge(id: string, source: string, target: string): AppEdge {
   return {
     id,
@@ -418,3 +441,91 @@ describe('graphStore auto-arrange', () => {
     expect(useGraphStore.getState().nodes).toHaveLength(0);
   });
 });
+
+  it('removes the board sections but keeps the file when a virtual SBC references it', () => {
+    useConfigStore.getState().setConfigFile('printer.cfg', {
+      filename: 'printer.cfg',
+      sections: [
+        { section_type: 'mcu', section_name: '', full_header: 'mcu', line_number: 1, params: [], header_comments: [], trailing_comments: [], is_commented_out: false },
+        { section_type: 'printer', section_name: '', full_header: 'printer', line_number: 2, params: [], header_comments: [], trailing_comments: [], is_commented_out: false },
+        { section_type: 'stepper_x', section_name: '', full_header: 'stepper_x', line_number: 3, params: [], header_comments: [], trailing_comments: [], is_commented_out: false },
+        { section_type: 'heater_bed', section_name: '', full_header: 'heater_bed', line_number: 4, params: [], header_comments: [], trailing_comments: [], is_commented_out: false },
+      ],
+      includes: [],
+      header_comments: [],
+      raw_text: '',
+    });
+    // Mainboard + virtual SBC both reference printer.cfg
+    useGraphStore.getState().addNode(makeHwNode('mainboard', { configFile: 'printer.cfg', mcuName: '' }));
+    useGraphStore.getState().addNode(makeHwNode('sbc', { configFile: 'printer.cfg', mcuName: 'host_mcu', hardwareType: 'sbc' }));
+    // Child nodes (what graphBuilder creates for each section) — correct line numbers
+    useGraphStore.getState().addNode(makeChildNode('c-mcu', 'mainboard', 'mcu', 'printer.cfg'));
+    useGraphStore.getState().addNode(makeChildNode('c-printer', 'mainboard', 'printer', 'printer.cfg'));
+    useGraphStore.getState().addNode(makeChildNode('c-stepper', 'mainboard', 'stepper_x', 'printer.cfg'));
+    useGraphStore.getState().addNode(makeChildNode('c-heater', 'mainboard', 'heater_bed', 'printer.cfg'));
+    // Fix their line numbers to match the config
+    const cfg = useConfigStore.getState().configFiles['printer.cfg'];
+    const byHeader = new Map(cfg.sections.map((s) => [s.full_header, s.line_number]));
+    for (const n of useGraphStore.getState().nodes) {
+      if (n.type === 'subComponent') {
+        const hdr = (n.data as Record<string, unknown>).sectionHeader as string;
+        useGraphStore.getState().updateNodeData(n.id, { sectionLineNumber: byHeader.get(hdr) });
+      }
+    }
+
+    useGraphStore.getState().removeNode('mainboard');
+
+    const after = useConfigStore.getState().configFiles['printer.cfg'];
+    // File survives (SBC references it) but all mainboard sections are gone
+    expect(after).toBeDefined();
+    expect(after.sections.map((s) => s.full_header)).toEqual([]);
+  });
+
+  it('removes sections even when child line numbers are STALE (config edited since graph build)', () => {
+    useConfigStore.getState().setConfigFile('printer.cfg', {
+      filename: 'printer.cfg',
+      sections: [
+        { section_type: 'mcu', section_name: '', full_header: 'mcu', line_number: 1, params: [], header_comments: [], trailing_comments: [], is_commented_out: false },
+        { section_type: 'printer', section_name: '', full_header: 'printer', line_number: 2, params: [], header_comments: [], trailing_comments: [], is_commented_out: false },
+        { section_type: 'stepper_x', section_name: '', full_header: 'stepper_x', line_number: 3, params: [], header_comments: [], trailing_comments: [], is_commented_out: false },
+      ],
+      includes: [],
+      header_comments: [],
+      raw_text: '',
+    });
+    useGraphStore.getState().addNode(makeHwNode('mainboard', { configFile: 'printer.cfg' }));
+    useGraphStore.getState().addNode(makeHwNode('sbc', { configFile: 'printer.cfg', mcuName: 'host_mcu', hardwareType: 'sbc' }));
+    // Children carry STALE line numbers (1) — config has them at 1,2,3
+    useGraphStore.getState().addNode(makeChildNode('c-mcu', 'mainboard', 'mcu'));
+    useGraphStore.getState().addNode(makeChildNode('c-printer', 'mainboard', 'printer'));
+    useGraphStore.getState().addNode(makeChildNode('c-stepper', 'mainboard', 'stepper_x'));
+
+    useGraphStore.getState().removeNode('mainboard');
+
+    const after = useConfigStore.getState().configFiles['printer.cfg'];
+    expect(after).toBeDefined();
+    // Even with stale line numbers, all three sections must be removed — a
+    // silent no-op here is what makes deletes vanish from the diff.
+    expect(after.sections.map((s) => s.full_header)).toEqual([]);
+  });
+
+  it('delete leaves NO sections when hardware has no children (all sections are children)', () => {
+    useConfigStore.getState().setConfigFile('printer.cfg', {
+      filename: 'printer.cfg',
+      sections: [
+        { section_type: 'mcu', section_name: '', full_header: 'mcu', line_number: 1, params: [], header_comments: [], trailing_comments: [], is_commented_out: false },
+      ],
+      includes: [],
+      header_comments: [],
+      raw_text: '',
+    });
+    useGraphStore.getState().addNode(makeHwNode('mainboard', { configFile: 'printer.cfg' }));
+    useGraphStore.getState().addNode(makeHwNode('sbc', { configFile: 'printer.cfg', mcuName: 'host_mcu', hardwareType: 'sbc' }));
+    useGraphStore.getState().addNode(makeChildNode('c-mcu', 'mainboard', 'mcu'));
+
+    useGraphStore.getState().removeNode('mainboard');
+
+    const cf = useConfigStore.getState().configFiles['printer.cfg'];
+    expect(cf).toBeDefined();
+    expect(cf.sections).toHaveLength(0);
+  });

--- a/frontend/src/stores/__tests__/graphStore.test.ts
+++ b/frontend/src/stores/__tests__/graphStore.test.ts
@@ -177,6 +177,61 @@ describe('graphStore bulk + clear', () => {
     useGraphStore.getState().onNodesChange([{ type: 'remove', id: 'a' }]);
     expect(useGraphStore.getState().nodes.map((n) => n.id)).toEqual(['b']);
   });
+
+  it('onNodesChange remove deletes the config section and pushes undo history', () => {
+    // Set up a sub-component node backed by a config section
+    useConfigStore.getState().setConfigFile('printer.cfg', {
+      filename: 'printer.cfg',
+      sections: [{
+        section_type: 'stepper_x',
+        section_name: '',
+        full_header: 'stepper_x',
+        line_number: 3,
+        params: [],
+        header_comments: [],
+        trailing_comments: [],
+        is_commented_out: false,
+      }],
+      includes: [],
+      header_comments: [],
+      raw_text: '',
+    });
+    useGraphStore.getState().addNode({
+      id: 'sc1',
+      type: 'subComponent',
+      position: { x: 0, y: 0 },
+      parentId: 'hw1',
+      data: {
+        label: 'stepper_x',
+        sectionType: 'stepper_x',
+        sectionHeader: 'stepper_x',
+        sectionLineNumber: 3,
+        componentGroup: 'stepper',
+        section: {
+          section_type: 'stepper_x', section_name: '', full_header: 'stepper_x',
+          line_number: 3, params: [], header_comments: [], trailing_comments: [], is_commented_out: false,
+        },
+        parentHardwareId: 'hw1',
+        configFile: 'printer.cfg',
+        hasErrors: false,
+      },
+    } as AppNode);
+
+    // Pressing Delete dispatches a remove change through onNodesChange
+    useGraphStore.getState().onNodesChange([{ type: 'remove', id: 'sc1' }]);
+
+    const state = useGraphStore.getState();
+    expect(state.nodes).toHaveLength(0);
+    // Config section must be gone too — no orphan resurrection on next sync
+    expect(useConfigStore.getState().configFiles['printer.cfg'].sections).toHaveLength(0);
+    expect(state.canUndo).toBe(true);
+
+    // Undo restores both the node and the section
+    state.undo();
+    const restored = useGraphStore.getState();
+    expect(restored.nodes).toHaveLength(1);
+    expect(useConfigStore.getState().configFiles['printer.cfg'].sections).toHaveLength(1);
+  });
 });
 
 describe('graphStore undo/redo', () => {

--- a/frontend/src/stores/__tests__/graphStore.test.ts
+++ b/frontend/src/stores/__tests__/graphStore.test.ts
@@ -102,6 +102,54 @@ describe('graphStore node operations', () => {
     expect(useGraphStore.getState().nodes).toHaveLength(0);
   });
 
+  it('removeNode hardware preserves a config file shared with another board', () => {
+    // Two boards reference the same multi-MCU file (e.g. printer.cfg with two [mcu] sections)
+    useConfigStore.getState().setConfigFile('printer.cfg', {
+      filename: 'printer.cfg',
+      sections: [
+        {
+          section_type: 'mcu', section_name: 'mainboard', full_header: 'mcu mainboard',
+          line_number: 1, params: [], header_comments: [], trailing_comments: [], is_commented_out: false,
+        },
+        {
+          section_type: 'mcu', section_name: 'ebbtool', full_header: 'mcu ebbtool',
+          line_number: 2, params: [], header_comments: [], trailing_comments: [], is_commented_out: false,
+        },
+      ],
+      includes: [],
+      header_comments: [],
+      raw_text: '',
+    });
+    useGraphStore.getState().addNode(makeHwNode('hw1', { configFile: 'printer.cfg', mcuName: 'mainboard' }));
+    useGraphStore.getState().addNode(makeHwNode('hw2', { configFile: 'printer.cfg', mcuName: 'ebbtool' }));
+
+    // Delete only the first board
+    useGraphStore.getState().removeNode('hw1');
+
+    // The file must survive (hw2 still references it) with hw2's section intact
+    const cf = useConfigStore.getState().configFiles['printer.cfg'];
+    expect(cf).toBeDefined();
+    expect(cf.sections.some((s) => s.full_header === 'mcu ebbtool')).toBe(true);
+  });
+
+  it('removeNode hardware deletes the file when no other board references it', () => {
+    useConfigStore.getState().setConfigFile('solo.cfg', {
+      filename: 'solo.cfg',
+      sections: [{
+        section_type: 'mcu', section_name: 'solo', full_header: 'mcu solo',
+        line_number: 1, params: [], header_comments: [], trailing_comments: [], is_commented_out: false,
+      }],
+      includes: [],
+      header_comments: [],
+      raw_text: '',
+    });
+    useGraphStore.getState().addNode(makeHwNode('hw1', { configFile: 'solo.cfg', mcuName: 'solo' }));
+
+    useGraphStore.getState().removeNode('hw1');
+
+    expect(useConfigStore.getState().configFiles['solo.cfg']).toBeUndefined();
+  });
+
   it('setSelectedNode updates selection', () => {
     useGraphStore.getState().addNode(makeHwNode('n1'));
     useGraphStore.getState().setSelectedNode('n1');

--- a/frontend/src/stores/__tests__/graphStore.test.ts
+++ b/frontend/src/stores/__tests__/graphStore.test.ts
@@ -675,8 +675,11 @@ describe('graphStore configuration edge redraw/delete', () => {
     const redrawnEdgeId = useGraphStore.getState().edges[0].id;
     expect(redrawnEdgeId).not.toBe(originalEdgeId);
     const redrawn = useGraphStore.getState().edges[0];
-    expect(redrawn?.source).toBe('mainboard');
-    expect(redrawn?.target).toBe('toolhead');
+    // Direction is normalized: the edge always points FROM the included
+    // (non-primary) node TO the including (primary) node, regardless of
+    // draw direction — so the redrawn edge still reads toolhead → mainboard.
+    expect(redrawn?.source).toBe('toolhead');
+    expect(redrawn?.target).toBe('mainboard');
 
     // Now delete the line — include must be commented out in printer.cfg
     // (the file that owns the include), regardless of edge direction.
@@ -687,6 +690,66 @@ describe('graphStore configuration edge redraw/delete', () => {
     expect(useConfigStore.getState().isDirty).toBe(true);
   });
 
+  it('repointConfigEdge swaps the include to the new pair', () => {
+    // printer.cfg (primary mainboard) + toolhead_board.cfg, plus a second
+    // non-primary file so re-pointing changes the included file.
+    useConfigStore.getState().setConfigFile('printer.cfg', {
+      filename: 'printer.cfg',
+      sections: [
+        { section_type: 'include', section_name: 'toolhead_board.cfg', full_header: 'include toolhead_board.cfg', line_number: 1, params: [], header_comments: [], trailing_comments: [], is_commented_out: false },
+        { section_type: 'mcu', section_name: '', full_header: 'mcu', line_number: 2, params: [], header_comments: [], trailing_comments: [], is_commented_out: false },
+      ],
+      includes: ['toolhead_board.cfg'],
+      header_comments: [],
+      raw_text: '[include toolhead_board.cfg]\n[mcu]\n',
+    });
+    useConfigStore.getState().setConfigFile('toolhead_board.cfg', {
+      filename: 'toolhead_board.cfg',
+      sections: [
+        { section_type: 'mcu', section_name: 'toolhead', full_header: 'mcu toolhead', line_number: 1, params: [], header_comments: [], trailing_comments: [], is_commented_out: false },
+      ],
+      includes: [],
+      header_comments: [],
+      raw_text: '[mcu toolhead]\n',
+    });
+    useConfigStore.getState().setConfigFile('expander.cfg', {
+      filename: 'expander.cfg',
+      sections: [
+        { section_type: 'mcu', section_name: 'expander', full_header: 'mcu expander', line_number: 1, params: [], header_comments: [], trailing_comments: [], is_commented_out: false },
+      ],
+      includes: [],
+      header_comments: [],
+      raw_text: '[mcu expander]\n',
+    });
+    useConfigStore.getState().markClean();
+    useGraphStore.getState().addNode(makeHwNode('mainboard', { configFile: 'printer.cfg', isPrimary: true }));
+    useGraphStore.getState().addNode(makeHwNode('toolhead', { configFile: 'toolhead_board.cfg' }));
+    useGraphStore.getState().addNode(makeHwNode('expander', { configFile: 'expander.cfg' }));
+    const edgeId = useGraphStore.getState().addConfigurationEdge('toolhead', 'mainboard', 'toolhead');
+
+    // Re-point the edge: toolhead → expander (neither primary, so target
+    // includes source: expander.cfg gains [include toolhead_board.cfg] and
+    // printer.cfg's include is commented out).
+    useGraphStore.getState().repointConfigEdge(edgeId, 'toolhead', 'expander');
+
+    const edge = useGraphStore.getState().edges.find((e) => e.id === edgeId);
+    expect(edge?.source).toBe('toolhead');
+    expect(edge?.target).toBe('expander');
+
+    const printerCfg = useConfigStore.getState().configFiles['printer.cfg'];
+    expect(printerCfg.includes).toEqual([]);
+    expect(printerCfg.sections[0].is_commented_out).toBe(true);
+
+    const expanderCfg = useConfigStore.getState().configFiles['expander.cfg'];
+    expect(expanderCfg.includes).toEqual(['toolhead_board.cfg']);
+    expect(useConfigStore.getState().isDirty).toBe(true);
+
+    // Undo restores the original edge + include state
+    useGraphStore.getState().undo();
+    expect(useGraphStore.getState().edges.find((e) => e.id === edgeId)?.target).toBe('mainboard');
+    expect(useConfigStore.getState().configFiles['printer.cfg'].includes).toEqual(['toolhead_board.cfg']);
+  });
+
   it('deleting an edge drawn toolhead → mainboard still comments out the include', () => {
     const edgeId = setupToolheadMainboard();
 
@@ -694,5 +757,47 @@ describe('graphStore configuration edge redraw/delete', () => {
     const cf = useConfigStore.getState().configFiles['printer.cfg'];
     expect(cf.includes).toEqual([]);
     expect(cf.sections[0].is_commented_out).toBe(true);
+  });
+
+  it('syncGraphWithConfig does not create a phantom config edge to the SBC when printer.cfg hosts both MCUs', () => {
+    // printer.cfg contains [mcu] for the primary mainboard AND [mcu host_mcu]
+    // for the SBC — graphBuilder inserts the SBC node first, so the old
+    // configFile-first lookup attached include edges to the SBC.
+    const makeCfg = (filename: string, includes: string[]) => ({
+      filename,
+      sections: [
+        { section_type: 'include', section_name: 'toolhead_board.cfg', full_header: 'include toolhead_board.cfg', line_number: 1, params: [], header_comments: [], trailing_comments: [], is_commented_out: false },
+        { section_type: 'mcu', section_name: 'mainboard', full_header: 'mcu mainboard', line_number: 2, params: [], header_comments: [], trailing_comments: [], is_commented_out: false },
+        { section_type: 'mcu', section_name: 'host_mcu', full_header: 'mcu host_mcu', line_number: 3, params: [], header_comments: [], trailing_comments: [], is_commented_out: false },
+      ],
+      includes,
+      header_comments: [],
+      raw_text: '',
+    });
+    useConfigStore.getState().setConfigFile('printer.cfg', makeCfg('printer.cfg', ['toolhead_board.cfg']));
+    useConfigStore.getState().setConfigFile('toolhead_board.cfg', makeCfg('toolhead_board.cfg', []));
+    useGraphStore.setState({
+      nodes: [
+        // SBC first — this used to win the `find(configFile)` lookup
+        makeHwNode('sbc', { hardwareType: 'sbc', configFile: 'printer.cfg', mcuName: 'host_mcu', isPrimary: false }),
+        makeHwNode('mainboard', { hardwareType: 'mainboard', configFile: 'printer.cfg', mcuName: 'mainboard', isPrimary: true }),
+        makeHwNode('toolhead', { hardwareType: 'toolhead', configFile: 'toolhead_board.cfg', mcuName: 'ebbtool', isPrimary: false }),
+      ],
+      edges: [],
+    });
+
+    useGraphStore.getState().syncGraphWithConfig('printer.cfg');
+
+    const edges = useGraphStore.getState().edges;
+    const configEdges = edges.filter((e) => (e.data as Record<string, unknown>)?.edgeType === 'configuration');
+    // Exactly one config edge, between the toolhead and the PRIMARY mainboard —
+    // never attached to the SBC node.
+    expect(configEdges).toHaveLength(1);
+    expect(configEdges[0].source).toBe('toolhead');
+    expect(configEdges[0].target).toBe('mainboard');
+
+    // Running sync again (e.g. after a text edit) must not duplicate it
+    useGraphStore.getState().syncGraphWithConfig('printer.cfg');
+    expect(useGraphStore.getState().edges.filter((e) => (e.data as Record<string, unknown>)?.edgeType === 'configuration')).toHaveLength(1);
   });
 });

--- a/frontend/src/stores/__tests__/graphStore.test.ts
+++ b/frontend/src/stores/__tests__/graphStore.test.ts
@@ -336,6 +336,36 @@ describe('graphStore bulk + clear', () => {
     expect(restored.nodes).toHaveLength(1);
     expect(useConfigStore.getState().configFiles['printer.cfg'].sections).toHaveLength(1);
   });
+
+  it('Delete-key cascade (edges then nodes) restores edges on a single undo', () => {
+    // ReactFlow's deleteElements fires edge removes BEFORE node removes in the
+    // same synchronous batch. Both must collapse into ONE history entry so a
+    // single Ctrl+Z restores the node AND its connection lines.
+    // Drain any pre-existing history FIRST (adds don't push history, but
+    // earlier tests' removals do — undoing those would wipe our fixtures).
+    while (useGraphStore.getState().canUndo) useGraphStore.getState().undo();
+
+    useGraphStore.getState().addNode(makeHwNode('hw1', { configFile: 'a.cfg' }));
+    useGraphStore.getState().addNode(makeHwNode('hw2', { configFile: 'b.cfg' }));
+    useGraphStore.getState().addEdge(makeEdge('e1', 'hw1', 'hw2'));
+    useGraphStore.getState().addEdge(makeEdge('e2', 'hw1', 'hw1'));
+
+    // Simulate deleteElements order: edge remove changes first, then node removes
+    useGraphStore.getState().onEdgesChange([{ type: 'remove', id: 'e1' }, { type: 'remove', id: 'e2' }]);
+    useGraphStore.getState().onNodesChange([{ type: 'remove', id: 'hw1' }]);
+
+    const state = useGraphStore.getState();
+    expect(state.nodes.map((n) => n.id)).toEqual(['hw2']);
+    expect(state.edges).toHaveLength(0);
+    expect(state.canUndo).toBe(true);
+
+    // ONE undo must restore hw1 AND both edges (the edge push captured the
+    // full pre-delete state; the node push was deduped)
+    state.undo();
+    const restored = useGraphStore.getState();
+    expect(restored.nodes.map((n) => n.id).sort()).toEqual(['hw1', 'hw2']);
+    expect(restored.edges.map((e) => e.id).sort()).toEqual(['e1', 'e2']);
+  });
 });
 
 describe('graphStore undo/redo', () => {

--- a/frontend/src/stores/configStore.ts
+++ b/frontend/src/stores/configStore.ts
@@ -301,7 +301,13 @@ export const useConfigStore = create<ConfigState>((set, get) => ({
     set((s) => {
       const cf = s.configFiles[filename];
       if (!cf) return s;
-      const removeIndex = cf.sections.findIndex((sec) => matchesSectionIdentity(sec, fullHeader, lineNumber));
+      // Prefer exact (header, line) identity; fall back to header-only when
+      // the line number is stale (node data captured before later edits) so a
+      // delete never silently no-ops and vanishes from the diff.
+      let removeIndex = cf.sections.findIndex((sec) => matchesSectionIdentity(sec, fullHeader, lineNumber));
+      if (removeIndex === -1 && lineNumber != null && lineNumber !== 0) {
+        removeIndex = cf.sections.findIndex((sec) => sec.full_header === fullHeader);
+      }
       if (removeIndex === -1) return s;
       const sections = [...cf.sections];
       sections.splice(removeIndex, 1);

--- a/frontend/src/stores/configStore.ts
+++ b/frontend/src/stores/configStore.ts
@@ -114,6 +114,10 @@ interface ConfigState {
 
   /* ── Actions ──────────────────────────────────────── */
   setConfigFile: (filename: string, config: ConfigFile) => void;
+  /** Replace a file's config AND mark the project dirty + schedule revalidation.
+   *  Use this for user-driven mutations (graph edits, duplicate, panel saves).
+   *  Use setConfigFile for load paths, which manage dirty state explicitly. */
+  updateConfigFile: (filename: string, config: ConfigFile) => void;
   removeConfigFile: (filename: string) => void;
   setActiveFile: (filename: string) => void;
   setValidation: (filename: string, result: ValidationResult) => void;
@@ -190,6 +194,14 @@ export const useConfigStore = create<ConfigState>((set, get) => ({
     set((s) => ({
       configFiles: { ...s.configFiles, [filename]: config },
     })),
+
+  updateConfigFile: (filename, config) => {
+    set((s) => ({
+      isDirty: true,
+      configFiles: { ...s.configFiles, [filename]: config },
+    }));
+    scheduleRevalidation(get, set);
+  },
 
   removeConfigFile: (filename) =>
     set((s) => {

--- a/frontend/src/stores/configStore.ts
+++ b/frontend/src/stores/configStore.ts
@@ -160,6 +160,7 @@ interface ConfigState {
 
   /* Original text tracking */
   setOriginalText: (filename: string, text: string) => void;
+  removeOriginalTexts: (filenames: string[]) => void;
 
   /* File operations */
   renameConfigFile: (oldName: string, newName: string) => void;
@@ -447,6 +448,14 @@ export const useConfigStore = create<ConfigState>((set, get) => ({
     set((s) => ({
       originalTexts: { ...s.originalTexts, [filename]: text },
     })),
+
+  removeOriginalTexts: (filenames) =>
+    set((s) => {
+      if (filenames.length === 0) return s;
+      const next = { ...s.originalTexts };
+      for (const fn of filenames) delete next[fn];
+      return { originalTexts: next };
+    }),
 
   renameConfigFile: (oldName, newName) =>
     set((s) => {

--- a/frontend/src/stores/configStore.ts
+++ b/frontend/src/stores/configStore.ts
@@ -442,6 +442,8 @@ export const useConfigStore = create<ConfigState>((set, get) => ({
       activeFile: 'printer.cfg',
       validation: {},
       selectedSection: null,
+      selectedSectionFile: null,
+      selectedSectionLine: null,
       originalTexts: {},
       isDirty: false,
       textParseErrors: {},
@@ -452,6 +454,9 @@ export const useConfigStore = create<ConfigState>((set, get) => ({
       configFiles: configs,
       activeFile: Object.keys(configs)[0] || 'printer.cfg',
       isDirty: false,
+      selectedSection: null,
+      selectedSectionFile: null,
+      selectedSectionLine: null,
       textParseErrors: {},
     }),
 

--- a/frontend/src/stores/configStore.ts
+++ b/frontend/src/stores/configStore.ts
@@ -504,6 +504,9 @@ export const useConfigStore = create<ConfigState>((set, get) => ({
         validation: nextValidation,
         originalTexts: nextOriginals,
         textParseErrors: nextTextParseErrors,
+        selectedSection: s.selectedSection,
+        selectedSectionFile: s.selectedSectionFile === oldName ? newName : s.selectedSectionFile,
+        selectedSectionLine: s.selectedSectionLine,
       };
     }),
 

--- a/frontend/src/stores/configStore.ts
+++ b/frontend/src/stores/configStore.ts
@@ -108,6 +108,8 @@ interface ConfigState {
   validation: Record<string, ValidationResult>;
   schemas: Record<string, SectionSchema>;
   selectedSection: string | null; // full_header of selected section
+  selectedSectionFile: string | null; // config file owning the selected section (duplicate-header safe)
+  selectedSectionLine: number | null; // line number of the selected section (duplicate-header safe)
   originalTexts: Record<string, string>; // original exported text at import time
   isDirty: boolean; // true when config has unsaved changes
   textParseErrors: Record<string, string>; // per-file parse failures in the text view (last-good model is held)
@@ -122,7 +124,7 @@ interface ConfigState {
   setActiveFile: (filename: string) => void;
   setValidation: (filename: string, result: ValidationResult) => void;
   setSchemas: (schemas: Record<string, SectionSchema>) => void;
-  setSelectedSection: (header: string | null) => void;
+  setSelectedSection: (header: string | null, configFile?: string | null, lineNumber?: number | null) => void;
 
   /* Section operations */
   addSection: (filename: string, section: ConfigSection) => void;
@@ -187,6 +189,8 @@ export const useConfigStore = create<ConfigState>((set, get) => ({
   validation: {},
   schemas: {},
   selectedSection: null,
+  selectedSectionFile: null,
+  selectedSectionLine: null,
   originalTexts: {},
   isDirty: false,
   textParseErrors: {},
@@ -224,7 +228,9 @@ export const useConfigStore = create<ConfigState>((set, get) => ({
         validation: nextValidation,
         textParseErrors: nextTextParseErrors,
         activeFile: s.activeFile === filename ? remainingFiles[0] || 'printer.cfg' : s.activeFile,
-        selectedSection: s.activeFile === filename ? null : s.selectedSection,
+        selectedSection: s.activeFile === filename || s.selectedSectionFile === filename ? null : s.selectedSection,
+        selectedSectionFile: s.selectedSectionFile === filename ? null : s.selectedSectionFile,
+        selectedSectionLine: s.selectedSectionFile === filename ? null : s.selectedSectionLine,
       };
     }),
 
@@ -243,7 +249,12 @@ export const useConfigStore = create<ConfigState>((set, get) => ({
       ),
     })),
 
-  setSelectedSection: (header) => set({ selectedSection: header }),
+  setSelectedSection: (header, configFile, lineNumber) =>
+    set({
+      selectedSection: header,
+      selectedSectionFile: configFile ?? null,
+      selectedSectionLine: lineNumber ?? null,
+    }),
 
   addSection: (filename, section) => {
     set((s) => {

--- a/frontend/src/stores/graphStore.ts
+++ b/frontend/src/stores/graphStore.ts
@@ -32,6 +32,7 @@ import {
   ACTIVE_CHILD_Z_INDEX,
   GRID_SIZE,
 } from '../constants/graphLayout';
+import { getHardwareHexColor } from '../constants/graphColors';
 
 const STEPPER_SECTION_RE = /^stepper_[a-z]+(\d+)?$/;
 const EXTRUDER_SECTION_RE = /^extruder(\d+)?$/;
@@ -63,22 +64,6 @@ function getComponentGroup(sectionType: string, isFeature = false): string {
   if (STEPPER_SECTION_RE.test(sectionType)) return 'stepper';
   if (EXTRUDER_SECTION_RE.test(sectionType)) return 'extruder';
   return COMPONENT_GROUP_MAP[sectionType] || (isFeature ? sectionType : 'other');
-}
-
-// Hardware type → color mapping (shared with edge coloring)
-const HW_COLORS: Record<string, string> = {
-  sbc: '#22c55e',
-  mainboard: '#38bdf8',
-  toolhead: '#f472b6',
-  expander: '#a78bfa',
-  config_file: '#0f766e',
-  probe: '#ec4899',
-  accelerometer: '#84cc16',
-  other: '#64748b',
-};
-
-function getHardwareColor(hwType: string): string {
-  return HW_COLORS[hwType] || HW_COLORS.other;
 }
 
 /**
@@ -572,7 +557,7 @@ export const useGraphStore = create<GraphState>((set, get) => ({
         const tgtConfigFile = tgtData.configFile as string;
         const srcIsPrimary = Boolean(srcData.isPrimary) || srcConfigFile === 'printer.cfg';
         const tgtIsPrimary = Boolean(tgtData.isPrimary) || tgtConfigFile === 'printer.cfg';
-        const color = getHardwareColor(srcHwType);
+        const color = getHardwareHexColor(srcHwType);
         // Normalize direction: the edge always points FROM the included
         // (non-primary) node TO the including (primary) node, mirroring
         // graphBuilder's convention. Draw direction is arbitrary; showing it
@@ -616,7 +601,7 @@ export const useGraphStore = create<GraphState>((set, get) => ({
 
     // Default: configuration edge
     const id = nextEdgeId();
-    const color = getHardwareColor((tgtData?.hardwareType as string) || (srcData?.hardwareType as string) || 'other');
+    const color = getHardwareHexColor((tgtData?.hardwareType as string) || (srcData?.hardwareType as string) || 'other');
     const newEdge: AppEdge = {
       id,
       source: connection.source,
@@ -1811,7 +1796,7 @@ export const useGraphStore = create<GraphState>((set, get) => ({
 
   addConfigurationEdge: (sourceId, targetId, hwType, sourceHandle?, targetHandle?) => {
     const id = nextEdgeId();
-    const color = getHardwareColor(hwType);
+    const color = getHardwareHexColor(hwType);
     const edge: Edge = {
       id,
       source: sourceId,

--- a/frontend/src/stores/graphStore.ts
+++ b/frontend/src/stores/graphStore.ts
@@ -708,7 +708,7 @@ export const useGraphStore = create<GraphState>((set, get) => ({
             });
 
           // Create the new config file
-          configStore.setConfigFile(newConfigFile, {
+          configStore.updateConfigFile(newConfigFile, {
             filename: newConfigFile,
             sections: newSections,
             includes: [],
@@ -1598,7 +1598,7 @@ export const useGraphStore = create<GraphState>((set, get) => ({
 
       // Ensure target config file exists
       if (!configState.configFiles[newConfigFile]) {
-        configState.setConfigFile(newConfigFile, {
+        configState.updateConfigFile(newConfigFile, {
           filename: newConfigFile,
           sections: [],
           includes: [],
@@ -1643,7 +1643,7 @@ export const useGraphStore = create<GraphState>((set, get) => ({
           const updatedSection = updateSectionPins(section, oldMcuName, newMcuName, schemas);
           const cf = configState.configFiles[oldConfigFile];
           if (cf) {
-            configState.setConfigFile(oldConfigFile, {
+            configState.updateConfigFile(oldConfigFile, {
               ...cf,
               sections: cf.sections.map((s) => matchesSectionRef(s, ref) ? updatedSection : s),
             });

--- a/frontend/src/stores/graphStore.ts
+++ b/frontend/src/stores/graphStore.ts
@@ -13,6 +13,25 @@ import type { HardwareType, CommunicationType, ConfigFile, ConfigSection } from 
 import { useConfigStore } from './configStore';
 import { updateSectionPins, updateAllSectionPins } from '../utils/pinUtils';
 import { buildUniqueSectionDraft } from '../utils/sectionNaming';
+import {
+  CONTAINER_WIDTH,
+  CONTAINER_HEADER_HEIGHT,
+  CHILD_SLOT_HEIGHT,
+  CONTAINER_PADDING_BOTTOM,
+  CHILD_LEFT_X,
+  CHILD_RIGHT_X,
+  COLLAPSED_HEIGHT,
+  COLLAPSED_WIDTH,
+  TILE_HEADER_HEIGHT,
+  GROUP_ITEM_HEIGHT,
+  GROUP_BODY_PADDING,
+  TILE_GAP,
+  HARDWARE_Z_INDEX,
+  SELECTED_PARENT_Z_INDEX,
+  CHILD_NODE_Z_INDEX,
+  ACTIVE_CHILD_Z_INDEX,
+  GRID_SIZE,
+} from '../constants/graphLayout';
 
 const STEPPER_SECTION_RE = /^stepper_[a-z]+(\d+)?$/;
 const EXTRUDER_SECTION_RE = /^extruder(\d+)?$/;
@@ -88,43 +107,6 @@ function detectNodeCommType(nodeData: Record<string, unknown>): CommunicationTyp
   }
   return 'usb';
 }
-
-// ── Container layout constants ────────────────────────────────
-/** Total width of a hardware container node */
-const CONTAINER_WIDTH = 400;
-/** Height reserved for the hardware node header/info area */
-const CONTAINER_HEADER_HEIGHT = 110;
-/** Vertical slot size per child node (compact tiles) */
-const CHILD_SLOT_HEIGHT = 40;
-/** Padding below last child row */
-const CONTAINER_PADDING_BOTTOM = 16;
-/** X position (relative to parent) for left-column children (features) */
-const CHILD_LEFT_X = 12;
-/** X position (relative to parent) for right-column children (sub-components) */
-const CHILD_RIGHT_X = 208;
-/** Height of a hardware node when collapsed (just the header) */
-const COLLAPSED_HEIGHT = 56;
-/** Width of a hardware node when collapsed */
-const COLLAPSED_WIDTH = 200;
-
-/** Height of a compact tile's header row */
-const TILE_HEADER_HEIGHT = 36;
-/** Height per item row in an expanded GroupNode body */
-const GROUP_ITEM_HEIGHT = 22;
-/** Vertical padding inside the expanded GroupNode body (top + bottom) */
-const GROUP_BODY_PADDING = 12;
-/** Gap between tiles in a column */
-const TILE_GAP = 4;
-/** Base stacking for top-level hardware cards */
-const HARDWARE_Z_INDEX = 0;
-/** Elevated stacking for the selected parent hardware card */
-const SELECTED_PARENT_Z_INDEX = 100;
-/** Child cards should always render above major component cards */
-const CHILD_NODE_Z_INDEX = 200;
-/** Selected child cards stay above sibling cards and action overlays */
-const ACTIVE_CHILD_Z_INDEX = 300;
-/** Shared canvas snap size for manual placement and auto-arrange anchors */
-const GRID_SIZE = 20;
 
 function snapToGrid(value: number): number {
   return Math.round(value / GRID_SIZE) * GRID_SIZE;

--- a/frontend/src/stores/graphStore.ts
+++ b/frontend/src/stores/graphStore.ts
@@ -1013,6 +1013,7 @@ export const useGraphStore = create<GraphState>((set, get) => ({
           configFile: resolvedFile,
           hasErrors: false,
           validationStatus: 'valid',
+          isStandalone: true,
         },
       };
       set((s) => ({ nodes: [...s.nodes, node as AppNode] }));
@@ -1103,6 +1104,7 @@ export const useGraphStore = create<GraphState>((set, get) => ({
           configFile: resolvedFile,
           hasErrors: false,
           validationStatus: 'valid',
+          isStandalone: true,
         },
       };
       set((s) => ({ nodes: [...s.nodes, node as AppNode] }));

--- a/frontend/src/stores/graphStore.ts
+++ b/frontend/src/stores/graphStore.ts
@@ -1397,6 +1397,7 @@ export const useGraphStore = create<GraphState>((set, get) => ({
   snapChildrenToColumns: (parentId, draggedNodeId, draggedY) => {
     set((s) => {
       const newNodes = [...s.nodes] as AppNode[];
+      const selectedId = s.selectedNodeId;
 
       // Classify children into left (features) and right (components) columns
       const leftChildren: AppNode[] = [];
@@ -1413,14 +1414,18 @@ export const useGraphStore = create<GraphState>((set, get) => ({
       }
 
       // For the column containing the dragged node, sort by Y but use the
-      // dragged node's new Y to determine its insertion position
+      // dragged node's new Y to determine its insertion position. Positions
+      // accumulate variable slot heights (getNodeSlotHeight) so expanded
+      // groups don't overlap the tiles stacked after them — mirroring
+      // reflowParentChildren instead of the fixed CHILD_SLOT_HEIGHT.
       const sortColumn = (col: AppNode[]) => {
         col.sort((a, b) => {
           const ay = a.id === draggedNodeId ? draggedY : a.position.y;
           const by = b.id === draggedNodeId ? draggedY : b.position.y;
           return ay - by;
         });
-        col.forEach((child, i) => {
+        let yOffset = CONTAINER_HEADER_HEIGHT;
+        for (const child of col) {
           const idx = newNodes.findIndex((n) => n.id === child.id);
           if (idx >= 0) {
             const isLeft = leftChildren.includes(child);
@@ -1428,26 +1433,35 @@ export const useGraphStore = create<GraphState>((set, get) => ({
               ...newNodes[idx],
               position: {
                 x: isLeft ? CHILD_LEFT_X : CHILD_RIGHT_X,
-                y: CONTAINER_HEADER_HEIGHT + i * CHILD_SLOT_HEIGHT,
+                y: yOffset,
               },
             };
+            yOffset += getNodeSlotHeight(newNodes[idx], selectedId);
           }
-        });
+        }
       };
 
       sortColumn(leftChildren);
       sortColumn(rightChildren);
 
-      // Resize parent
-      const sz = computeHardwareSize(leftChildren.length, rightChildren.length);
+      // Resize parent to fit the taller column (variable heights, like reflow)
+      const totalLeft = leftChildren.reduce(
+        (acc, child) => acc + getNodeSlotHeight(child, selectedId),
+        CONTAINER_HEADER_HEIGHT,
+      ) - CONTAINER_HEADER_HEIGHT;
+      const totalRight = rightChildren.reduce(
+        (acc, child) => acc + getNodeSlotHeight(child, selectedId),
+        CONTAINER_HEADER_HEIGHT,
+      ) - CONTAINER_HEADER_HEIGHT;
       const pIdx = newNodes.findIndex((n) => n.id === parentId);
       if (pIdx >= 0) {
         const pData = newNodes[pIdx].data as Record<string, unknown>;
         const isCollapsed = !!pData.collapsed;
         if (!isCollapsed) {
+          const newHeight = CONTAINER_HEADER_HEIGHT + Math.max(totalLeft, totalRight, 0) + CONTAINER_PADDING_BOTTOM;
           newNodes[pIdx] = {
             ...newNodes[pIdx],
-            style: { ...newNodes[pIdx].style, width: sz.width, height: sz.height },
+            style: { ...newNodes[pIdx].style, width: CONTAINER_WIDTH, height: Math.max(newHeight, 160) },
           };
         }
       }

--- a/frontend/src/stores/graphStore.ts
+++ b/frontend/src/stores/graphStore.ts
@@ -254,6 +254,7 @@ interface GraphState {
   addEdge: (edge: AppEdge) => void;
   removeEdge: (id: string) => void;
   updateEdgeData: (id: string, data: Partial<AppEdge['data']>) => void;
+  repointConfigEdge: (id: string, newSourceId: string, newTargetId: string) => void;
   selectedEdgeId: string | null;
   setSelectedEdge: (id: string | null) => void;
 
@@ -590,10 +591,19 @@ export const useGraphStore = create<GraphState>((set, get) => ({
         const srcIsPrimary = Boolean(srcData.isPrimary) || srcConfigFile === 'printer.cfg';
         const tgtIsPrimary = Boolean(tgtData.isPrimary) || tgtConfigFile === 'printer.cfg';
         const color = getHardwareColor(srcHwType);
+        // Normalize direction: the edge always points FROM the included
+        // (non-primary) node TO the including (primary) node, mirroring
+        // graphBuilder's convention. Draw direction is arbitrary; showing it
+        // verbatim would label the primary as "source" half the time.
+        // When the primary was drawn as source, swap so the non-primary
+        // (included) node becomes the source.
+        const swapDirection = srcIsPrimary && !tgtIsPrimary;
+        const normalizedSource = swapDirection ? connection.target : connection.source;
+        const normalizedTarget = swapDirection ? connection.source : connection.target;
         const newEdge: AppEdge = {
           id,
-          source: connection.source,
-          target: connection.target,
+          source: normalizedSource,
+          target: normalizedTarget,
           sourceHandle: connection.sourceHandle ?? undefined,
           targetHandle: connection.targetHandle ?? undefined,
           data: { edgeType: 'configuration', sourceHardwareType: srcHwType as HardwareType, color },
@@ -956,6 +966,55 @@ export const useGraphStore = create<GraphState>((set, get) => ({
         e.id === id ? { ...e, data: { ...e.data, ...data } } : e,
       ) as AppEdge[],
     })),
+
+  repointConfigEdge: (id, newSourceId, newTargetId) => {
+    const { edges, nodes } = get();
+    const edge = edges.find((e) => e.id === id);
+    if (!edge) return;
+    const configStore = useConfigStore.getState();
+
+    // Snapshot BEFORE any mutation so one undo restores edge + includes.
+    get().pushHistory();
+
+    // Resolve the file include that the OLD edge represents, then comment it out
+    const oldSrc = nodes.find((n) => n.id === edge.source);
+    const oldTgt = nodes.find((n) => n.id === edge.target);
+    const oldSrcFile = (oldSrc?.data as Record<string, unknown> | undefined)?.configFile as string | undefined;
+    const oldTgtFile = (oldTgt?.data as Record<string, unknown> | undefined)?.configFile as string | undefined;
+    if (oldSrcFile && oldTgtFile && oldSrcFile !== oldTgtFile) {
+      const oldSrcPrimary = Boolean((oldSrc?.data as Record<string, unknown> | undefined)?.isPrimary) || oldSrcFile === 'printer.cfg';
+      if (oldSrcPrimary) {
+        configStore.removeInclude(oldSrcFile, oldTgtFile);
+      } else {
+        configStore.removeInclude(oldTgtFile, oldSrcFile);
+      }
+    }
+
+    // Update the edge to point at the new pair (normalized: included → primary)
+    const newSrc = nodes.find((n) => n.id === newSourceId);
+    const newTgt = nodes.find((n) => n.id === newTargetId);
+    const newSrcFile = (newSrc?.data as Record<string, unknown> | undefined)?.configFile as string | undefined;
+    const newTgtFile = (newTgt?.data as Record<string, unknown> | undefined)?.configFile as string | undefined;
+    const newSrcPrimary = Boolean((newSrc?.data as Record<string, unknown> | undefined)?.isPrimary) || newSrcFile === 'printer.cfg';
+    const newTgtPrimary = Boolean((newTgt?.data as Record<string, unknown> | undefined)?.isPrimary) || newTgtFile === 'printer.cfg';
+    const normalizedSource = newTgtPrimary && !newSrcPrimary ? newTargetId : newSourceId;
+    const normalizedTarget = newTgtPrimary && !newSrcPrimary ? newSourceId : newTargetId;
+
+    set((s) => ({
+      edges: s.edges.map((e) =>
+        e.id === id ? { ...e, source: normalizedSource, target: normalizedTarget } : e,
+      ) as AppEdge[],
+    }));
+
+    // Add the include for the new pair (primary includes non-primary)
+    if (newSrcFile && newTgtFile && newSrcFile !== newTgtFile) {
+      if (newSrcPrimary && !newTgtPrimary) {
+        configStore.addInclude(newSrcFile, newTgtFile);
+      } else {
+        configStore.addInclude(newTgtFile, newSrcFile);
+      }
+    }
+  },
 
   addHardwareNode: (hwType, label, configFile, position, mcuName) => {
     const id = nextNodeId();
@@ -2015,17 +2074,31 @@ export const useGraphStore = create<GraphState>((set, get) => ({
     }
 
     // 4. Sync include directives → configuration edges
-    // Find the hardware node for this config file
-    const thisHwNode = get().nodes.find((n) => {
+    // Find the hardware node for this config file. printer.cfg can host BOTH the
+    // primary mainboard [mcu] and the SBC host_mcu — when multiple hardware
+    // nodes share the file, the include edge must attach to the PRIMARY node
+    // (isPrimary), not whichever node happens to appear first (graphBuilder
+    // inserts the SBC first, which caused phantom edges to the SBC).
+    const matchingHwNodes = get().nodes.filter((n) => {
       if (n.type !== 'hardware') return false;
       const nodeFile = (n.data as Record<string, unknown>).configFile as string || '';
       const nodeBasename = nodeFile.replace(/^.*[\\/]/, '');
       const filenameBasename = filename.replace(/^.*[\\/]/, '');
       return nodeFile === filename || nodeBasename === filenameBasename;
     });
+    const thisHwNode = matchingHwNodes.find(
+      (n) => Boolean((n.data as Record<string, unknown>).isPrimary),
+    ) ?? matchingHwNodes[0];
 
     if (thisHwNode) {
       const includes = cf.includes || [];
+
+      // Helper: is this edge a config edge connecting the same two hardware nodes
+      // (either direction)? Mirrors onConnect's pair normalization — direction
+      // never matters, the include always lives in the primary file.
+      const isPairEdge = (e: AppEdge, aId: string, bId: string) =>
+        (e.data as Record<string, unknown>)?.edgeType === 'configuration' &&
+        ((e.source === aId && e.target === bId) || (e.source === bId && e.target === aId));
 
       // Remove configuration edges no longer backed by an include directive
       const existingIncomingEdges = get().edges.filter(
@@ -2047,7 +2120,13 @@ export const useGraphStore = create<GraphState>((set, get) => ({
         }
       }
 
-      // Add configuration edges for newly-added include directives
+      // Add configuration edges for newly-added include directives.
+      // The include belongs to THIS hardware node's file, but the edge that
+      // represents it must connect the two hardware nodes of the involved
+      // files — resolved by filename, never by assuming thisHwNode is the
+      // primary. When the include lives in printer.cfg (owned by the SBC
+      // node), the edge must still land on the PRIMARY node so a redraw
+      // doesn't spawn a duplicate phantom edge to the SBC.
       for (const inc of includes) {
         const incBasename = inc.replace(/^.*[\\/]/, '');
         const includedHwNode = get().nodes.find((n) => {
@@ -2057,15 +2136,20 @@ export const useGraphStore = create<GraphState>((set, get) => ({
           return nodeBasename === incBasename || nodeFile === inc;
         });
         if (!includedHwNode || includedHwNode.id === thisHwNode.id) continue;
-        const edgeExists = get().edges.some(
-          (e) =>
-            (e.data as Record<string, unknown>)?.edgeType === 'configuration' &&
-            e.source === includedHwNode.id &&
-            e.target === thisHwNode.id,
-        );
+        // Resolve the include target: the primary (printer.cfg) node if one of
+        // the pair is primary, otherwise thisHwNode (the file declaring it).
+        const includedData = includedHwNode.data as Record<string, unknown>;
+        const thisData = thisHwNode.data as Record<string, unknown>;
+        const includedFile = includedData.configFile as string || '';
+        const thisFile = thisData.configFile as string || '';
+        const includedIsPrimary = Boolean(includedData.isPrimary) || includedFile === 'printer.cfg';
+        const thisIsPrimary = Boolean(thisData.isPrimary) || thisFile === 'printer.cfg';
+        const edgeSource = thisIsPrimary && !includedIsPrimary ? includedHwNode.id : thisHwNode.id;
+        const edgeTarget = thisIsPrimary && !includedIsPrimary ? thisHwNode.id : includedHwNode.id;
+        const edgeExists = get().edges.some((e) => isPairEdge(e, edgeSource, edgeTarget));
         if (!edgeExists) {
           const hwType = (includedHwNode.data as Record<string, unknown>).hardwareType as HardwareType;
-          get().addConfigurationEdge(includedHwNode.id, thisHwNode.id, hwType);
+          get().addConfigurationEdge(edgeSource, edgeTarget, hwType);
         }
       }
 

--- a/frontend/src/stores/graphStore.ts
+++ b/frontend/src/stores/graphStore.ts
@@ -512,7 +512,18 @@ export const useGraphStore = create<GraphState>((set, get) => ({
         if (srcNode?.type !== 'hardware' || tgtNode?.type !== 'hardware') return;
         const srcFile = (srcNode.data as Record<string, unknown>).configFile as string;
         const tgtFile = (tgtNode.data as Record<string, unknown>).configFile as string;
-        useConfigStore.getState().removeInclude(tgtFile, srcFile);
+        // Mirror onConnect's include direction: the include always lives in the
+        // primary (printer.cfg) file, NOT determined by edge drag direction.
+        // A redrawn edge can flip source/target, so keying off direction here
+        // would try to comment an include inside the wrong file and silently
+        // leave [include toolhead_board.cfg] active.
+        const srcIsPrimary = Boolean((srcNode.data as Record<string, unknown>).isPrimary) || srcFile === 'printer.cfg';
+        const tgtIsPrimary = Boolean((tgtNode.data as Record<string, unknown>).isPrimary) || tgtFile === 'printer.cfg';
+        if (srcIsPrimary && !tgtIsPrimary) {
+          useConfigStore.getState().removeInclude(srcFile, tgtFile);
+        } else {
+          useConfigStore.getState().removeInclude(tgtFile, srcFile);
+        }
       });
     }
     set((s) => ({
@@ -591,24 +602,21 @@ export const useGraphStore = create<GraphState>((set, get) => ({
         set((s) => ({
           edges: [...s.edges.filter((e) => !existing.some((ex) => ex.id === e.id)), newEdge],
         }));
-        // Remove old includes for these files (from old connection)
-        existing.forEach((ex) => {
-          const exSrc = nodes.find((n) => n.id === ex.source);
-          const exTgt = nodes.find((n) => n.id === ex.target);
-          if (exSrc && exTgt) {
-            const exSrcFile = (exSrc.data as Record<string, unknown>).configFile as string;
-            const exTgtFile = (exTgt.data as Record<string, unknown>).configFile as string;
-            useConfigStore.getState().removeInclude(exTgtFile, exSrcFile);
-            useConfigStore.getState().removeInclude(exSrcFile, exTgtFile);
+        // Only touch the include relationship when this pair wasn't already
+        // connected. Redrawing an existing edge (e.g. toolhead↔mainboard)
+        // would otherwise remove→re-add the identical include, marking the
+        // config dirty with a blank diff. Direction never matters here: the
+        // include target is decided by which node holds printer.cfg, so
+        // redrawing the same pair in either direction changes nothing.
+        if (existing.length === 0) {
+          // Include handling:
+          // - If one side is primary/printer.cfg, always include non-primary in printer.cfg.
+          // - Otherwise preserve drag direction (target includes source).
+          if (srcIsPrimary && !tgtIsPrimary) {
+            useConfigStore.getState().addInclude(srcConfigFile, tgtConfigFile);
+          } else {
+            useConfigStore.getState().addInclude(tgtConfigFile, srcConfigFile);
           }
-        });
-        // Include handling:
-        // - If one side is primary/printer.cfg, always include non-primary in printer.cfg.
-        // - Otherwise preserve drag direction (target includes source).
-        if (srcIsPrimary && !tgtIsPrimary) {
-          useConfigStore.getState().addInclude(srcConfigFile, tgtConfigFile);
-        } else {
-          useConfigStore.getState().addInclude(tgtConfigFile, srcConfigFile);
         }
       }
       return;

--- a/frontend/src/stores/graphStore.ts
+++ b/frontend/src/stores/graphStore.ts
@@ -400,6 +400,37 @@ function sortNodesParentsFirst(nodes: AppNode[]): AppNode[] {
   return result;
 }
 
+/**
+ * Remove the config-model sections (or config file for hardware) backing a
+ * node. Shared by removeNode and onNodesChange so the Delete key and the ✕
+ * button can't drift apart. Does NOT touch the graph store — callers decide
+ * when to pushHistory and how to apply the node removal.
+ */
+function cleanupRemovedNodeConfig(node: AppNode, configStore: ReturnType<typeof useConfigStore.getState>): void {
+  const d = node.data as Record<string, unknown>;
+  const configFile = d.configFile as string | undefined;
+  if (!configFile) return;
+
+  if (node.type === 'subComponent' || node.type === 'feature') {
+    const sectionHeader = d.sectionHeader as string | undefined;
+    if (sectionHeader) {
+      configStore.removeSection(configFile, sectionHeader, d.sectionLineNumber as number | undefined);
+    }
+  } else if (node.type === 'group') {
+    const children = d.children as Array<{ sectionHeader: string; sectionLineNumber?: number; configFile?: string }> | undefined;
+    if (children) {
+      for (const child of children) {
+        const childFile = child.configFile || configFile;
+        if (child.sectionHeader) {
+          configStore.removeSection(childFile, child.sectionHeader, child.sectionLineNumber);
+        }
+      }
+    }
+  } else if (node.type === 'hardware') {
+    configStore.removeConfigFile(configFile);
+  }
+}
+
 export const useGraphStore = create<GraphState>((set, get) => ({
   nodes: [],
   edges: [],
@@ -408,10 +439,26 @@ export const useGraphStore = create<GraphState>((set, get) => ({
   selectedEdgeId: null,
   fitViewTrigger: 0,
 
-  onNodesChange: (changes) =>
+  onNodesChange: (changes) => {
+    // ReactFlow dispatches Delete-key node removals through onNodesChange as
+    // { type: 'remove' } changes. Route them through the same config cleanup
+    // as removeNode so the section is deleted from the config model (not just
+    // the graph) and the action is undoable — otherwise the section
+    // resurrects on the next syncGraphWithConfig and Ctrl+Z does nothing.
+    const removes = changes.filter((c) => c.type === 'remove');
+    if (removes.length > 0) {
+      get().pushHistory();
+      const configStore = useConfigStore.getState();
+      for (const change of removes) {
+        const id = (change as { id: string }).id;
+        const node = get().nodes.find((n) => n.id === id);
+        if (node) cleanupRemovedNodeConfig(node, configStore);
+      }
+    }
     set((s) => ({
       nodes: sortNodesParentsFirst(applyNodeChanges(changes, s.nodes) as AppNode[]),
-    })),
+    }));
+  },
 
   onEdgesChange: (changes) => {
     // Clean up includes for removed configuration edges between hardware nodes
@@ -557,35 +604,7 @@ export const useGraphStore = create<GraphState>((set, get) => ({
     // Remove corresponding config sections for each removed node
     const configStore = useConfigStore.getState();
     for (const rn of removedNodes) {
-      const d = rn.data as Record<string, unknown>;
-      const configFile = d.configFile as string | undefined;
-      if (!configFile) continue;
-
-      if (rn.type === 'subComponent' || rn.type === 'feature') {
-        const sectionHeader = d.sectionHeader as string | undefined;
-        if (sectionHeader) {
-          configStore.removeSection(configFile, sectionHeader, d.sectionLineNumber as number | undefined);
-        }
-      } else if (rn.type === 'group') {
-        const children = d.children as Array<{ sectionHeader: string; sectionLineNumber?: number; configFile?: string }> | undefined;
-        if (children) {
-          for (const child of children) {
-            const childFile = child.configFile || configFile;
-            if (child.sectionHeader) {
-              configStore.removeSection(childFile, child.sectionHeader, child.sectionLineNumber);
-            }
-          }
-        }
-      }
-    }
-
-    // If removing a hardware node, delete its entire config file
-    if (node?.type === 'hardware') {
-      const d = node.data as Record<string, unknown>;
-      const configFile = d.configFile as string | undefined;
-      if (configFile) {
-        configStore.removeConfigFile(configFile);
-      }
+      cleanupRemovedNodeConfig(rn, configStore);
     }
 
     set((s) => {

--- a/frontend/src/stores/graphStore.ts
+++ b/frontend/src/stores/graphStore.ts
@@ -446,6 +446,11 @@ function cleanupRemovedNodeConfig(
   }
 }
 
+/** Module-level flag: deleteElements fires edge removes before node removes in
+ *  the same batch. Set while that batch is in flight so onNodesChange skips its
+ *  duplicate history push (the edge push already captured the full state). */
+let edgeRemoveBatchPending = false;
+
 export const useGraphStore = create<GraphState>((set, get) => ({
   nodes: [],
   edges: [],
@@ -460,9 +465,19 @@ export const useGraphStore = create<GraphState>((set, get) => ({
     // as removeNode so the section is deleted from the config model (not just
     // the graph) and the action is undoable — otherwise the section
     // resurrects on the next syncGraphWithConfig and Ctrl+Z does nothing.
+    //
+    // deleteElements fires edge removes BEFORE node removes (same batch), and
+    // onEdgesChange already pushed a full history snapshot that includes the
+    // edges. Pushing again here would snapshot the POST-edge-removal state,
+    // so Ctrl+Z would restore the node but not its connection lines. Skip the
+    // duplicate push when an edge-remove batch is pending; trash-can deletes
+    // (removeNode) are unaffected (single push).
     const removes = changes.filter((c) => c.type === 'remove');
     if (removes.length > 0) {
-      get().pushHistory();
+      if (!edgeRemoveBatchPending) {
+        get().pushHistory();
+      }
+      edgeRemoveBatchPending = false;
       const configStore = useConfigStore.getState();
       const nodesSnapshot = get().nodes;
       for (const change of removes) {
@@ -480,6 +495,13 @@ export const useGraphStore = create<GraphState>((set, get) => ({
     // Clean up includes for removed configuration edges between hardware nodes
     const removes = changes.filter((c) => c.type === 'remove');
     if (removes.length > 0) {
+      // Mark this batch so onNodesChange (fired later by deleteElements) knows
+      // the history push already captured the full pre-delete state. Cleared
+      // on a microtask: deleteElements fires edge+node triggers synchronously,
+      // so the flag is only visible to that same batch — a standalone edge
+      // delete (no node changes follow) must not leak the flag forward.
+      edgeRemoveBatchPending = true;
+      queueMicrotask(() => { edgeRemoveBatchPending = false; });
       get().pushHistory();
       const { nodes, edges } = get();
       removes.forEach((c) => {

--- a/frontend/src/stores/graphStore.ts
+++ b/frontend/src/stores/graphStore.ts
@@ -11,7 +11,7 @@ import {
 import type { AppNode, AppEdge, GroupNodeData } from '../types/graph';
 import type { HardwareType, CommunicationType, ConfigFile, ConfigSection } from '../types/config';
 import { useConfigStore } from './configStore';
-import { updateSectionPins } from '../utils/pinUtils';
+import { updateSectionPins, updateAllSectionPins } from '../utils/pinUtils';
 import { buildUniqueSectionDraft } from '../utils/sectionNaming';
 
 const STEPPER_SECTION_RE = /^stepper_[a-z]+(\d+)?$/;
@@ -706,11 +706,14 @@ export const useGraphStore = create<GraphState>((set, get) => ({
           fileCounter++;
         }
 
-        // Copy sections from source config, renaming MCU section
+        // Copy sections from source config, renaming MCU section. Drop
+        // [include] (a clone shouldn't re-include the source's children) and
+        // [printer] (unique to the primary board — duplicating it into a
+        // non-primary file is invalid).
         const srcCf = configStore.configFiles[srcConfigFile];
         if (srcCf) {
           const newSections = srcCf.sections
-            .filter((s) => s.section_type !== 'include')
+            .filter((s) => s.section_type !== 'include' && s.section_type !== 'printer')
             .map((s) => {
               if (s.section_type === 'mcu') {
                 return {
@@ -726,10 +729,15 @@ export const useGraphStore = create<GraphState>((set, get) => ({
               };
             });
 
+          // Rewrite pin prefixes (step_pin: mainboard:PA0 → mainboard_2:PA0)
+          // so the clone references the NEW mcu, not a stale pointer to the
+          // source board. Mirrors reparentNode's MCU-context change.
+          const finalSections = updateAllSectionPins(newSections, srcMcuName, newMcuName, configStore.schemas);
+
           // Create the new config file
           configStore.updateConfigFile(newConfigFile, {
             filename: newConfigFile,
-            sections: newSections,
+            sections: finalSections,
             includes: [],
             header_comments: [...srcCf.header_comments],
           });

--- a/frontend/src/stores/graphStore.ts
+++ b/frontend/src/stores/graphStore.ts
@@ -405,8 +405,16 @@ function sortNodesParentsFirst(nodes: AppNode[]): AppNode[] {
  * node. Shared by removeNode and onNodesChange so the Delete key and the ✕
  * button can't drift apart. Does NOT touch the graph store — callers decide
  * when to pushHistory and how to apply the node removal.
+ *
+ * For hardware nodes the config FILE is only deleted when no other hardware
+ * node still references it — two boards can share one multi-MCU file, and
+ * deleting one board must not delete the other's sections.
  */
-function cleanupRemovedNodeConfig(node: AppNode, configStore: ReturnType<typeof useConfigStore.getState>): void {
+function cleanupRemovedNodeConfig(
+  node: AppNode,
+  configStore: ReturnType<typeof useConfigStore.getState>,
+  allNodes: AppNode[],
+): void {
   const d = node.data as Record<string, unknown>;
   const configFile = d.configFile as string | undefined;
   if (!configFile) return;
@@ -427,7 +435,14 @@ function cleanupRemovedNodeConfig(node: AppNode, configStore: ReturnType<typeof 
       }
     }
   } else if (node.type === 'hardware') {
-    configStore.removeConfigFile(configFile);
+    // Only delete the config file if no OTHER hardware node references it
+    const stillReferenced = allNodes.some(
+      (n) => n.id !== node.id && n.type === 'hardware'
+        && (n.data as Record<string, unknown>).configFile === configFile,
+    );
+    if (!stillReferenced) {
+      configStore.removeConfigFile(configFile);
+    }
   }
 }
 
@@ -449,10 +464,11 @@ export const useGraphStore = create<GraphState>((set, get) => ({
     if (removes.length > 0) {
       get().pushHistory();
       const configStore = useConfigStore.getState();
+      const nodesSnapshot = get().nodes;
       for (const change of removes) {
         const id = (change as { id: string }).id;
-        const node = get().nodes.find((n) => n.id === id);
-        if (node) cleanupRemovedNodeConfig(node, configStore);
+        const node = nodesSnapshot.find((n) => n.id === id);
+        if (node) cleanupRemovedNodeConfig(node, configStore, nodesSnapshot);
       }
     }
     set((s) => ({
@@ -603,8 +619,9 @@ export const useGraphStore = create<GraphState>((set, get) => ({
 
     // Remove corresponding config sections for each removed node
     const configStore = useConfigStore.getState();
+    const allNodes = state.nodes;
     for (const rn of removedNodes) {
-      cleanupRemovedNodeConfig(rn, configStore);
+      cleanupRemovedNodeConfig(rn, configStore, allNodes);
     }
 
     set((s) => {

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -17,6 +17,13 @@ export interface ConfigSection {
   header_comments: string[];
   trailing_comments?: string[];
   is_commented_out?: boolean;
+  /**
+   * Frontend-only: per-param `is_commented_out` state captured when the
+   * section was suppressed, so unsuppressing restores individually-commented
+   * params instead of enabling everything. Ignored by the backend (Pydantic
+   * drops unknown fields) and never written to config text.
+   */
+  suppressedParams?: Record<string, boolean>;
 }
 
 export interface ConfigFile {

--- a/frontend/src/utils/__tests__/featureSections.test.ts
+++ b/frontend/src/utils/__tests__/featureSections.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { hasFeatureSectionType } from '../featureSections';
+import type { ConfigFile } from '../../types/config';
+
+function makeFile(sectionTypes: string[]): ConfigFile {
+  return {
+    filename: 'printer.cfg',
+    sections: sectionTypes.map((section_type) => ({
+      section_type,
+      section_name: '',
+      full_header: `[${section_type}]`,
+      params: [],
+      line_number: 1,
+      header_comments: [],
+    })),
+    includes: [],
+    header_comments: [],
+  };
+}
+
+describe('hasFeatureSectionType', () => {
+  it('returns true when any file already has the section type', () => {
+    const files = { 'printer.cfg': makeFile(['bed_mesh', 'input_shaper']) };
+    expect(hasFeatureSectionType(files, 'bed_mesh')).toBe(true);
+  });
+
+  it('returns false when no file has the section type', () => {
+    const files = { 'printer.cfg': makeFile(['bed_mesh']) };
+    expect(hasFeatureSectionType(files, 'z_tilt')).toBe(false);
+  });
+
+  it('searches across all files', () => {
+    const files = {
+      'printer.cfg': makeFile(['bed_mesh']),
+      'features.cfg': makeFile(['input_shaper']),
+    };
+    expect(hasFeatureSectionType(files, 'input_shaper')).toBe(true);
+  });
+
+  it('never blocks gcode_macro (repeatable section)', () => {
+    const files = { 'printer.cfg': makeFile(['gcode_macro']) };
+    expect(hasFeatureSectionType(files, 'gcode_macro')).toBe(false);
+  });
+
+  it('returns false for empty files', () => {
+    expect(hasFeatureSectionType({}, 'bed_mesh')).toBe(false);
+  });
+});

--- a/frontend/src/utils/__tests__/mcuPrimary.test.ts
+++ b/frontend/src/utils/__tests__/mcuPrimary.test.ts
@@ -5,6 +5,7 @@ import {
   renameMcuSections,
   applyMcuRenameToFiles,
   planPrimarySwap,
+  type PlanNode,
 } from '../mcuPrimary';
 import type { ConfigFile } from '../../types/config';
 
@@ -160,5 +161,55 @@ describe('planPrimarySwap', () => {
     });
     expect(plan.renames).toEqual([]);
     expect(plan.nodeUpdates).toEqual([]);
+  });
+
+  it('repoints group children whose configFile matches a renamed file', () => {
+    // Group nodes carry their own configFile AND a children array where each
+    // child also records its configFile. Both must be repointed when the file
+    // is renamed, or clicking a group child resolves against a stale filename
+    // and the sidebar shows nothing.
+    const groupNode = {
+      id: 'group1',
+      type: 'group',
+      parentId: 'mainboard',
+      data: {
+        configFile: 'printer.cfg',
+        children: [
+          { sectionHeader: 'bed_mesh', configFile: 'printer.cfg' },
+          { sectionHeader: 'z_tilt', configFile: 'printer.cfg' },
+        ],
+      },
+    };
+    const plan = planPrimarySwap({
+      oldPrimaryId: 'mainboard',
+      oldMcuName: 'mainboard',
+      newPrimaryId: 'toolhead',
+      newConfigFile: 'toolhead_board.cfg',
+      nodes: [...nodes, groupNode as unknown as PlanNode],
+    });
+    expect(plan.renames).toContainEqual({ from: 'printer.cfg', to: 'mainboard.cfg' });
+    // The group node itself gets repointed…
+    expect(plan.nodeUpdates).toContainEqual({ nodeId: 'group1', configFile: 'mainboard.cfg' });
+    // …AND each child inside it.
+    expect(plan.groupChildRenames).toContainEqual({ nodeId: 'group1', from: 'printer.cfg', to: 'mainboard.cfg' });
+  });
+
+  it('repoints ANY node referencing a renamed file, including standalone nodes', () => {
+    // A standalone (parentless) sub-component may reference printer.cfg even
+    // though it is not a child of the old primary — it must still be repointed.
+    const standalone = {
+      id: 'standalone1',
+      type: 'subComponent',
+      parentId: null,
+      data: { configFile: 'printer.cfg', sectionHeader: 'probe' },
+    };
+    const plan = planPrimarySwap({
+      oldPrimaryId: 'mainboard',
+      oldMcuName: 'mainboard',
+      newPrimaryId: 'toolhead',
+      newConfigFile: 'toolhead_board.cfg',
+      nodes: [...nodes, standalone as unknown as PlanNode],
+    });
+    expect(plan.nodeUpdates).toContainEqual({ nodeId: 'standalone1', configFile: 'mainboard.cfg' });
   });
 });

--- a/frontend/src/utils/__tests__/mcuPrimary.test.ts
+++ b/frontend/src/utils/__tests__/mcuPrimary.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest';
+import {
+  demotedConfigFilename,
+  mcuHeaderFor,
+  renameMcuSections,
+  applyMcuRenameToFiles,
+  planPrimarySwap,
+} from '../mcuPrimary';
+import type { ConfigFile } from '../../types/config';
+
+function makeFile(filename: string, sections: ConfigFile['sections']): ConfigFile {
+  return { filename, sections, includes: [], header_comments: [] };
+}
+
+function mcuSection(name: string, extraParams: Array<{ key: string; value: string }> = []): ConfigFile['sections'][number] {
+  return {
+    section_type: 'mcu',
+    section_name: name,
+    full_header: name ? `mcu ${name}` : 'mcu',
+    line_number: 1,
+    params: [
+      { key: 'serial', value: '/dev/ttyACM0', is_commented_out: false, comment: '', separator: ':' },
+      ...extraParams.map((p) => ({ ...p, is_commented_out: false, comment: '', separator: ':' })),
+    ],
+    header_comments: [],
+    trailing_comments: [],
+    is_commented_out: false,
+  };
+}
+
+describe('demotedConfigFilename', () => {
+  it('lowercases and underscores the mcu name', () => {
+    expect(demotedConfigFilename('Main Board')).toBe('main_board.cfg');
+  });
+
+  it('handles single-word names', () => {
+    expect(demotedConfigFilename('toolhead')).toBe('toolhead.cfg');
+  });
+});
+
+describe('mcuHeaderFor', () => {
+  it('returns bare [mcu] for empty name (primary)', () => {
+    expect(mcuHeaderFor('')).toBe('mcu');
+  });
+
+  it('returns [mcu name] for named mcus', () => {
+    expect(mcuHeaderFor('toolhead')).toBe('mcu toolhead');
+  });
+});
+
+describe('renameMcuSections', () => {
+  it('renames the mcu section header and rewrites pin prefixes', () => {
+    const sections = [
+      mcuSection('mainboard'),
+      {
+        section_type: 'stepper_x', section_name: '', full_header: 'stepper_x', line_number: 2,
+        params: [{ key: 'step_pin', value: 'mainboard:PA0', is_commented_out: false, comment: '', separator: ':' }],
+        header_comments: [], trailing_comments: [], is_commented_out: false,
+      },
+    ];
+    const out = renameMcuSections(sections, 'mainboard', 'toolhead');
+    expect(out[0].full_header).toBe('mcu toolhead');
+    expect(out[0].section_name).toBe('toolhead');
+    expect(out[1].params[0].value).toBe('toolhead:PA0');
+  });
+
+  it('promoting to primary strips the mcu name', () => {
+    const sections = [mcuSection('toolhead')];
+    const out = renameMcuSections(sections, 'toolhead', '');
+    expect(out[0].full_header).toBe('mcu');
+    expect(out[0].section_name).toBe('');
+  });
+
+  it('leaves unrelated sections untouched', () => {
+    const sections = [mcuSection('toolhead'), mcuSection('expander')];
+    const out = renameMcuSections(sections, 'toolhead', '');
+    expect(out[1].full_header).toBe('mcu expander');
+    expect(out[1].section_name).toBe('expander');
+  });
+});
+
+describe('applyMcuRenameToFiles', () => {
+  it('updates the target file and each listed child file, leaving others untouched', () => {
+    const files: Record<string, ConfigFile> = {
+      'printer.cfg': makeFile('printer.cfg', [
+        mcuSection('mainboard'),
+        {
+          section_type: 'stepper_x', section_name: '', full_header: 'stepper_x', line_number: 2,
+          params: [{ key: 'step_pin', value: 'mainboard:PA0', is_commented_out: false, comment: '', separator: ':' }],
+          header_comments: [], trailing_comments: [], is_commented_out: false,
+        },
+      ]),
+      'toolhead_board.cfg': makeFile('toolhead_board.cfg', [
+        mcuSection('toolhead'),
+        {
+          section_type: 'extruder', section_name: '', full_header: 'extruder', line_number: 2,
+          params: [{ key: 'step_pin', value: 'mainboard:PB0', is_commented_out: false, comment: '', separator: ':' }],
+          header_comments: [], trailing_comments: [], is_commented_out: false,
+        },
+      ]),
+      'other.cfg': makeFile('other.cfg', [mcuSection('expander')]),
+    };
+
+    const out = applyMcuRenameToFiles(files, 'printer.cfg', ['toolhead_board.cfg'], 'mainboard', 'spider', {});
+    expect(out['printer.cfg'].sections[0].full_header).toBe('mcu spider');
+    expect(out['printer.cfg'].sections[1].params[0].value).toBe('spider:PA0');
+    expect(out['toolhead_board.cfg'].sections[1].params[0].value).toBe('spider:PB0');
+    // Unlisted file is untouched
+    expect(out['other.cfg'].sections[0].full_header).toBe('mcu expander');
+    // Original record is not mutated
+    expect(files['printer.cfg'].sections[0].full_header).toBe('mcu mainboard');
+  });
+});
+
+describe('planPrimarySwap', () => {
+  const nodes = [
+    { id: 'mainboard', parentId: null, data: { configFile: 'printer.cfg' } },
+    { id: 'toolhead', parentId: null, data: { configFile: 'toolhead_board.cfg' } },
+    // children of the old primary
+    { id: 'c1', parentId: 'mainboard', data: { configFile: 'printer.cfg' } },
+    { id: 'c2', parentId: 'toolhead', data: { configFile: 'toolhead_board.cfg' } },
+  ];
+
+  it('renames old primary file to {name}.cfg and new primary file to printer.cfg, with child updates', () => {
+    const plan = planPrimarySwap({
+      oldPrimaryId: 'mainboard',
+      oldMcuName: 'mainboard',
+      newPrimaryId: 'toolhead',
+      newConfigFile: 'toolhead_board.cfg',
+      nodes,
+    });
+    expect(plan.renames).toEqual([
+      { from: 'printer.cfg', to: 'mainboard.cfg' },
+      { from: 'toolhead_board.cfg', to: 'printer.cfg' },
+    ]);
+    expect(plan.nodeUpdates).toContainEqual({ nodeId: 'mainboard', configFile: 'mainboard.cfg' });
+    expect(plan.nodeUpdates).toContainEqual({ nodeId: 'c1', configFile: 'mainboard.cfg' });
+    expect(plan.nodeUpdates).toContainEqual({ nodeId: 'toolhead', configFile: 'printer.cfg' });
+    expect(plan.nodeUpdates).toContainEqual({ nodeId: 'c2', configFile: 'printer.cfg' });
+  });
+
+  it('skips the old-primary rename when there is no old primary', () => {
+    const plan = planPrimarySwap({
+      oldPrimaryId: null,
+      oldMcuName: '',
+      newPrimaryId: 'toolhead',
+      newConfigFile: 'toolhead_board.cfg',
+      nodes,
+    });
+    expect(plan.renames).toEqual([{ from: 'toolhead_board.cfg', to: 'printer.cfg' }]);
+  });
+
+  it('skips the new-primary rename when it is already printer.cfg', () => {
+    const plan = planPrimarySwap({
+      oldPrimaryId: null,
+      oldMcuName: '',
+      newPrimaryId: 'mainboard',
+      newConfigFile: 'printer.cfg',
+      nodes,
+    });
+    expect(plan.renames).toEqual([]);
+    expect(plan.nodeUpdates).toEqual([]);
+  });
+});

--- a/frontend/src/utils/__tests__/sectionResolver.test.ts
+++ b/frontend/src/utils/__tests__/sectionResolver.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { resolveSection } from '@/utils/sectionResolver';
+import type { ConfigFile } from '@/types/config';
+
+function makeFile(filename: string, sections: Array<{ header: string; line: number }>): ConfigFile {
+  return {
+    filename,
+    sections: sections.map((s) => ({
+      section_type: s.header.split(' ')[0],
+      section_name: s.header.split(' ').slice(1).join(' '),
+      full_header: s.header,
+      line_number: s.line,
+      params: [],
+      header_comments: [],
+      trailing_comments: [],
+      is_commented_out: false,
+    })),
+    includes: [],
+    header_comments: [],
+    raw_text: '',
+  };
+}
+
+const configFiles: Record<string, ConfigFile> = {
+  'printer.cfg': makeFile('printer.cfg', [
+    { header: 'idle_timeout', line: 10 },
+    { header: 'gcode_macro LEVEL_BED', line: 20 },
+  ]),
+  'macros.cfg': makeFile('macros.cfg', [
+    { header: 'idle_timeout', line: 5 },
+    { header: 'gcode_macro LEVEL_BED', line: 15 },
+  ]),
+};
+
+describe('resolveSection', () => {
+  it('returns null when no header is given', () => {
+    expect(resolveSection(configFiles, null)).toBeNull();
+  });
+
+  it('resolves by header when no file is known (legacy behavior)', () => {
+    const result = resolveSection(configFiles, 'gcode_macro LEVEL_BED');
+    expect(result?.filename).toBe('printer.cfg');
+    expect(result?.section.line_number).toBe(20);
+  });
+
+  it('prefers the carried config file over first-match across files', () => {
+    const result = resolveSection(configFiles, 'idle_timeout', 'macros.cfg');
+    expect(result?.filename).toBe('macros.cfg');
+    expect(result?.section.line_number).toBe(5);
+  });
+
+  it('respects the carried line number within the carried file', () => {
+    const result = resolveSection(configFiles, 'gcode_macro LEVEL_BED', 'macros.cfg', 15);
+    expect(result?.filename).toBe('macros.cfg');
+    expect(result?.section.line_number).toBe(15);
+  });
+
+  it('falls back to header-only search when carried line is missing', () => {
+    const result = resolveSection(configFiles, 'idle_timeout', 'macros.cfg', undefined);
+    expect(result?.section.line_number).toBe(5);
+  });
+
+  it('returns null when carried file does not exist', () => {
+    expect(resolveSection(configFiles, 'idle_timeout', 'nope.cfg')).toBeNull();
+  });
+
+  it('matches by header + line across files when file unknown', () => {
+    const result = resolveSection(configFiles, 'gcode_macro LEVEL_BED', undefined, 15);
+    expect(result?.filename).toBe('macros.cfg');
+  });
+});

--- a/frontend/src/utils/__tests__/sectionSuppress.test.ts
+++ b/frontend/src/utils/__tests__/sectionSuppress.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { toggleSectionSuppressed } from '../sectionSuppress';
+import type { ConfigSection } from '../../types/config';
+
+function makeSection(params: Array<{ key: string; commented?: boolean }>): ConfigSection {
+  return {
+    section_type: 'gcode_macro',
+    section_name: 'X',
+    full_header: 'gcode_macro X',
+    line_number: 1,
+    header_comments: [],
+    params: params.map((p) => ({
+      key: p.key,
+      value: '',
+      comment: '',
+      is_commented_out: !!p.commented,
+    })),
+  };
+}
+
+describe('toggleSectionSuppressed', () => {
+  it('comments all real params when suppressing', () => {
+    const section = makeSection([{ key: 'gcode' }, { key: 'description' }]);
+    const result = toggleSectionSuppressed(section, true);
+    expect(result.is_commented_out).toBe(true);
+    expect(result.params.every((p) => p.is_commented_out)).toBe(true);
+  });
+
+  it('captures prior per-param state so unsuppress restores individually-commented params', () => {
+    // User individually commented `description` before suppressing the section.
+    const section = makeSection([{ key: 'gcode' }, { key: 'description', commented: true }]);
+    const suppressed = toggleSectionSuppressed(section, true);
+    // While suppressed everything is commented.
+    expect(suppressed.params.every((p) => p.is_commented_out)).toBe(true);
+
+    const restored = toggleSectionSuppressed(suppressed, false);
+    // The individually-commented param stays commented; the active one returns.
+    expect(restored.params.find((p) => p.key === 'gcode')?.is_commented_out).toBe(false);
+    expect(restored.params.find((p) => p.key === 'description')?.is_commented_out).toBe(true);
+    expect(restored.is_commented_out).toBe(false);
+  });
+
+  it('enables everything when unsuppressing a section with no recorded prior state', () => {
+    const section = makeSection([{ key: 'gcode', commented: true }, { key: 'description', commented: true }]);
+    const result = toggleSectionSuppressed(section, false);
+    expect(result.is_commented_out).toBe(false);
+    expect(result.params.every((p) => !p.is_commented_out)).toBe(true);
+  });
+
+  it('leaves _comment_ pseudo-params untouched', () => {
+    const section = makeSection([{ key: 'gcode' }]);
+    section.params.push({ key: '_comment_', value: '# a note', comment: '', is_commented_out: false });
+    const suppressed = toggleSectionSuppressed(section, true);
+    const commentParam = suppressed.params.find((p) => p.key === '_comment_');
+    expect(commentParam?.is_commented_out).toBe(false);
+    expect(commentParam?.value).toBe('# a note');
+  });
+
+  it('keeps param values and keys intact across the toggle cycle', () => {
+    const section = makeSection([{ key: 'gcode', commented: true }]);
+    section.params[0].value = 'BED_MESH_CALIBRATE';
+    const restored = toggleSectionSuppressed(toggleSectionSuppressed(section, true), false);
+    expect(restored.params[0].key).toBe('gcode');
+    expect(restored.params[0].value).toBe('BED_MESH_CALIBRATE');
+  });
+
+  it('does not carry the snapshot field into the restored section', () => {
+    const section = makeSection([{ key: 'gcode' }]);
+    const restored = toggleSectionSuppressed(toggleSectionSuppressed(section, true), false);
+    expect((restored as unknown as Record<string, unknown>).suppressedParams).toBeUndefined();
+  });
+});

--- a/frontend/src/utils/featureSections.ts
+++ b/frontend/src/utils/featureSections.ts
@@ -1,0 +1,15 @@
+import type { ConfigFile } from '../types/config';
+
+/**
+ * True when any config file already contains a section of the given type.
+ * Feature sections are singletons per project (except gcode_macro, which can
+ * repeat), so the AddMenu/panel uses this to disable duplicate feature adds.
+ */
+export function hasFeatureSectionType(
+  configFiles: Record<string, ConfigFile>,
+  sectionType: string,
+): boolean {
+  return sectionType !== 'gcode_macro' && Object.values(configFiles).some(
+    (configFile) => configFile.sections.some((section) => section.section_type === sectionType),
+  );
+}

--- a/frontend/src/utils/mcuPrimary.ts
+++ b/frontend/src/utils/mcuPrimary.ts
@@ -77,14 +77,23 @@ export interface NodeFileUpdate {
   configFile: string;
 }
 
+/** Repoint every child inside a group node whose configFile === from → to. */
+export interface GroupChildRename {
+  nodeId: string;
+  from: string;
+  to: string;
+}
+
 export interface PrimarySwapPlan {
   renames: FileRename[];
   nodeUpdates: NodeFileUpdate[];
+  groupChildRenames: GroupChildRename[];
 }
 
-interface PlanNode {
+export interface PlanNode {
   id: string;
   parentId?: string | null;
+  type?: string;
   data?: unknown;
 }
 
@@ -92,8 +101,10 @@ interface PlanNode {
  * Compute the file renames + node configFile updates needed to make a new
  * primary MCU: the old primary's printer.cfg → {oldMcuName}.cfg, the new
  * primary's file → printer.cfg, and every affected node (hardware + its
- * children) repointed. Pure — returns a plan for the caller to apply via
- * store actions.
+ * children) repointed. Group nodes also carry a children array whose entries
+ * each record their own configFile — those are repointed via
+ * groupChildRenames so sidebar section resolution never hits a stale
+ * filename. Pure — returns a plan for the caller to apply via store actions.
  */
 export function planPrimarySwap(opts: {
   oldPrimaryId: string | null;
@@ -103,35 +114,43 @@ export function planPrimarySwap(opts: {
   nodes: PlanNode[];
 }): PrimarySwapPlan {
   const renames: FileRename[] = [];
-  const nodeUpdates: NodeFileUpdate[] = [];
 
   const fileOf = (n: PlanNode): string | undefined =>
     (n.data as { configFile?: string } | undefined)?.configFile;
 
   // Old primary: printer.cfg → {oldMcuName}.cfg
   if (opts.oldPrimaryId && opts.oldMcuName) {
-    const demotedFileName = demotedConfigFilename(opts.oldMcuName);
-    renames.push({ from: 'printer.cfg', to: demotedFileName });
-    nodeUpdates.push({ nodeId: opts.oldPrimaryId, configFile: demotedFileName });
-    for (const child of opts.nodes) {
-      if (child.parentId === opts.oldPrimaryId && fileOf(child) === 'printer.cfg') {
-        nodeUpdates.push({ nodeId: child.id, configFile: demotedFileName });
-      }
-    }
+    renames.push({ from: 'printer.cfg', to: demotedConfigFilename(opts.oldMcuName) });
   }
 
   // New primary: {newConfigFile} → printer.cfg
   if (opts.newConfigFile && opts.newConfigFile !== 'printer.cfg') {
     renames.push({ from: opts.newConfigFile, to: 'printer.cfg' });
-    nodeUpdates.push({ nodeId: opts.newPrimaryId, configFile: 'printer.cfg' });
-    for (const child of opts.nodes) {
-      if (child.parentId === opts.newPrimaryId && fileOf(child) === opts.newConfigFile) {
-        nodeUpdates.push({ nodeId: child.id, configFile: 'printer.cfg' });
+  }
+
+  // Repoint every node whose configFile matches a renamed file (top-level
+  // hardware + sub-component/feature/group nodes). Group nodes also carry a
+  // children array whose entries each record their own configFile — those are
+  // repointed via groupChildRenames so sidebar section resolution never hits
+  // a stale filename.
+  const nodeUpdates: NodeFileUpdate[] = [];
+  const groupChildRenames: GroupChildRename[] = [];
+  for (const r of renames) {
+    for (const n of opts.nodes) {
+      if (fileOf(n) === r.from) {
+        nodeUpdates.push({ nodeId: n.id, configFile: r.to });
+      }
+      if (n.type === 'group') {
+        const children = (n.data as { children?: Array<{ configFile?: string }> } | undefined)?.children;
+        if (!Array.isArray(children)) continue;
+        if (children.some((c) => c.configFile === r.from)) {
+          groupChildRenames.push({ nodeId: n.id, from: r.from, to: r.to });
+        }
       }
     }
   }
 
-  return { renames, nodeUpdates };
+  return { renames, nodeUpdates, groupChildRenames };
 }
 
 /** Apply a plan's file renames via a renameConfigFile-style callback. */
@@ -140,4 +159,36 @@ export function applyRenames(
   renameConfigFile: (from: string, to: string) => void,
 ): void {
   for (const r of plan.renames) renameConfigFile(r.from, r.to);
+}
+
+/**
+ * Apply a plan's node configFile updates via an updateNodeData-style
+ * callback (top-level hardware + sub-component/feature/group nodes).
+ */
+export function applyNodeUpdates(
+  plan: PrimarySwapPlan,
+  updateNodeData: (nodeId: string, data: { configFile: string }) => void,
+): void {
+  for (const u of plan.nodeUpdates) updateNodeData(u.nodeId, { configFile: u.configFile });
+}
+
+/**
+ * Apply a plan's group-child repoints: for each group node listed, rewrite
+ * every child entry whose configFile matches the renamed source file.
+ */
+export function applyGroupChildRenames(
+  plan: PrimarySwapPlan,
+  nodes: PlanNode[],
+  updateNodeData: (nodeId: string, data: { children: unknown }) => void,
+): void {
+  for (const g of plan.groupChildRenames) {
+    const groupNode = nodes.find((n) => n.id === g.nodeId);
+    if (!groupNode) continue;
+    const children = (groupNode.data as { children?: Array<{ configFile?: string; [k: string]: unknown }> } | undefined)?.children;
+    if (!Array.isArray(children)) continue;
+    const updated = children.map((c) =>
+      c.configFile === g.from ? { ...c, configFile: g.to } : c,
+    );
+    updateNodeData(g.nodeId, { children: updated });
+  }
 }

--- a/frontend/src/utils/mcuPrimary.ts
+++ b/frontend/src/utils/mcuPrimary.ts
@@ -1,0 +1,143 @@
+import type { ConfigFile, ConfigSection, SectionSchema } from '../types/config';
+import { updateAllSectionPins } from './pinUtils';
+
+/**
+ * Pure helpers for the MCU rename / primary promotion flow.
+ *
+ * The SettingsPanel orchestrates these against the stores; the file/name/pin
+ * math lives here so it's unit-testable and identical across every caller
+ * (MCU rename dialog, primary toggle, demote-with-name flow).
+ */
+
+/** Demoted primary's config file name: "Main Board" → "main_board.cfg". */
+export function demotedConfigFilename(mcuName: string): string {
+  return `${mcuName.toLowerCase().replace(/\s+/g, '_')}.cfg`;
+}
+
+/** Section header for an MCU: "mcu" (primary/unnamed) or "mcu <name>". */
+export function mcuHeaderFor(mcuName: string): string {
+  return mcuName ? `mcu ${mcuName}` : 'mcu';
+}
+
+/**
+ * Rename an MCU section ([mcu old] → [mcu new]) and rewrite pin prefixes on
+ * every section in the list (updateAllSectionPins handles the stepper/extruder
+ * etc. pin params). Returns a new sections array; inputs are untouched.
+ */
+export function renameMcuSections(
+  sections: ConfigSection[],
+  oldMcuName: string,
+  newMcuName: string,
+  schemas?: Record<string, SectionSchema>,
+): ConfigSection[] {
+  const oldHeader = mcuHeaderFor(oldMcuName);
+  const newHeader = mcuHeaderFor(newMcuName);
+  const renamed = sections.map((sec) => {
+    if (sec.full_header === oldHeader) {
+      return { ...sec, section_name: newMcuName, full_header: newHeader };
+    }
+    return sec;
+  });
+  return updateAllSectionPins(renamed, oldMcuName, newMcuName, schemas);
+}
+
+/**
+ * Apply an MCU rename across a target file plus any child config files that
+ * may reference the MCU's pins. Returns a NEW configFiles record (only the
+ * affected files replaced); inputs are untouched.
+ */
+export function applyMcuRenameToFiles(
+  configFiles: Record<string, ConfigFile>,
+  targetFile: string,
+  childFiles: string[],
+  oldMcuName: string,
+  newMcuName: string,
+  schemas?: Record<string, SectionSchema>,
+): Record<string, ConfigFile> {
+  const filesToUpdate = new Set([targetFile, ...childFiles]);
+  const next: Record<string, ConfigFile> = {};
+  for (const filename of Object.keys(configFiles)) {
+    next[filename] = configFiles[filename];
+  }
+  for (const filename of filesToUpdate) {
+    const cf = configFiles[filename];
+    if (!cf) continue;
+    next[filename] = { ...cf, sections: renameMcuSections(cf.sections, oldMcuName, newMcuName, schemas) };
+  }
+  return next;
+}
+
+export interface FileRename {
+  from: string;
+  to: string;
+}
+
+export interface NodeFileUpdate {
+  nodeId: string;
+  configFile: string;
+}
+
+export interface PrimarySwapPlan {
+  renames: FileRename[];
+  nodeUpdates: NodeFileUpdate[];
+}
+
+interface PlanNode {
+  id: string;
+  parentId?: string | null;
+  data?: unknown;
+}
+
+/**
+ * Compute the file renames + node configFile updates needed to make a new
+ * primary MCU: the old primary's printer.cfg → {oldMcuName}.cfg, the new
+ * primary's file → printer.cfg, and every affected node (hardware + its
+ * children) repointed. Pure — returns a plan for the caller to apply via
+ * store actions.
+ */
+export function planPrimarySwap(opts: {
+  oldPrimaryId: string | null;
+  oldMcuName: string;
+  newPrimaryId: string;
+  newConfigFile: string;
+  nodes: PlanNode[];
+}): PrimarySwapPlan {
+  const renames: FileRename[] = [];
+  const nodeUpdates: NodeFileUpdate[] = [];
+
+  const fileOf = (n: PlanNode): string | undefined =>
+    (n.data as { configFile?: string } | undefined)?.configFile;
+
+  // Old primary: printer.cfg → {oldMcuName}.cfg
+  if (opts.oldPrimaryId && opts.oldMcuName) {
+    const demotedFileName = demotedConfigFilename(opts.oldMcuName);
+    renames.push({ from: 'printer.cfg', to: demotedFileName });
+    nodeUpdates.push({ nodeId: opts.oldPrimaryId, configFile: demotedFileName });
+    for (const child of opts.nodes) {
+      if (child.parentId === opts.oldPrimaryId && fileOf(child) === 'printer.cfg') {
+        nodeUpdates.push({ nodeId: child.id, configFile: demotedFileName });
+      }
+    }
+  }
+
+  // New primary: {newConfigFile} → printer.cfg
+  if (opts.newConfigFile && opts.newConfigFile !== 'printer.cfg') {
+    renames.push({ from: opts.newConfigFile, to: 'printer.cfg' });
+    nodeUpdates.push({ nodeId: opts.newPrimaryId, configFile: 'printer.cfg' });
+    for (const child of opts.nodes) {
+      if (child.parentId === opts.newPrimaryId && fileOf(child) === opts.newConfigFile) {
+        nodeUpdates.push({ nodeId: child.id, configFile: 'printer.cfg' });
+      }
+    }
+  }
+
+  return { renames, nodeUpdates };
+}
+
+/** Apply a plan's file renames via a renameConfigFile-style callback. */
+export function applyRenames(
+  plan: PrimarySwapPlan,
+  renameConfigFile: (from: string, to: string) => void,
+): void {
+  for (const r of plan.renames) renameConfigFile(r.from, r.to);
+}

--- a/frontend/src/utils/sectionResolver.ts
+++ b/frontend/src/utils/sectionResolver.ts
@@ -1,0 +1,46 @@
+import type { ConfigFile, ConfigSection } from '@/types/config';
+
+export interface ResolvedSection {
+  section: ConfigSection;
+  filename: string;
+}
+
+/**
+ * Resolve a section by (header, file?, line?).
+ *
+ * When a config file is carried, that file is authoritative: search it first
+ * by exact line match when a line is known, then by header alone. If the
+ * carried file has no match, return null — never fall through to a
+ * duplicate header in another file (that is the bug this util fixes).
+ *
+ * Cross-file search happens only when NO file is carried (legacy behavior),
+ * preferring an exact line match when one is known.
+ *
+ * Returns null when nothing matches.
+ */
+export function resolveSection(
+  configFiles: Record<string, ConfigFile>,
+  header: string | null,
+  configFile?: string | null,
+  lineNumber?: number | null,
+): ResolvedSection | null {
+  if (!header) return null;
+
+  const lineMatch = (s: ConfigSection) =>
+    lineNumber == null || lineNumber === 0 || s.line_number === lineNumber;
+
+  if (configFile) {
+    const cf = configFiles[configFile];
+    if (!cf) return null;
+    const found = cf.sections.find((s) => s.full_header === header && lineMatch(s));
+    if (found) return { section: found, filename: configFile };
+    return null;
+  }
+
+  // Fallback: search across all config files (legacy behavior)
+  for (const [filename, cf] of Object.entries(configFiles)) {
+    const found = cf.sections.find((s) => s.full_header === header && lineMatch(s));
+    if (found) return { section: found, filename };
+  }
+  return null;
+}

--- a/frontend/src/utils/sectionSuppress.ts
+++ b/frontend/src/utils/sectionSuppress.ts
@@ -1,0 +1,40 @@
+import type { ConfigSection } from '../types/config';
+
+/**
+ * Toggle a section's suppressed (commented-out) state while preserving
+ * per-param comment state.
+ *
+ * Suppressing comments out every real param AND records each param's prior
+ * `is_commented_out` in `suppressedParams`. Unsuppressing restores that
+ * recorded state — so params the user individually commented stay commented —
+ * rather than enabling everything. Sections with no recorded snapshot (e.g.
+ * loaded from disk already suppressed) enable all params on unsuppress, which
+ * matches the old behavior.
+ *
+ * `_comment_` pseudo-params (standalone comment lines) are never touched.
+ */
+export function toggleSectionSuppressed(
+  section: ConfigSection,
+  suppress: boolean,
+): ConfigSection {
+  if (suppress) {
+    const suppressedParams: Record<string, boolean> = {};
+    const params = section.params.map((p) => {
+      if (p.key === '_comment_') return p;
+      // Record the pre-suppress state so unsuppress can restore it.
+      suppressedParams[p.key] = p.is_commented_out;
+      return { ...p, is_commented_out: true };
+    });
+    return { ...section, is_commented_out: true, suppressedParams, params };
+  }
+
+  const prior = section.suppressedParams;
+  const params = section.params.map((p) => {
+    if (p.key === '_comment_') return p;
+    const wasCommented = prior ? prior[p.key] : undefined;
+    // Restore the recorded pre-suppress state; unknown params enable.
+    return { ...p, is_commented_out: wasCommented ?? false };
+  });
+  const { suppressedParams: _dropped, ...rest } = section;
+  return { ...rest, is_commented_out: false, params };
+}

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -485,9 +485,42 @@ def test_save_configs(monkeypatch, tmp_path):
     })
 
     assert response.status_code == 200
-    assert response.json() == {'saved': ['printer.cfg', 'other.cfg'], 'file_count': 2}
+    assert response.json() == {'saved': ['printer.cfg', 'other.cfg'], 'removed': [], 'file_count': 2}
     assert (tmp_path / 'printer.cfg').exists()
     assert (tmp_path / 'other.cfg').exists()
+
+
+def test_save_configs_deletes_removed_files(monkeypatch, tmp_path):
+    monkeypatch.setattr(routes, 'CONFIG_STORAGE_DIR', tmp_path)
+    (tmp_path / 'printer.cfg').write_text(SIMPLE_CFG, encoding='utf-8')
+    (tmp_path / 'toolhead_board.cfg').write_text(OTHER_CFG, encoding='utf-8')
+
+    response = client.post('/api/configs/save', json={
+        'files': {
+            'printer.cfg': SIMPLE_CFG,
+        },
+        'deleted': ['toolhead_board.cfg'],
+    })
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body['saved'] == ['printer.cfg']
+    assert body['removed'] == ['toolhead_board.cfg']
+    assert (tmp_path / 'printer.cfg').exists()
+    assert not (tmp_path / 'toolhead_board.cfg').exists()
+
+
+def test_save_configs_deletes_only_files_that_exist(monkeypatch, tmp_path):
+    monkeypatch.setattr(routes, 'CONFIG_STORAGE_DIR', tmp_path)
+
+    response = client.post('/api/configs/save', json={
+        'files': {'printer.cfg': SIMPLE_CFG},
+        'deleted': ['ghost.cfg'],
+    })
+
+    assert response.status_code == 200
+    assert response.json()['removed'] == []
+    assert not (tmp_path / 'ghost.cfg').exists()
 
 
 def test_save_configs_rejects_path_traversal(monkeypatch, tmp_path):
@@ -503,6 +536,19 @@ def test_save_configs_rejects_path_traversal(monkeypatch, tmp_path):
     assert response.status_code == 200
     assert response.json()['saved'] == ['good.cfg']
     assert 'Invalid filename: ../../evil.cfg' in response.json()['errors']
+
+
+def test_save_configs_rejects_traversal_in_deleted(monkeypatch, tmp_path):
+    monkeypatch.setattr(routes, 'CONFIG_STORAGE_DIR', tmp_path)
+
+    response = client.post('/api/configs/save', json={
+        'files': {'printer.cfg': SIMPLE_CFG},
+        'deleted': ['../evil.cfg'],
+    })
+
+    assert response.status_code == 200
+    assert 'Invalid filename: ../evil.cfg' in response.json()['errors']
+    assert not (tmp_path.parent / 'evil.cfg').exists()
 
 
 def test_save_configs_no_files():

--- a/tests/test_native_firmware_routes.py
+++ b/tests/test_native_firmware_routes.py
@@ -12,6 +12,41 @@ from main import app  # noqa: E402
 client = TestClient(app)
 
 
+def test_native_apply_deletes_removed_files(monkeypatch, tmp_path):
+    """Deleting a file in the model must remove it from the Pi config dir."""
+    monkeypatch.setattr(native_routes, 'is_native_platform', lambda: True)
+    monkeypatch.setattr(native_routes, 'load_settings', lambda: {})
+    monkeypatch.setattr(native_routes, 'get_default_config_path', lambda: str(tmp_path))
+    (tmp_path / 'printer.cfg').write_text('[printer]\nkinematics: cartesian\n', encoding='utf-8')
+    (tmp_path / 'toolhead_board.cfg').write_text('[mcu toolhead]\nserial: /dev/serial/by-id/x\n', encoding='utf-8')
+
+    response = client.post('/api/native/apply', json={
+        'files': {'printer.cfg': '[printer]\nkinematics: cartesian\n'},
+        'deleted': ['toolhead_board.cfg'],
+    })
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body['files'] == ['printer.cfg']
+    assert body['removed'] == ['toolhead_board.cfg']
+    assert (tmp_path / 'printer.cfg').exists()
+    assert not (tmp_path / 'toolhead_board.cfg').exists()
+
+
+def test_native_apply_rejects_traversal_in_deleted(monkeypatch, tmp_path):
+    monkeypatch.setattr(native_routes, 'is_native_platform', lambda: True)
+    monkeypatch.setattr(native_routes, 'load_settings', lambda: {})
+    monkeypatch.setattr(native_routes, 'get_default_config_path', lambda: str(tmp_path))
+
+    response = client.post('/api/native/apply', json={
+        'files': {'printer.cfg': '[printer]\nkinematics: cartesian\n'},
+        'deleted': ['../evil.cfg'],
+    })
+
+    assert response.status_code == 400
+    assert not (tmp_path.parent / 'evil.cfg').exists()
+
+
 def test_klipper_firmware_state_returns_service_payload(monkeypatch):
     payload = {
         'available': True,


### PR DESCRIPTION
## Summary

Five phases of graph-view work on the KWC printer-configuration graph: config mutations from the sidebar/graph are now undoable and dirty-marking, section selection is duplicate-header safe, layout + trace positions persist, comm-type toggling no longer corrupts the serial device, edge routing is stable, MCU rename/primary-swap logic is extracted to a tested util, and stale file/header references after renames are repointed so the sidebar never blanks.

**Key changes**
- **Config store** — `updateConfigFile` dirty-marking; `renameConfigFile` remaps `selectedSectionFile` (sidebar survives file renames)
- **Graph store** — layout persistence (native + browser localStorage), undo history for sidebar mutations, MCU dialog cancel is lossless, edge redraw no longer dirties config, delete comments the include regardless of draw direction, drag-snap respects expanded group heights
- **Section resolution** — carries file+line (duplicate-header safe); `sectionResolver.ts`, `sectionSuppress.ts` extracted as pure utils
- **MCU primary flow** — extracted to `mcuPrimary.ts` (`applyMcuRenameToFiles`, `planPrimarySwap`, `renameMcuSections`); primary swap now repoints ALL nodes (incl. standalone) + group children; `applyMcuNameChange` repoints child MCU section headers
- **Shared constants** — `constants/graphLayout.ts`, `constants/graphColors.ts` (single source of truth)
- **Comm menu** — type toggle changes line color + detect field only, never the serial value (matches v2.1)

## Test Plan
- Backend: `381 passed` (pytest, repo root)
- Frontend: `491 passed` (vitest), `tsc -b` clean
- CI: backend + frontend jobs green on branch pushes
- Manual validation (user): trace/card position persistence, comm-type toggle, suppress-comment preservation, drag-snap, MCU rename/primary flow

## Commits
30 commits: `8c9e1d8..54d7ffe` — fix(graph)/feat(graph)/refactor(graph) with regression tests for each behavior change.