### PR TITLE
fix(user-validation): validation hardening, install reliability, AI chat improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,9 @@ After install, proceed to http://{your_ip_here}:8099
 
 ### Moonraker update_manager
 
-If you want Moonraker to manage updates in Mainsail or Fluidd, add the following section to `moonraker.conf`:
+The installer automatically registers KWC with Moonraker's update manager when it finds a `moonraker.conf` (kiauh layout: `~/printer_data/config/moonraker.conf`): it writes a dedicated `klipper-wire-configurator-update.cfg` include file (same pattern as obico's) and adds `[include klipper-wire-configurator-update.cfg]` to the config. Updates then appear in Mainsail/Fluidd's update manager. Uninstall removes the include file and line.
+
+To manage it manually instead, add the following section to `moonraker.conf`:
 
 ```ini
 [update_manager klipper-wire-configurator]

--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ info_tags:
 	desc=Klipper Wire Configurator
 ```
 
+### Mainsail sidebar link
+
+If Mainsail is detected on the machine (its `~/mainsail` install or an `[update_manager mainsail]` entry in `moonraker.conf`), the installer adds a **KWC** entry to Mainsail's custom navigation — it writes `navi.json` into the `.theme` folder inside the Klipper config directory (`~/printer_data/config/.theme` on kiauh installs). The link opens `http://<this-host>:8099` in a new tab, positioned below Machine. Fluidd and OctoPrint have no custom-navigation support, so nothing is written for them. Re-running the installer (or `--uninstall`) adds/removes only the KWC entry, leaving any other custom navigation entries untouched.
+
 ### Uninstall
 
 If you installed into `~/Klipper-Wire-Configurator`:

--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 # Klipper Wire Configurator
 
-Klipper Wire Configurator is a web-based tool for inspecting, creating, and editing Klipper `printer.cfg` files with an intuitive graphical interface. It simplifies configuration management by providing visual tools to view connections, add components from the official reference, validate settings in real-time, and apply changes directly to your printer. The software runs locally on your SBC and is completely free and open-source under the GPL3 license.
+Klipper Wire Configurator (KWC) is a web-based tool for inspecting, creating, and editing Klipper configuration files with an intuitive graphical interface. It simplifies configuration management by providing visual tools to view links between files, see communication paths, add components and features from the official reference, validate settings in real-time against the klipper runtime, and apply changes directly to your printer configuration files. The software runs locally on your SBC and is completely free and open-source under the GPL3 license.
 
 Special thanks to the Klipper, Mainsail, Moonraker, Fluidd, and other teams whose work was heavily referenced for this project.
 
 ## Table of contents
 
 - [Features](#features)
-- [AI Chat](docs/AI_CHAT.md)
 - [Installing](#installing/uninstalling)
 - [Troubleshooting](#troubleshooting)
 - [Development](#development)
@@ -16,9 +15,9 @@ Special thanks to the Klipper, Mainsail, Moonraker, Fluidd, and other teams whos
 
 ### Visual Tools
 
-- View your printer's hardware as interactive cards and wires—MCUs, steppers, heaters, probes, and more.
-- Add any Klipper component directly from the official Config Reference documentation.
-- Import example configurations organized by board type (Mainboard, Toolhead, Probe, Expander) with fuzzy search.
+- View your printer's hardware as interactive cards and connection wires.
+- Add any Klipper component or feature directly from the official Config Reference documentation.
+- Import example configurations organized by board type (Mainboard, Toolhead, Probe, Expander).
 - Delete, modify, or reposition components using drag-and-drop interactions.
 - Auto-detect and manage USB, UART, and CAN communications with ID detection.
 
@@ -26,12 +25,12 @@ Special thanks to the Klipper, Mainsail, Moonraker, Fluidd, and other teams whos
 
 - See validation warnings and errors in real-time as you edit to catch mistakes before they cause runtime failures.
 - Review a side-by-side diff of your changes before exporting or applying them to your printer.
-- Save and apply configuration updates directly, then manually restart Klipper when ready.
+- Save and apply configuration updates directly.
 - Edit files in Text View with multi-file fuzzy search, per-line error highlighting, and traditional config management.
 
 ### Advanced Features
 
-- Create, manage, and simulate macros that reflects your printer configuration.
+- Create, manage, and simulate macros that reflect your printer configuration.
 - Add an AI assistant that references official Klipper documentation, Config Reference excerpts, and your current config with explicit review and approval before applying ([read about it](docs/AI_CHAT.md)).
 - Build, download, and flash Katapult and Klipper firmware directly from the UI.
 
@@ -75,18 +74,14 @@ Special thanks to the Klipper, Mainsail, Moonraker, Fluidd, and other teams whos
 <img src="images/AI_Chat.png" width="100%">
 <div style="height: 45%;"></div>
 
-## AI Chat
-
-The AI assistant answers Klipper questions and drafts config changes, macros, and printer-memory updates using the bundled Klipper documentation, example configs, and your loaded project files. Nothing the assistant produces touches your config until you review and approve it in the draft preview dialog.
-
-The full [AI Chat guide](docs/AI_CHAT.md) covers configuration, how a request flows from prompt to file edit, the draft-block file-edit protocol, printer memory, and the accuracy test results for the models we've benchmarked.
-
 ## Prerequisites
 
-- Raspberry Pi OS or another Debian-based distribution. Must be bookworm or newer.
+- Raspberry Pi OS or another linux distribution. Must be bookworm or newer. 
 - Python 3.10+
 - Git and internet access for the initial install.
 - Klipper
+- Moonraker
+- Mainsail/Fluidd
 - Katapult (optional)
 
 ## Installing/Uninstalling
@@ -104,10 +99,14 @@ bash scripts/install.sh
 
 Run **without sudo** — the installer escalates internally wherever needed (apt, systemd, and writes into the Moonraker config dir). `sudo bash scripts/install.sh` resets `$HOME` to `/root`, so the Moonraker config directory isn't found, the update_manager/Mainsail sidebar setup is silently skipped, and the app installs into `/root` instead of your user's home.
 
-Note: On 32-bit Raspberry Pi OS (`armv7` / `armhf`), the installer automatically uses the distro `nodejs` package. I haven't tried 64-bit, YMMV.
+Note: On 32-bit Raspberry Pi OS (`armv7` / `armhf`), the installer automatically uses the distro `nodejs` package.
 A successful install ends by checking the service health and printing the installer log path under `/tmp/klipper-wire-configurator-install-*.log`.
 
-After install, proceed to http://{your_ip_here}:8099
+### Mainsail sidebar link
+
+If you are using Mainsail the installer adds a **KWC** entry to Mainsail's custom navigation — it writes `navi.json` into the `.theme` folder inside the Klipper config directory (`~/printer_data/config/.theme` on kiauh installs). The link opens `http://<this-host>:8099` in a new tab, positioned below Machine. Re-running the installer (or `--uninstall`) adds/removes only the KWC entry, leaving any other custom navigation entries untouched.
+
+If using Fluidd or Octoprint, proceed to http://{your_ip_here}:8099 
 
 ### Moonraker update_manager
 
@@ -128,10 +127,6 @@ managed_services: klipper-wire-configurator
 info_tags:
 	desc=Klipper Wire Configurator
 ```
-
-### Mainsail sidebar link
-
-If Mainsail is detected on the machine (its `~/mainsail` install or an `[update_manager mainsail]` entry in `moonraker.conf`), the installer adds a **KWC** entry to Mainsail's custom navigation — it writes `navi.json` into the `.theme` folder inside the Klipper config directory (`~/printer_data/config/.theme` on kiauh installs). The link opens `http://<this-host>:8099` in a new tab, positioned below Machine. Fluidd and OctoPrint have no custom-navigation support, so nothing is written for them. Re-running the installer (or `--uninstall`) adds/removes only the KWC entry, leaving any other custom navigation entries untouched.
 
 ### Uninstall
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ cd Klipper-Wire-Configurator
 bash scripts/install.sh
 ```
 
+Run **without sudo** — the installer escalates internally wherever needed (apt, systemd, and writes into the Moonraker config dir). `sudo bash scripts/install.sh` resets `$HOME` to `/root`, so the Moonraker config directory isn't found, the update_manager/Mainsail sidebar setup is silently skipped, and the app installs into `/root` instead of your user's home.
+
 Note: On 32-bit Raspberry Pi OS (`armv7` / `armhf`), the installer automatically uses the distro `nodejs` package. I haven't tried 64-bit, YMMV.
 A successful install ends by checking the service health and printing the installer log path under `/tmp/klipper-wire-configurator-install-*.log`.
 

--- a/backend/api/ai_routes.py
+++ b/backend/api/ai_routes.py
@@ -1686,6 +1686,37 @@ def _extract_provider_content(provider: str, data: dict) -> str:
     return data.get("choices", [{}])[0].get("message", {}).get("content", "")
 
 
+def _extract_usage_info(data: dict) -> dict | None:
+    """Extract token usage + finish_reason from a provider response.
+
+    Used to surface per-turn budget consumption in /ai/chat responses so the
+    accuracy harness can tell a truncated answer (finish_reason=length) from
+    a genuinely wrong one. Thinking models report reasoning tokens under
+    usage.completion_tokens_details.reasoning_tokens — those count against the
+    same max_tokens budget as visible content.
+    """
+    if not isinstance(data, dict):
+        return None
+    usage = data.get("usage")
+    if not isinstance(usage, dict):
+        return None
+    choice = (data.get("choices") or [{}])[0]
+    completion_tokens = usage.get("completion_tokens")
+    if not isinstance(completion_tokens, int):
+        return None
+    details = usage.get("completion_tokens_details")
+    reasoning_tokens = None
+    if isinstance(details, dict):
+        rt = details.get("reasoning_tokens")
+        if isinstance(rt, int):
+            reasoning_tokens = rt
+    return {
+        "completionTokens": completion_tokens,
+        "reasoningTokens": reasoning_tokens,
+        "finishReason": choice.get("finish_reason") or "",
+    }
+
+
 def _build_api_base_url(api_url: str) -> str:
     parsed = urlparse(api_url)
     if not parsed.scheme or not parsed.netloc:
@@ -1848,6 +1879,11 @@ async def chat_proxy(req: ChatRequest):
                 logger_context="initial",
                 stop_event=stop_event,
             )
+            usage_events: list[dict] = []
+            initial_usage = _extract_usage_info(current_data)
+            if initial_usage:
+                initial_usage["context"] = "initial"
+                usage_events.append(initial_usage)
 
             tool_turns = 0
             current_messages = list(messages)
@@ -1905,6 +1941,10 @@ async def chat_proxy(req: ChatRequest):
                             logger_context="config-fallback",
                             stop_event=stop_event,
                         )
+                        cfg_usage = _extract_usage_info(current_data)
+                        if cfg_usage:
+                            cfg_usage["context"] = "config-fallback"
+                            usage_events.append(cfg_usage)
 
             # ── Auto-search fallback ──
             # If the model didn't call any tools on the first pass, do a backend
@@ -1951,6 +1991,10 @@ async def chat_proxy(req: ChatRequest):
                             logger_context="auto-search",
                             stop_event=stop_event,
                         )
+                        search_usage = _extract_usage_info(current_data)
+                        if search_usage:
+                            search_usage["context"] = "auto-search"
+                            usage_events.append(search_usage)
 
             while tool_turns < MAX_MCP_TOOL_TURNS:
                 if stop_event is not None and stop_event.is_set():
@@ -2047,6 +2091,10 @@ async def chat_proxy(req: ChatRequest):
                     logger_context=f"tool-turn-{tool_turns}",
                     stop_event=stop_event,
                 )
+                turn_usage = _extract_usage_info(current_data)
+                if turn_usage:
+                    turn_usage["context"] = f"tool-turn-{tool_turns}"
+                    usage_events.append(turn_usage)
 
             # Clean up any remaining tool call blocks in the final content.
             # Check whether the content contained tool call blocks BEFORE cleanup
@@ -2115,6 +2163,10 @@ async def chat_proxy(req: ChatRequest):
                     logger_context=f"empty-reprompt-{empty_reprompts}",
                     stop_event=stop_event,
                 )
+                retry_usage = _extract_usage_info(current_data)
+                if retry_usage:
+                    retry_usage["context"] = f"empty-reprompt-{empty_reprompts}"
+                    usage_events.append(retry_usage)
 
                 # Some models (DeepSeek "flash", Qwen, ...) ignore the
                 # no-tools instruction and emit tool calls as plain text —
@@ -2196,6 +2248,18 @@ async def chat_proxy(req: ChatRequest):
                 "mcpToolNames": mcp_tool_names,
                 "toolCalls": executed_tool_calls,
                 "repromptCount": empty_reprompts,
+                "usage": {
+                    "completionTokens": sum(
+                        (e.get("completionTokens") or 0) for e in usage_events
+                    ),
+                    "reasoningTokens": sum(
+                        (e.get("reasoningTokens") or 0) for e in usage_events
+                    ),
+                    "events": usage_events,
+                    "truncated": any(
+                        (e.get("finishReason") or "") == "length" for e in usage_events
+                    ),
+                },
             }
         except ChatStoppedError:
             logger.info("Chat stopped by user | requestId=%s", req.requestId)

--- a/backend/api/ai_routes.py
+++ b/backend/api/ai_routes.py
@@ -105,6 +105,17 @@ FUNC_CALL_CLEANUP_RE = re.compile(
     r"(?:^|\n)\s*(?:call[\s:]?\s*)?(?:tool_call[\s:]*)?\w+\s*\([^)]*\)\s*(?=\n|$)",
     re.DOTALL,
 )
+# Bracket-wrapped Python-style calls: [tool_name(arg1="val1", arg2=val2)].
+# Emitted as plain text by models that know the OpenAI-style [tool(args)]
+# rendering but not the configured protocol (observed 2026-08 on local
+# models: [read_user_config(filename=Hotkey.cfg)] leaked into chat because
+# FUNC_CALL_RE is line-anchored and the '[' defeats it). Extraction and
+# cleanup are gated on KNOWN tool names so config headers ([probe]) and
+# prose with parens are never treated as calls.
+BRACKET_CALL_RE = re.compile(
+    r"\[\s*(\w+)\s*\(\s*(.+?)\s*\)\s*\]",
+    re.DOTALL,
+)
 # DeepSeek DSML (Data Structure Markup Language) native tool-call markup.
 # DeepSeek V3.2/V4 models emit tool calls as:
 #   <||DSML||tool_calls>
@@ -1126,6 +1137,21 @@ def _extract_tool_calls(text: str) -> list[dict]:
                 arguments[key] = value
         calls.append({"name": name, "arguments": arguments})
 
+    # Format 7: bracket-wrapped calls [name(k=v, ...)] (see BRACKET_CALL_RE).
+    # Gated on known tool names — config headers ([probe]) and prose with
+    # parens must never extract as calls.
+    known_tool_names = {t["name"] for t in _mcp_server._list_tools()}
+    for bracket_match in BRACKET_CALL_RE.finditer(text):
+        content = bracket_match.group(0).strip()
+        if not content or content in seen_contents:
+            continue
+        name = bracket_match.group(1).strip()
+        if name not in known_tool_names:
+            continue
+        seen_contents.add(content)
+        arguments = _parse_kwargs(bracket_match.group(2).strip())
+        calls.append({"name": name, "arguments": arguments})
+
     if calls:
         names = [c["name"] for c in calls]
         logger.debug("Extracted %d tool call(s): %s", len(calls), names)
@@ -1146,6 +1172,20 @@ def _parse_kwargs(args_text: str) -> dict:
         arg_value = arg_match.group(2).strip().strip('"').strip("'")
         arguments[arg_name] = arg_value
     return arguments
+
+
+def _strip_bracket_tool_calls(text: str) -> str:
+    """Strip bracket-wrapped tool calls whose name is a REAL tool.
+
+    Name-gated mirror of BRACKET_CALL_RE: only known tool names are removed,
+    so config section headers ([probe], [include printer.cfg]) and prose with
+    parens survive the cleanup chain.
+    """
+    known_tool_names = {t["name"] for t in _mcp_server._list_tools()}
+    return BRACKET_CALL_RE.sub(
+        lambda m: "" if m.group(1).strip() in known_tool_names else m.group(0),
+        text,
+    )
 
 
 # llama.cpp/Gemma text-protocol templates wrap tool calls in decoration
@@ -1988,6 +2028,7 @@ async def chat_proxy(req: ChatRequest):
                         clean_content = ALT_TOOL_CALL_CONTENT_RE.sub("", clean_content).strip()
                         clean_content = CALL_SYNTAX_CLEANUP_RE.sub("", clean_content).strip()
                         clean_content = FUNC_CALL_CLEANUP_RE.sub("", clean_content).strip()
+                        clean_content = _strip_bracket_tool_calls(clean_content).strip()
                         clean_content = DSML_CLEANUP_RE.sub("", clean_content).strip()
                         clean_content = XML_TOOL_CALLS_CLEANUP_RE.sub("", clean_content).strip()
                         if clean_content:
@@ -2022,6 +2063,7 @@ async def chat_proxy(req: ChatRequest):
             final_content = ALT_TOOL_CALL_CONTENT_RE.sub("", final_content).strip()
             final_content = CALL_SYNTAX_CLEANUP_RE.sub("", final_content).strip()
             final_content = FUNC_CALL_CLEANUP_RE.sub("", final_content).strip()
+            final_content = _strip_bracket_tool_calls(final_content).strip()
             final_content = DSML_CLEANUP_RE.sub("", final_content).strip()
             # If the cleanup left nothing but the original was a tool call,
             # don't restore the raw tool call text — return empty instead.
@@ -2095,6 +2137,7 @@ async def chat_proxy(req: ChatRequest):
                     clean_assistant = ALT_TOOL_CALL_CONTENT_RE.sub("", clean_assistant).strip()
                     clean_assistant = CALL_SYNTAX_CLEANUP_RE.sub("", clean_assistant).strip()
                     clean_assistant = FUNC_CALL_CLEANUP_RE.sub("", clean_assistant).strip()
+                    clean_assistant = _strip_bracket_tool_calls(clean_assistant).strip()
                     clean_assistant = DSML_CLEANUP_RE.sub("", clean_assistant).strip()
                     clean_assistant = XML_TOOL_CALLS_CLEANUP_RE.sub("", clean_assistant).strip()
                     if clean_assistant:
@@ -2117,6 +2160,7 @@ async def chat_proxy(req: ChatRequest):
                 final_content = ALT_TOOL_CALL_CONTENT_RE.sub("", final_content).strip()
                 final_content = CALL_SYNTAX_CLEANUP_RE.sub("", final_content).strip()
                 final_content = FUNC_CALL_CLEANUP_RE.sub("", final_content).strip()
+                final_content = _strip_bracket_tool_calls(final_content).strip()
                 final_content = DSML_CLEANUP_RE.sub("", final_content).strip()
                 final_content = XML_TOOL_CALLS_CLEANUP_RE.sub("", final_content).strip()
 

--- a/backend/parser/config_parser.py
+++ b/backend/parser/config_parser.py
@@ -139,6 +139,10 @@ NAMED_SECTION_TYPES = {
     "adxl345", "lis2dw", "lis3dh", "bmi160", "mpu9250", "icm20948",
     "angle", "probe_eddy_current",
     "axis_twist_compensation", "smart_effector",
+    # Moonraker update_manager entries: `[update_manager <name>]` sections
+    # live in moonraker.conf (not Klipper), but they are a legitimate named
+    # section type and must not be flagged as unknown by the validator.
+    "update_manager",
 }
 
 

--- a/backend/parser/config_schema.py
+++ b/backend/parser/config_schema.py
@@ -2057,6 +2057,35 @@ _register(SectionDef(
     params=[],
 ))
 
+# ── Moonraker ──
+# `[update_manager <name>]` sections are Moonraker config (not Klipper), so
+# they have no Klipper schema — register them as a known named section so the
+# validator stops flagging every one as "Unknown section type". No params are
+# required; the common Moonraker options are listed for form rendering.
+_register(SectionDef(
+    section_type="update_manager",
+    display_name="Moonraker Update Manager",
+    category="config_helper",
+    component_group="system",
+    is_named=True,
+    description="Moonraker update_manager entry (git_repo/web/command...) — validated by Moonraker, not Klipper",
+    params=[
+        _str("type", "Update source type (git_repo, web, command, zip, json_file)"),
+        _str("repo", "GitHub repo (owner/name)"),
+        _str("path", "Local path of the installed software"),
+        _str("origin", "Git remote origin URL"),
+        _str("primary_branch", "Primary branch tracked for updates"),
+        _str("channel", "Release channel (stable/beta/dev)"),
+        _str("managed_services", "Systemd services to restart after update"),
+        _str("install_script", "Path to the install script"),
+        _str("requirements", "Path to a pip requirements file"),
+        _str("system_dependencies", "System packages to install"),
+        _str("virtualenv", "Path to the virtualenv to update"),
+        _str("env", "Environment variables for the update command"),
+        _int("refresh_interval", "Update check interval (hours)"),
+    ],
+))
+
 
 def get_section_def(section_type: str) -> Optional[SectionDef]:
     """Get the schema for a section type."""

--- a/backend/parser/validator.py
+++ b/backend/parser/validator.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
+from functools import lru_cache
 from typing import Optional
 
 import jinja2
@@ -332,6 +333,30 @@ _MACRO_JINJA_ENV = jinja2.Environment("{%", "%}", "{", "}")
 # Section types whose gcode bodies are Jinja templates evaluated by Klipper.
 _MACRO_TEMPLATE_SECTIONS = frozenset({"gcode_macro", "delayed_gcode"})
 
+# Compile results are cached by comment-stripped body: project validation runs
+# on every load (and per file), so a config with many macros spends most of its
+# startup time re-parsing the same template text. Line numbers returned are
+# body-relative and re-based at call time, so cached entries are safe to reuse
+# across sections/files. Bounded to keep memory in check.
+@lru_cache(maxsize=2048)
+def _compile_macro_template(body: str) -> tuple[str, int] | None:
+    """Compile a stripped gcode body as Klipper Jinja.
+
+    Returns None when the template is valid, or (message, body_lineno) on a
+    TemplateSyntaxError. body_lineno is 1-indexed within the gcode body.
+    """
+    # A body with no '{' at all is plain text — jinja2 can never raise on it.
+    # ~half of real-world macros are plain G-code, so skip the compile entirely
+    # (behavior-identical: from_string on text-only templates always succeeds).
+    if "{" not in body:
+        return None
+    try:
+        _MACRO_JINJA_ENV.from_string(body)
+        return None
+    except jinja2.exceptions.TemplateSyntaxError as exc:
+        # str(None) renders "None" — same output the caller's f-string produced.
+        return (str(exc.message), exc.lineno)
+
 
 def _strip_inline_comments(body: str) -> str:
     """Mirror Klipper's config parsing before templates reach jinja2.
@@ -371,21 +396,22 @@ def _validate_macro_jinja(section: ConfigSection, result: ValidationResult) -> N
     body = gcode_param.value
     if not body.strip():
         return
-    try:
-        # Klipper strips inline #/; comments from every config line before
-        # the body is templated; do the same so community comment styles do
-        # not false-positive.
-        _MACRO_JINJA_ENV.from_string(_strip_inline_comments(body))
-    except jinja2.exceptions.TemplateSyntaxError as exc:
-        # exc.lineno is 1-indexed within the gcode body, which starts on the
-        # line after the 'gcode:' key.
-        result.errors.append(ValidationError(
-            severity="error",
-            section=section.full_header,
-            param="gcode",
-            message=f"Jinja template error in macro: {exc.message}",
-            line_number=gcode_param.line_number + exc.lineno,
-        ))
+    # Klipper strips inline #/; comments from every config line before
+    # the body is templated; do the same so community comment styles do
+    # not false-positive.
+    outcome = _compile_macro_template(_strip_inline_comments(body))
+    if outcome is None:
+        return
+    message, body_lineno = outcome
+    # body_lineno is 1-indexed within the gcode body, which starts on the
+    # line after the 'gcode:' key.
+    result.errors.append(ValidationError(
+        severity="error",
+        section=section.full_header,
+        param="gcode",
+        message=f"Jinja template error in macro: {message}",
+        line_number=gcode_param.line_number + body_lineno,
+    ))
 
 
 def validate_config(config: ConfigFile, *, is_multi_file: bool = False) -> ValidationResult:

--- a/backend/services/warning_acknowledgments.py
+++ b/backend/services/warning_acknowledgments.py
@@ -26,12 +26,17 @@ def _acknowledged_warnings_file() -> Path:
 
 
 def _serialize_param_value(value: str) -> list[str]:
-    parts = value.split("\n")
-    if len(parts) <= 1:
-        return [parts[0]]
-    lines = [parts[0]]
-    lines.extend(f"    {part}" for part in parts[1:])
-    return lines
+    """Split a param value into its physical lines for the canonical snippet.
+
+    Continuation lines MUST be emitted verbatim — with the exact indentation
+    the parser captured in the value. The acknowledgment comparison is
+    ``canonicalize_section(live) == canonicalize_section(parse(stored))``, and
+    the parser preserves continuation-line whitespace as-is. Any re-indentation
+    here inflates on every write->parse cycle, so the stored snippet never
+    matches the live config (real case: ``[update_manager moonraker-obico]``
+    with an indented ``managed_services:`` block could never be acknowledged).
+    """
+    return value.split("\n")
 
 
 def canonicalize_section(section: ConfigSection) -> str:

--- a/docs/AI_CHAT.md
+++ b/docs/AI_CHAT.md
@@ -1,6 +1,8 @@
 # AI Chat
 
-The KWC AI assistant answers Klipper questions and drafts config changes, macros, and printer-memory updates using the bundled Klipper documentation, example configs, and your loaded project files. Nothing the assistant produces touches your config until you review and approve it in the draft preview dialog.
+The KWC AI assistant answers Klipper questions and drafts config changes, macros, and printer-memory updates using the bundled Klipper documentation, example configs, and your loaded project files. Nothing the assistant produces touches your config until you review and approve it in the draft preview dialog. The docs MCP points to your active config file path and the installed Klipper folder. This ensures the docs referenced match your installed version of Klipper and stay up to date.
+
+I'm still experimenting with this feature, learning new ways help the model create accurate and desired outputs. My goal is for this to be entirely reliable using only a small local model.
 
 ## Configuration
 
@@ -10,17 +12,22 @@ Open the chat from the toolbar, then click the settings button to configure:
 - **API key** — required only for cloud providers; local servers usually don't need one.
 - **Model** — any model the provider exposes; the model list is fetched from your endpoint.
 - **Max tokens** — cap on the assistant's reply length (default 4096).
+- **Temperature** — sets the model temperature (default 0.7)
+- **Tool Format** — only for openAI compatible providers, allows a native tool calling or text protocol format (default Auto)
 
 Provider settings, conversation history, and attached config files persist locally and are restored when you reopen a saved conversation.
 
 ## How a request works, from prompt to file edit
 
-1. **You send a message.** The app builds the request context: your message, recent conversation history, the active config file (plus any files you mention or attach), and current printer memory. File targeting itself is carried by the backend system prompt's `# file:` / mini-diff edit protocol; the frontend's optional targeted file-editing instructions are gated behind a build flag (`VITE_KWC_HANDHOLDING=1`) and off by default.
-2. **The backend prepares the prompt.** It adds the assistant's operating rules, the built-in tool list (Klipper docs search, example configs, validation, board detection, macro templates, and more), and a task anchor that keeps the model focused on your latest message even in long conversations.
-3. **The model answers with tools.** Cloud providers use native function calling; local servers use a text `tool` block protocol. The backend runs the requested tools (for example, searching the bundled docs or validating a snippet) and feeds the results back to the model, up to ten tool rounds. If the model calls no tool, the backend injects a documentation search automatically so answers stay grounded.
+1. **You send a message.** The app builds the request context: your message, recent conversation history, attached config files, and the current printer memory file.
+2. **The backend prepares the prompt.** It adds the assistant's operating rules, the built-in tool list (Klipper docs search, example configs, validation, board detection, macro templates, and more).
+3. **The model answers with tools.** Cloud providers use native function calling; local servers use a text `tool` block protocol by default. The backend runs the requested tools (for example, searching the bundled docs or validating a snippet) and feeds the results back to the model, up to ten tool rounds.
 4. **The reply is validated.** Config sections and printer-memory proposals are checked; if something is invalid, the assistant is asked to fix it (up to a few attempts) before you ever see it.
-5. **Config changes become a reviewable draft.** If the reply contains `cfg` blocks, the app merges them with your current project and shows a per-file preview with every changed, added, or deleted section highlighted.
-6. **You review and apply.** Accept the draft to apply the edits to your project; a file the assistant proposes to create appears as a new file. Nothing is written to disk or applied to your printer without your explicit approval.
+5. **Config changes become a reviewable draft.** If the reply contains `cfg` blocks, an **Apply and Review Changes** button appears. When selected it shows a diff of your current project with every changed, added, or deleted section highlighted. The changes must be approved by applying them. Changes will not fully write your active config or restart your printer until saved with toolbar "Save" menu.
+
+## Printer memory
+
+The assistant sees your printer memory (mainboard, toolhead, expander boards, kinematics, probe, etc.) as context on every request. If it is blank, the assistant investigates your configs and the bundled examples to propose a filled-in profile. Proposals come back as a `printer-memory` code block and are shown in a review dialog — saved only when you confirm.
 
 ## How the assistant targets config edits
 
@@ -34,10 +41,6 @@ The assistant communicates file changes as `cfg` code blocks using a simple prot
 - A pure addition needs no `-` line; a pure deletion needs no `+` line.
 
 Only changed, new, or deleted content is returned — never your whole file unless you ask for it. The app parses, merges, and validates these blocks against your real project, so what you preview is exactly what the merge will produce.
-
-## Printer memory
-
-The assistant sees your printer memory (mainboard, toolhead, expander boards, kinematics, probe, etc.) as context on every request. If it is blank, the assistant investigates your configs and the bundled examples to propose a filled-in profile. Proposals come back as a `printer-memory` code block and are shown in a review dialog — saved only when you confirm.
 
 ## Stopping, retrying, and resuming
 
@@ -53,12 +56,21 @@ How it works:
 
 - Each question starts a **fresh chat dialog** (a single user message, its own requestId), so the model cannot lean on prior conversation context.
 - Every question checks two things: **answer accuracy** (does the reply contain the expected facts / code / file-edit protocol?) and **tool reliability** (does the model use the right embedded tool for the job?).
-- The 55-question bank covers: **Q01–Q20** core tools (docs lookups, example configs, validation, calculations, draft-block protocol), **MACRO-01..11** (macro authoring, editing, fixing, template options, and the individual `validate_macro` checks), **TRIDENT-01..14** (the real Trident configs from `reference/Trident_backup` and the real backend user configs — read, edit, delete, manage, and fix the actual `printer.cfg`, `aux_fan.cfg`, and `PIS.cfg` via the draft-block protocol; the files are attached as read-only context and never modified), **MINIDIFF-01..04** (the mini-diff edit protocol — `level_bed` adaptive mode, `[printer] max_accel`, an `aux_fan.cfg` pin edit, and a tool-required `pressure_advance` edit), and **AMBI-01..08** (ambiguity cases — new-file drafts without an explicit name, hypothetical "what if" edits phrased as questions, batch section reads, multi-topic explain-and-edit turns, and content search for a bare pin value). An optional `--include-memory` flag adds MEMORY-01..03 printer-memory auto-fill checks.
-- Every step is logged: the request payload, raw response, tool names and tool-turn count, the per-question slice of the backend's own log, the pass/fail evaluation for each criterion, and a final summary. The script is stdlib-only — no third-party dependencies.
+- Every step is logged: the request payload, raw response, tool names and tool-turn count, the per-question slice of the backend's own log, the pass/fail evaluation for each criterion, and a final summary.
+
+### Question Bank
+| Item / Feature | Description & Details |
+| :--- | :--- |
+| Core Tools (Q01–Q20) | Covers docs lookups, example configs, validation, calculations, and draft-block protocol. |
+| Macro Authoring (MACRO-01..11) | Includes macro authoring, editing, fixing, template options, and individual `validate_macro` checks. |
+| Trident Configs (TRIDENT-01..14) | Real Trident configs from `reference/Trident_backup` and backend user configs (read, edit, delete, manage). Includes `printer.cfg`, `aux_fan.cfg`, and `PIS.cfg`. Files are read-only context. |
+| Mini-Diff Edit (MINIDIFF-01..04) | Covers mini-diff protocol: `level_bed` adaptive mode, `[printer] max_accel`, pin edits (`aux_fan.cfg`), and tool-required `pressure_advance` edit. |
+| Ambiguity Cases (AMBI-01..08) | Handles new-file drafts without names, hypothetical "what if" questions, batch section reads, multi-topic explain-and-edit turns, and content search for bare pin values. |
+| Optional Memory Check (MEMORY-01..03) | Adds printer-memory auto-fill checks when the `--include-memory` flag is used. |
 
 ### Results on local models (55-question bank)
 
-Tested on the local llama.cpp/LM Studio server with the same settings as day-to-day use (`--max-tokens 4096 --temperature 0.7 --tool-protocol native`):
+Tested on the local llama.cpp with the same settings as day-to-day use (`--max-tokens 4096 --temperature 0.7 --tool-protocol native`):
 
 | Model | PASS | Rate |
 | --- | --- | --- |
@@ -67,18 +79,14 @@ Tested on the local llama.cpp/LM Studio server with the same settings as day-to-
 | qwen3.5-9b | 44/55 | 80% |
 | qwen3.5-4b | 42/55 | 76% |
 | gemma-4-e2b | 41/55 | 75% |
-| gpt-oss-20b | 30/50 | 60% |
-
-Run dates and notes: the gemma-4-12b / gemma-4-e4b / gemma-4-e2b / qwen3.5-4b / qwen3.5-9b rows are full 55-question runs from 2026-08-05. The gpt-oss-20b row is the earlier 2026-08-03 run on the 50-question bank (not re-run; it requires `--tool-protocol native`). The qwen3.5-9b server alias now points at the DeepSeek-V4-Flash-MTP merged GGUF (`jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-MTP-Q6_K`), which differs from the plain qwen3.5-9b file that scored 44/50 (88%) on 08-03 — the drop is at least partly a model-file change, not pure variance. One qwen3.5-9b question (Q01) errored with a 500 and counts as a fail.
 
 What that looks like in practice:
 
 - **gemma-4-12b** is the strongest local model and the current recommendation — 98% on the full bank. Its only miss (AMBI-04) is the same one as the morning run: it emitted an edit block for a hypothetical "what would happen if" question instead of just answering.
 - **gemma-4-e4b** is a solid mid-size at ~87%, a few points behind 12b. Its misses are a mix of draft-protocol cases (Q17, TRIDENT-13, MINIDIFF-01) and ambiguity turns (AMBI-03/05/07).
-- **qwen3.5-9b** lands ~80% on the current DeepSeek-V4-Flash-MTP merged file. It handles real-file edits well but misses several mini-diff/ambiguity cases.
+- **qwen3.5-9b** lands ~80%. It handles real-file edits well but misses several mini-diff/ambiguity cases.
 - **qwen3.5-4b** is decent for a 4B model (~76%) and fine for lighter use, but it stumbles on the harder real-file and mini-diff edits (TRIDENT-02/03/04/07/08/10 and MINIDIFF-01/03/04).
 - **gemma-4-e2b** (the smallest we benchmarked, ~2B class) improves to ~75% on the full bank but is still the weakest — it reaches for the wrong tool and fails most macro-validation and draft-protocol edit cases. Fine for casual documentation Q&A, not reliable for edit workflows.
-- **gpt-oss-20b** lands around 60% and **requires** the native tool protocol (its text-protocol replies come back empty) — pass `--tool-protocol native` when testing it.
 
 Run-to-run variance of a few points is normal (the model gets a fresh dialog per question, and tool calls are nondeterministic), which is why the table shows single-run numbers rather than ranges.
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -39,6 +39,7 @@ import AddMenu from './components/AddMenu';
 import MacroDesignerDialog from './components/dialogs/MacroDesignerDialog';
 
 import type { AppEdge, AppNode, ValidationStatus } from './types/graph';
+import type { ConfigFile, ValidationResult } from './types/config';
 import type { MacroDesignerPersistedState } from './types/macroDesigner';
 import { combineValidationStatuses } from './utils/validationStatus';
 import { isBackupConfigFilename } from './utils/backupFiles';
@@ -170,6 +171,105 @@ function applySavedEdgeLayout(saved: SavedEdgeLayout[] | undefined, graphStore: 
     return next as import('./types/graph').AppEdge;
   });
   graphStore.setEdges(updatedEdges);
+}
+
+/**
+ * Browser-mode fallback: restore the last saved config session from backend
+ * storage (project/load-saved) and the saved graph layout from localStorage.
+ * Only called when native mode is NOT active — native mode reads the real
+ * config from the Pi disk via the native startup path instead.
+ */
+async function restoreSavedConfigsFromBackend(): Promise<void> {
+  const configStore = useConfigStore.getState();
+  // Belt-and-suspenders: if another loader (e.g. native) already populated
+  // configs, don't clobber them.
+  if (Object.keys(configStore.configFiles).length > 0) {
+    return;
+  }
+
+  try {
+    const result = await api.loadSavedConfigs();
+    if (!result.files || Object.keys(result.files).length === 0) return;
+
+    let schemas = configStore.schemas;
+    if (Object.keys(schemas).length === 0) {
+      try {
+        const schemaResult = await api.getSchema();
+        configStore.setSchemas(schemaResult.schemas);
+        schemas = schemaResult.schemas;
+      } catch { /* proceed without */ }
+    }
+
+    // Use loadConfigs to replace all configs at once (avoids duplicates)
+    const allConfigs: Record<string, ConfigFile> = {};
+    const allValidations: Record<string, ValidationResult> = {};
+
+    for (const [filename, fileResult] of Object.entries(result.files)) {
+      allConfigs[filename] = fileResult.config;
+      allValidations[filename] = fileResult.validation;
+    }
+
+    configStore.loadConfigs(allConfigs);
+
+    for (const [filename, validation] of Object.entries(allValidations)) {
+      configStore.setValidation(filename, validation);
+    }
+
+    for (const [filename, config] of Object.entries(allConfigs)) {
+      if (config.raw_text) {
+        configStore.setOriginalText(filename, config.raw_text);
+      }
+    }
+
+    // Clear graph first, then rebuild to avoid duplicate nodes
+    const graphStore = useGraphStore.getState();
+    graphStore.clearGraph();
+    const { buildProjectGraph } = await import('./utils/graphBuilder');
+    buildProjectGraph(allConfigs, graphStore, schemas, allValidations);
+
+    // Browser mode: restore saved layout from localStorage (if any)
+    try {
+      const saved = localStorage.getItem('kwc.graphLayout');
+      if (saved) {
+        const layout = JSON.parse(saved) as {
+          graphNodes?: Array<{ id: string; position: { x: number; y: number } }>;
+          graphEdges?: Array<{
+            id: string;
+            data?: Record<string, unknown>;
+            sourceHandle?: string;
+            targetHandle?: string;
+          }>;
+          macroDesigner?: MacroDesignerPersistedState;
+        };
+        if (layout.macroDesigner) {
+          useMacroDesignerStore.getState().hydratePersistedState(layout.macroDesigner);
+        }
+        if (layout.graphNodes) {
+          const positionMap = new Map(
+            layout.graphNodes.map((n) => [n.id, n.position]),
+          );
+          const currentNodes = useGraphStore.getState().nodes;
+          const updatedNodes = currentNodes.map((node) => {
+            const savedPos = positionMap.get(node.id);
+            if (savedPos) {
+              return { ...node, position: savedPos } as AppNode;
+            }
+            return node;
+          });
+          graphStore.setNodes(updatedNodes);
+        }
+        // Restore edge routing: custom bend points + which side of each
+        // node the line connects to. Without this, a refresh resets every
+        // trace to default top/bottom routing even though card positions
+        // survived.
+        applySavedEdgeLayout(layout.graphEdges, graphStore);
+      }
+    } catch { /* malformed/absent layout — keep auto-arranged positions */ }
+
+    configStore.markClean();
+  } catch {
+    // No saved configs — that's fine, start empty
+  }
 }
 
 /** Sits inside <ReactFlow> and calls fitView whenever trigger increments. */
@@ -352,106 +452,30 @@ export default function App() {
     return unsub;
   }, []);
 
-  // Restore saved configs from disk on startup (non-native fallback).
-  // If native mode already loaded configs, this does nothing.
+  // Restore saved configs from backend storage on startup (non-native fallback).
+  // Waits for the native status check so the two loaders can't race: native
+  // mode loads from the Pi config dir (effect above); browser mode restores
+  // the last saved session. Previously this fired on mount regardless —
+  // wasting ~400ms of load-saved work on native startups and racing
+  // buildProjectGraph (additive), a duplicate-cards source.
   const savedConfigRestored = useRef(false);
   useEffect(() => {
     if (savedConfigRestored.current) return;
 
-    savedConfigRestored.current = true;  // Mark immediately to prevent double-load
-
-    const configStore = useConfigStore.getState();
-    const existingFiles = Object.keys(configStore.configFiles);
-    if (existingFiles.length > 0) {
-      // Native mode already loaded configs — skip restore
-      return;
-    }
-
-    (async () => {
-      try {
-        const result = await api.loadSavedConfigs();
-        if (!result.files || Object.keys(result.files).length === 0) return;
-
-        let schemas = configStore.schemas;
-        if (Object.keys(schemas).length === 0) {
-          try {
-            const schemaResult = await api.getSchema();
-            configStore.setSchemas(schemaResult.schemas);
-            schemas = schemaResult.schemas;
-          } catch { /* proceed without */ }
-        }
-
-        // Use loadConfigs to replace all configs at once (avoids duplicates)
-        const allConfigs: Record<string, import('./types/config').ConfigFile> = {};
-        const allValidations: Record<string, import('./types/config').ValidationResult> = {};
-
-        for (const [filename, fileResult] of Object.entries(result.files)) {
-          allConfigs[filename] = fileResult.config;
-          allValidations[filename] = fileResult.validation;
-        }
-
-        configStore.loadConfigs(allConfigs);
-
-        for (const [filename, validation] of Object.entries(allValidations)) {
-          configStore.setValidation(filename, validation);
-        }
-
-        for (const [filename, config] of Object.entries(allConfigs)) {
-          if (config.raw_text) {
-            configStore.setOriginalText(filename, config.raw_text);
-          }
-        }
-
-        // Clear graph first, then rebuild to avoid duplicate nodes
-        const graphStore = useGraphStore.getState();
-        graphStore.clearGraph();
-        const { buildProjectGraph } = await import('./utils/graphBuilder');
-        buildProjectGraph(allConfigs, graphStore, schemas, allValidations);
-
-        // Browser mode: restore saved layout from localStorage (if any)
-        try {
-          const saved = localStorage.getItem('kwc.graphLayout');
-          if (saved) {
-            const layout = JSON.parse(saved) as {
-              graphNodes?: Array<{ id: string; position: { x: number; y: number } }>;
-              graphEdges?: Array<{
-                id: string;
-                data?: Record<string, unknown>;
-                sourceHandle?: string;
-                targetHandle?: string;
-              }>;
-              macroDesigner?: MacroDesignerPersistedState;
-            };
-            if (layout.macroDesigner) {
-              useMacroDesignerStore.getState().hydratePersistedState(layout.macroDesigner);
-            }
-            if (layout.graphNodes) {
-              const positionMap = new Map(
-                layout.graphNodes.map((n) => [n.id, n.position]),
-              );
-              const currentNodes = useGraphStore.getState().nodes;
-              const updatedNodes = currentNodes.map((node) => {
-                const savedPos = positionMap.get(node.id);
-                if (savedPos) {
-                  return { ...node, position: savedPos } as import('./types/graph').AppNode;
-                }
-                return node;
-              });
-              graphStore.setNodes(updatedNodes);
-            }
-            // Restore edge routing: custom bend points + which side of each
-            // node the line connects to. Without this, a refresh resets every
-            // trace to default top/bottom routing even though card positions
-            // survived.
-            applySavedEdgeLayout(layout.graphEdges, graphStore);
-          }
-        } catch { /* malformed/absent layout — keep auto-arranged positions */ }
-
-        configStore.markClean();
-      } catch {
-        // No saved configs — that's fine, start empty
+    let unsub: () => void = () => {};
+    const maybeRestore = () => {
+      if (savedConfigRestored.current) return;
+      const state = useNativeStore.getState();
+      if (state.isNative === null) return; // status check still in flight
+      savedConfigRestored.current = true;
+      unsub();
+      if (!state.isNative) {
+        void restoreSavedConfigsFromBackend();
       }
-    })();
+    };
+    unsub = useNativeStore.subscribe(maybeRestore);
+    maybeRestore();
+    return unsub;
   }, []);
 
   // Auto-save layout (debounced). Native mode persists via the backend;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -43,6 +43,13 @@ import type { ConfigFile, ValidationResult } from './types/config';
 import type { MacroDesignerPersistedState } from './types/macroDesigner';
 import { combineValidationStatuses } from './utils/validationStatus';
 import { isBackupConfigFilename } from './utils/backupFiles';
+import {
+  LAYOUT_STORAGE_KEY,
+  buildLayoutPayload,
+  applySavedNodePositions,
+  applySavedEdgeLayout,
+  loadSavedLayout,
+} from './utils/layoutPersistence';
 import { useMacroDesignerStore } from './stores/macroDesignerStore';
 
 function getSectionValidationKey(configFile: string | undefined, sectionHeader: string): string {
@@ -126,53 +133,6 @@ function computeHardwareDragPreviewSize(nodes: Node[], hardwareId: string) {
   };
 }
 
-/** Saved edge layout entry (id may differ from rebuilt edges — pair-match). */
-interface SavedEdgeLayout {
-  id: string;
-  source?: string;
-  target?: string;
-  data?: Record<string, unknown>;
-  sourceHandle?: string;
-  targetHandle?: string;
-}
-
-/**
- * Overlay saved edge routing (custom bend points + connection sides) onto the
- * freshly rebuilt graph. Matches by PAIR (source+target+edgeType), falling back
- * to id: edge ids come from a module-level counter, so a line drawn at runtime
- * (edge_7) gets a different id after the config rebuild than the one the save
- * captured. The source/target/type triple is stable across rebuilds, and comm
- * edges are matched direction-agnostically (the rebuild always emits SBC →
- * hardware but the user may have drawn the opposite way).
- */
-function applySavedEdgeLayout(saved: SavedEdgeLayout[] | undefined, graphStore: ReturnType<typeof useGraphStore.getState>) {
-  if (!saved || saved.length === 0) return;
-  const pairKey = (e: { source?: string; target?: string; data?: Record<string, unknown> }) => {
-    const t = (e.data as Record<string, unknown> | undefined)?.edgeType as string | undefined;
-    const [a, b] = [e.source ?? '', e.target ?? ''].sort();
-    return [a, b, t ?? ''].join('|');
-  };
-  const savedByPair = new Map(saved.map((e) => [pairKey(e), e]));
-  const savedById = new Map(saved.map((e) => [e.id, e]));
-  const currentEdges = useGraphStore.getState().edges;
-  const updatedEdges = currentEdges.map((edge) => {
-    const found = savedByPair.get(pairKey(edge)) ?? savedById.get(edge.id);
-    if (!found) return edge;
-    const next: Record<string, unknown> = { ...edge };
-    if (found.data) {
-      next.data = {
-        ...edge.data,
-        ...found.data,
-        customMiddlePoints: (found.data as Record<string, unknown>).customMiddlePoints,
-      } as unknown as import('./types/graph').AppEdge['data'];
-    }
-    if (found.sourceHandle) next.sourceHandle = found.sourceHandle;
-    if (found.targetHandle) next.targetHandle = found.targetHandle;
-    return next as import('./types/graph').AppEdge;
-  });
-  graphStore.setEdges(updatedEdges);
-}
-
 /**
  * Browser-mode fallback: restore the last saved config session from backend
  * storage (project/load-saved) and the saved graph layout from localStorage.
@@ -227,44 +187,22 @@ async function restoreSavedConfigsFromBackend(): Promise<void> {
     const { buildProjectGraph } = await import('./utils/graphBuilder');
     buildProjectGraph(allConfigs, graphStore, schemas, allValidations);
 
-    // Browser mode: restore saved layout from localStorage (if any)
-    try {
-      const saved = localStorage.getItem('kwc.graphLayout');
-      if (saved) {
-        const layout = JSON.parse(saved) as {
-          graphNodes?: Array<{ id: string; position: { x: number; y: number } }>;
-          graphEdges?: Array<{
-            id: string;
-            data?: Record<string, unknown>;
-            sourceHandle?: string;
-            targetHandle?: string;
-          }>;
-          macroDesigner?: MacroDesignerPersistedState;
-        };
-        if (layout.macroDesigner) {
-          useMacroDesignerStore.getState().hydratePersistedState(layout.macroDesigner);
-        }
-        if (layout.graphNodes) {
-          const positionMap = new Map(
-            layout.graphNodes.map((n) => [n.id, n.position]),
-          );
-          const currentNodes = useGraphStore.getState().nodes;
-          const updatedNodes = currentNodes.map((node) => {
-            const savedPos = positionMap.get(node.id);
-            if (savedPos) {
-              return { ...node, position: savedPos } as AppNode;
-            }
-            return node;
-          });
-          graphStore.setNodes(updatedNodes);
-        }
-        // Restore edge routing: custom bend points + which side of each
-        // node the line connects to. Without this, a refresh resets every
-        // trace to default top/bottom routing even though card positions
-        // survived.
-        applySavedEdgeLayout(layout.graphEdges, graphStore);
+    // Browser mode: restore saved layout from localStorage (if any).
+    // Position/edge restore is keyed by content identity (logicalKey) with
+    // exact-id fallback — see utils/layoutPersistence.
+    const layout = await loadSavedLayout(false);
+    if (layout) {
+      if (layout.macroDesigner) {
+        useMacroDesignerStore.getState().hydratePersistedState(layout.macroDesigner as MacroDesignerPersistedState);
       }
-    } catch { /* malformed/absent layout — keep auto-arranged positions */ }
+      const gs = useGraphStore.getState();
+      gs.setNodes(applySavedNodePositions(gs.nodes, layout.graphNodes));
+      // Restore edge routing: custom bend points + which side of each
+      // node the line connects to. Without this, a refresh resets every
+      // trace to default top/bottom routing even though card positions
+      // survived.
+      gs.setEdges(applySavedEdgeLayout(gs.edges, layout.graphEdges, gs.nodes, layout.graphNodes));
+    }
 
     configStore.markClean();
   } catch {
@@ -407,37 +345,17 @@ export default function App() {
             buildProjectGraph(allConfigs, graphStore, schemas, allValidations);
 
             // Now try to restore graph positions from saved layout
-            try {
-              const layoutResult = await api.loadNativeLayout();
-              if (layoutResult.layout) {
-                const layout = layoutResult.layout as {
-                  graphNodes?: Array<{ id: string; position: { x: number; y: number } }>;
-                  graphEdges?: SavedEdgeLayout[];
-                  macroDesigner?: MacroDesignerPersistedState;
-                };
-                if (layout.macroDesigner) {
-                  useMacroDesignerStore.getState().hydratePersistedState(layout.macroDesigner);
-                }
-                // Overlay saved positions onto the newly built graph nodes
-                if (layout.graphNodes) {
-                  const positionMap = new Map(
-                    layout.graphNodes.map((n) => [n.id, n.position]),
-                  );
-                  const currentNodes = useGraphStore.getState().nodes;
-                  const updatedNodes = currentNodes.map((node) => {
-                    const savedPos = positionMap.get(node.id);
-                    if (savedPos) {
-                      return { ...node, position: savedPos } as import('./types/graph').AppNode;
-                    }
-                    return node;
-                  });
-                  graphStore.setNodes(updatedNodes);
-                }
-                // Restore edge routing the same way as the browser-mode path
-                // (pair-matched, direction-agnostic — see applySavedEdgeLayout).
-                applySavedEdgeLayout(layout.graphEdges as SavedEdgeLayout[] | undefined, graphStore);
+            // (content-keyed with exact-id fallback — see utils/layoutPersistence)
+            const layout = await loadSavedLayout(true);
+            if (layout) {
+              if (layout.macroDesigner) {
+                useMacroDesignerStore.getState().hydratePersistedState(layout.macroDesigner as MacroDesignerPersistedState);
               }
-            } catch { /* no saved layout — use auto-arranged positions */ }
+              const gs = useGraphStore.getState();
+              gs.setNodes(applySavedNodePositions(gs.nodes, layout.graphNodes));
+              // Restore edge routing the same way as the browser-mode path.
+              gs.setEdges(applySavedEdgeLayout(gs.edges, layout.graphEdges, gs.nodes, layout.graphNodes));
+            }
 
             configStore.markClean();
           } catch {
@@ -480,29 +398,19 @@ export default function App() {
 
   // Auto-save layout (debounced). Native mode persists via the backend;
   // browser mode falls back to localStorage so arrangements survive refresh.
+  // Both modes store the SAME canonical payload (id + position + logicalKey
+  // per node, endpoint-bearing edges) so restore can key on content identity.
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const saveLayoutNow = useCallback((n: typeof nodes, e: typeof edges) => {
     if (n.length === 0) return;
     const macroDesigner = useMacroDesignerStore.getState().exportPersistedState();
+    const layout = buildLayoutPayload(n, e, macroDesigner);
     const isNative = useNativeStore.getState().isNative;
     if (isNative) {
-      api.saveNativeLayout({
-        graphNodes: n,
-        graphEdges: e,
-        macroDesigner,
-      }).catch(() => { /* ignore save errors */ });
+      api.saveNativeLayout(layout).catch(() => { /* ignore save errors */ });
     } else {
       try {
-        localStorage.setItem('kwc.graphLayout', JSON.stringify({
-          graphNodes: n.map((node) => ({ id: node.id, position: node.position })),
-          graphEdges: e.map((edge) => ({
-            id: edge.id,
-            data: edge.data,
-            sourceHandle: edge.sourceHandle ?? undefined,
-            targetHandle: edge.targetHandle ?? undefined,
-          })),
-          macroDesigner,
-        }));
+        localStorage.setItem(LAYOUT_STORAGE_KEY, JSON.stringify(layout));
       } catch { /* ignore quota / privacy-mode errors */ }
     }
   }, []);

--- a/frontend/src/components/TextEditor.tsx
+++ b/frontend/src/components/TextEditor.tsx
@@ -1,8 +1,11 @@
 import { useState, useCallback, useMemo, useRef, useEffect } from 'react';
 import { useConfigStore } from '../stores/configStore';
 import { useGraphStore } from '../stores/graphStore';
+import { useNativeStore } from '../stores/nativeStore';
 import * as api from '../services/api';
 import ConfigReferenceDialog from './dialogs/ConfigReferenceDialog';
+import { buildProjectGraph } from '../utils/graphBuilder';
+import { restoreLayoutAfterRebuild } from '../utils/layoutPersistence';
 import type { ExampleConfig, ConfigFile, ConfigSection } from '../types/config';
 
 interface SearchResult {
@@ -581,11 +584,19 @@ function TextEditor({ isActive = true }: { isActive?: boolean }) {
       });
       setActiveFile(name);
 
-      // Rebuild the whole graph so the new file's hardware/features appear —
-      // mirrors the import path (clearGraph first avoids duplicate nodes).
+      // Full rebuild over ALL config files (mirrors the import path).
+      // The previous code did clearGraph() + syncGraphWithConfig(name) —
+      // a single-file sync that can only add sections to EXISTING hardware
+      // nodes, so after clearGraph() deleted them nothing could be
+      // recreated and the canvas went empty.
+      const configStore = useConfigStore.getState();
       const graphStore = useGraphStore.getState();
       graphStore.clearGraph();
-      graphStore.syncGraphWithConfig(name);
+      buildProjectGraph(configStore.configFiles, graphStore, configStore.schemas, configStore.validation);
+      // The rebuild renumbers node ids — re-apply the saved layout so the
+      // new file appears in the user's existing arrangement instead of
+      // resetting every card to auto-arranged.
+      await restoreLayoutAfterRebuild(graphStore, useNativeStore.getState().isNative);
     } catch (err) {
       console.error('Failed to load reference config:', err);
     }

--- a/frontend/src/components/dialogs/AiDraftPreviewDialog.tsx
+++ b/frontend/src/components/dialogs/AiDraftPreviewDialog.tsx
@@ -259,12 +259,12 @@ export default function AiDraftPreviewDialog({
                           key={`${fileDiff.filename}_${index}`}
                           className={
                             line.type === 'added'
-                              ? 'bg-green-500/15 px-3 text-green-400'
+                              ? 'w-max min-w-full bg-green-500/15 px-3 text-green-400'
                               : line.type === 'removed'
-                                ? 'bg-red-500/15 px-3 text-red-400'
+                                ? 'w-max min-w-full bg-red-500/15 px-3 text-red-400'
                                 : line.type === 'header'
-                                  ? 'bg-blue-500/10 px-3 py-0.5 text-blue-400'
-                                  : 'px-3 text-[var(--color-text-secondary)]'
+                                  ? 'w-max min-w-full bg-blue-500/10 px-3 py-0.5 text-blue-400'
+                                  : 'w-max min-w-full px-3 text-[var(--color-text-secondary)]'
                           }
                         >
                           <span className="mr-2 select-none opacity-40">

--- a/frontend/src/components/dialogs/ApplyDialog.tsx
+++ b/frontend/src/components/dialogs/ApplyDialog.tsx
@@ -633,12 +633,12 @@ export default function ApplyDialog({ onClose, canAnalyzeWithAi = false, onAnaly
                                   key={i}
                                   className={
                                     line.type === 'added'
-                                      ? 'bg-green-500/15 text-green-400 px-3'
+                                      ? 'w-max min-w-full bg-green-500/15 text-green-400 px-3'
                                       : line.type === 'removed'
-                                        ? 'bg-red-500/15 text-red-400 px-3'
+                                        ? 'w-max min-w-full bg-red-500/15 text-red-400 px-3'
                                         : line.type === 'header'
-                                          ? 'bg-blue-500/10 text-blue-400 px-3 py-0.5'
-                                          : 'text-[var(--color-text-secondary)] px-3'
+                                          ? 'w-max min-w-full bg-blue-500/10 text-blue-400 px-3 py-0.5'
+                                          : 'w-max min-w-full text-[var(--color-text-secondary)] px-3'
                                   }
                                 >
                                   <span className="select-none opacity-40 mr-2">

--- a/frontend/src/components/dialogs/ChatDialog.tsx
+++ b/frontend/src/components/dialogs/ChatDialog.tsx
@@ -177,6 +177,7 @@ const ChatDialog: React.FC<ChatDialogProps> = ({
   const [editPort, setEditPort] = useState(settings.port);
   const [editMaxTokens, setEditMaxTokens] = useState(String(settings.maxTokens ?? 4096));
   const [editTemperature, setEditTemperature] = useState(String(settings.temperature ?? 0.7));
+  const [editToolProtocol, setEditToolProtocol] = useState<'auto' | 'native' | 'text'>(settings.toolProtocol ?? 'auto');
 
   const resolvedEditApiUrl = resolveProviderApiUrl(
     editApiProvider,
@@ -213,6 +214,7 @@ const ChatDialog: React.FC<ChatDialogProps> = ({
       setEditPort(settings.port);
       setEditMaxTokens(String(settings.maxTokens ?? 4096));
       setEditTemperature(String(settings.temperature ?? 0.7));
+      setEditToolProtocol(settings.toolProtocol ?? 'auto');
       setError(null);
       // Opening the dialog consumes any background completion signal — the
       // toolbar button returns to its default color (the user is looking at
@@ -264,6 +266,7 @@ const ChatDialog: React.FC<ChatDialogProps> = ({
       port: editPort,
       maxTokens: Math.max(256, parseInt(editMaxTokens, 10) || 4096),
       temperature: parseTemperature(editTemperature),
+      toolProtocol: editToolProtocol,
     });
     setShowSettings(false);
   }, [
@@ -275,6 +278,7 @@ const ChatDialog: React.FC<ChatDialogProps> = ({
     editModel,
     editProviderModels,
     editTemperature,
+    editToolProtocol,
     resolvedEditApiUrl,
     setSettings,
   ]);
@@ -368,6 +372,7 @@ const ChatDialog: React.FC<ChatDialogProps> = ({
           requestId: stopRequestId,
           maxTokens: Math.max(256, parseInt(editMaxTokens, 10) || 4096),
           temperature: parseTemperature(editTemperature),
+          toolProtocol: editToolProtocol,
           fullRewriteGuard: FULL_REWRITE_GUARD_ENABLED,
         };
 
@@ -797,6 +802,8 @@ const ChatDialog: React.FC<ChatDialogProps> = ({
     setEditMaxTokens,
     editTemperature,
     setEditTemperature,
+    editToolProtocol,
+    setEditToolProtocol,
     resolvedEditApiUrl,
     onSaveSettings: handleSaveSettings,
   };

--- a/frontend/src/components/dialogs/ChatDialog.tsx
+++ b/frontend/src/components/dialogs/ChatDialog.tsx
@@ -15,6 +15,8 @@ import { useAiStore, AiProvider, providerRequiresApiKey, type ChatMessage } from
 import { useChatHistoryStore } from '../../stores/chatHistoryStore';
 import { useConfigStore } from '../../stores/configStore';
 import { useGraphStore } from '../../stores/graphStore';
+import { useNativeStore } from '../../stores/nativeStore';
+import { restoreLayoutAfterRebuild } from '../../utils/layoutPersistence';
 import { usePrinterMemoryStore, DEFAULT_PRINTER_MEMORY, type PrinterMemory } from '../../stores/printerMemoryStore';
 import * as api from '../../services/api';
 import {
@@ -772,6 +774,10 @@ const ChatDialog: React.FC<ChatDialogProps> = ({
       const latestConfigFiles = useConfigStore.getState().configFiles;
       const latestValidation = useConfigStore.getState().validation;
       buildProjectGraph(latestConfigFiles, graphStore, schemas, latestValidation);
+      // The rebuild renumbers node ids — re-apply the saved layout so
+      // accepting an AI edit doesn't auto-arrange over the user's current
+      // arrangement (and the autosave can't persist that reset).
+      await restoreLayoutAfterRebuild(graphStore, useNativeStore.getState().isNative);
       setError(null);
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Failed to accept assistant changes.');

--- a/frontend/src/components/dialogs/ChatMessageList.tsx
+++ b/frontend/src/components/dialogs/ChatMessageList.tsx
@@ -95,10 +95,10 @@ function MarkdownCode({ children, className, inline }: CodeProps) {
                 key={index}
                 className={
                   kind === 'removal'
-                    ? 'bg-red-500/15 px-3 text-red-400'
+                    ? 'w-max min-w-full bg-red-500/15 px-3 text-red-400'
                     : kind === 'addition'
-                      ? 'bg-green-500/15 px-3 text-green-400'
-                      : 'px-3 text-[var(--color-text-primary)]'
+                      ? 'w-max min-w-full bg-green-500/15 px-3 text-green-400'
+                      : 'w-max min-w-full px-3 text-[var(--color-text-primary)]'
                 }
               >
                 <span className="mr-2 select-none opacity-40">
@@ -351,6 +351,12 @@ const ChatMessageList: React.FC<ChatMessageListProps> = ({
                     td: ({ children }: TableDataCellProps) => (
                       <td className="border border-[var(--color-bg-tertiary)] px-2 py-1 align-top">{children}</td>
                     ),
+                    // MarkdownCode renders its own <pre> inside a styled wrapper
+                    // div. Drop react-markdown's default <pre> wrapper so the
+                    // code block is not nested inside invalid HTML
+                    // (<pre><div>…<pre>), which lets long lines push outside
+                    // the bubble instead of scrolling.
+                    pre: ({ children }: ComponentPropsWithoutRef<'pre'>) => <>{children}</>,
                     code: MarkdownCode,
                   }}
                 >

--- a/frontend/src/components/dialogs/ChatSettingsPanel.tsx
+++ b/frontend/src/components/dialogs/ChatSettingsPanel.tsx
@@ -30,6 +30,8 @@ export interface ChatSettingsPanelProps {
   setEditMaxTokens: (v: string) => void;
   editTemperature: string;
   setEditTemperature: (v: string) => void;
+  editToolProtocol: 'auto' | 'native' | 'text';
+  setEditToolProtocol: (v: 'auto' | 'native' | 'text') => void;
   resolvedEditApiUrl: string;
   onSaveSettings: () => void;
   onClose?: () => void;
@@ -54,6 +56,8 @@ const ChatSettingsPanel: React.FC<ChatSettingsPanelProps> = ({
   setEditMaxTokens,
   editTemperature,
   setEditTemperature,
+  editToolProtocol,
+  setEditToolProtocol,
   resolvedEditApiUrl,
   onSaveSettings,
   onClose,
@@ -239,6 +243,28 @@ const ChatSettingsPanel: React.FC<ChatSettingsPanelProps> = ({
     </div>
   );
 
+  // Only meaningful for openai-compatible endpoints (the backend's scheme
+  // split http→text / https→native is the 'auto' default).
+  const toolFormatField = editApiProvider === 'openai-compatible' ? (
+    <div>
+      <label className="block text-[10px] font-semibold text-[var(--color-text-secondary)] uppercase tracking-wider mb-1.5">
+        Tool Format
+      </label>
+      <select
+        className="w-full px-3 py-2 rounded-lg text-xs font-mono bg-[var(--color-bg-primary)] border border-[var(--color-bg-tertiary)] text-[var(--color-text-primary)] focus:border-[var(--color-accent)] focus:outline-none transition-colors"
+        value={editToolProtocol}
+        onChange={(e) => setEditToolProtocol(e.target.value as 'auto' | 'native' | 'text')}
+      >
+        <option value="auto">Auto</option>
+        <option value="native">Native</option>
+        <option value="text">Text</option>
+      </select>
+      <p className="text-[10px] text-[var(--color-text-secondary)] mt-1">
+        Auto: http → text ```tool, https → native. Force either if the model misformats calls.
+      </p>
+    </div>
+  ) : null;
+
   const maxTokensField = (
     <div>
       <label className="block text-[10px] font-semibold text-[var(--color-text-secondary)] uppercase tracking-wider mb-1.5">
@@ -295,6 +321,7 @@ const ChatSettingsPanel: React.FC<ChatSettingsPanelProps> = ({
       {modelField}
       {apiUrlField}
       {apiKeyField}
+      {toolFormatField}
       {maxTokensAndTemperatureRow}
     </div>
   );
@@ -410,6 +437,7 @@ const ChatSettingsPanel: React.FC<ChatSettingsPanelProps> = ({
               placeholder="sk-..."
             />
           </div>
+          {toolFormatField}
           <div className="flex gap-2">
             <div className="flex-1">
               <label className="block text-[10px] text-[var(--color-text-secondary)] mb-1">Max Tokens</label>

--- a/frontend/src/components/dialogs/DiffDialog.tsx
+++ b/frontend/src/components/dialogs/DiffDialog.tsx
@@ -159,12 +159,12 @@ export default function DiffDialog({ onClose }: DiffDialogProps) {
                       key={i}
                       className={
                         line.type === 'added'
-                          ? 'bg-green-500/15 text-green-400 px-3'
+                          ? 'w-max min-w-full bg-green-500/15 text-green-400 px-3'
                           : line.type === 'removed'
-                            ? 'bg-red-500/15 text-red-400 px-3'
+                            ? 'w-max min-w-full bg-red-500/15 text-red-400 px-3'
                             : line.type === 'header'
-                              ? 'bg-blue-500/10 text-blue-400 px-3 py-1'
-                              : 'text-[var(--color-text-secondary)] px-3'
+                              ? 'w-max min-w-full bg-blue-500/10 text-blue-400 px-3 py-1'
+                              : 'w-max min-w-full text-[var(--color-text-secondary)] px-3'
                       }
                     >
                       <span className="select-none opacity-50 mr-2">

--- a/frontend/src/components/dialogs/ExportDialog.tsx
+++ b/frontend/src/components/dialogs/ExportDialog.tsx
@@ -267,12 +267,12 @@ export default function ExportDialog({ onClose }: ExportDialogProps) {
                                   key={i}
                                   className={
                                     line.type === 'added'
-                                      ? 'bg-green-500/15 text-green-400 px-3'
+                                      ? 'w-max min-w-full bg-green-500/15 text-green-400 px-3'
                                       : line.type === 'removed'
-                                        ? 'bg-red-500/15 text-red-400 px-3'
+                                        ? 'w-max min-w-full bg-red-500/15 text-red-400 px-3'
                                         : line.type === 'header'
-                                          ? 'bg-blue-500/10 text-blue-400 px-3 py-0.5'
-                                          : 'text-[var(--color-text-secondary)] px-3'
+                                          ? 'w-max min-w-full bg-blue-500/10 text-blue-400 px-3 py-0.5'
+                                          : 'w-max min-w-full text-[var(--color-text-secondary)] px-3'
                                   }
                                 >
                                   <span className="select-none opacity-40 mr-2">

--- a/frontend/src/components/dialogs/ImportDialog.tsx
+++ b/frontend/src/components/dialogs/ImportDialog.tsx
@@ -2,8 +2,10 @@ import { useState, useRef, useCallback } from 'react';
 import JSZip from 'jszip';
 import { useConfigStore } from '../../stores/configStore';
 import { useGraphStore } from '../../stores/graphStore';
+import { useNativeStore } from '../../stores/nativeStore';
 import * as api from '../../services/api';
 import { buildProjectGraph } from '../../utils/graphBuilder';
+import { restoreLayoutAfterRebuild } from '../../utils/layoutPersistence';
 import { buildInitialSelection, findOverlappingFiles } from '../../utils/importSelection';
 import { countChangedLines, createConfigPatch } from '../../utils/configDiff';
 import type { ConfigFile } from '../../types/config';
@@ -149,6 +151,11 @@ export default function ImportDialog({ onClose }: ImportDialogProps) {
         allValidations[filename] = fileResult.validation;
       }
       buildProjectGraph(allConfigs, graphStore, schemas, allValidations);
+
+      // The rebuild renumbers node ids — re-apply the saved layout so an
+      // import doesn't auto-arrange over the user's arrangement (and the
+      // autosave can't persist that reset).
+      await restoreLayoutAfterRebuild(graphStore, useNativeStore.getState().isNative);
 
       // Sort results: main file first, then alphabetical
       importResults.sort((a, b) => {

--- a/frontend/src/components/dialogs/OpenFromPiDialog.tsx
+++ b/frontend/src/components/dialogs/OpenFromPiDialog.tsx
@@ -5,6 +5,7 @@ import { useMacroDesignerStore } from '../../stores/macroDesignerStore';
 import { useNativeStore } from '../../stores/nativeStore';
 import * as api from '../../services/api';
 import { buildProjectGraph } from '../../utils/graphBuilder';
+import { restoreLayoutAfterRebuild } from '../../utils/layoutPersistence';
 import { isBackupConfigFilename } from '../../utils/backupFiles';
 import type { ConfigFile, ValidationResult } from '../../types/config';
 
@@ -137,6 +138,11 @@ export default function OpenFromPiDialog({ onClose }: OpenFromPiDialogProps) {
       // Build graph
       const graphStore = useGraphStore.getState();
       buildProjectGraph(allConfigs, graphStore, schemas, allValidations);
+
+      // The rebuild renumbers node ids — re-apply the saved layout so an
+      // open doesn't auto-arrange over the user's arrangement, and the
+      // macro-state persist below saves the restored arrangement.
+      await restoreLayoutAfterRebuild(graphStore, isNative);
 
       if (clearMacroDesignerState) {
         await persistClearedMacroDesignerState();

--- a/frontend/src/components/dialogs/RevertDialog.tsx
+++ b/frontend/src/components/dialogs/RevertDialog.tsx
@@ -5,6 +5,7 @@ import { useMacroDesignerStore } from '../../stores/macroDesignerStore';
 import { useNativeStore } from '../../stores/nativeStore';
 import * as api from '../../services/api';
 import { buildProjectGraph } from '../../utils/graphBuilder';
+import { restoreLayoutAfterRebuild } from '../../utils/layoutPersistence';
 import type { ConfigFile, ValidationResult } from '../../types/config';
 
 interface RevertDialogProps {
@@ -73,6 +74,10 @@ export default function RevertDialog({ onClose }: RevertDialogProps) {
         // Rebuild graph
         const graphStore = useGraphStore.getState();
         buildProjectGraph(allConfigs, graphStore, schemas, allValidations);
+        // Re-apply the saved layout — the rebuild renumbers node ids, and
+        // the macro-state persist below must save the restored arrangement,
+        // not the auto-arranged one.
+        await restoreLayoutAfterRebuild(graphStore, isNative);
       } else {
         // Non-native mode: re-parse from originalTexts
         const { originalTexts } = configStore;
@@ -100,6 +105,8 @@ export default function RevertDialog({ onClose }: RevertDialogProps) {
         // Rebuild graph
         const graphStore = useGraphStore.getState();
         buildProjectGraph(allConfigs, graphStore, schemas, allValidations);
+        // Re-apply the saved layout (same reason as the native branch above).
+        await restoreLayoutAfterRebuild(graphStore, isNative);
       }
 
       if (clearMacroDesignerState) {

--- a/frontend/src/components/edges/CommunicationEdge.tsx
+++ b/frontend/src/components/edges/CommunicationEdge.tsx
@@ -156,12 +156,7 @@ function CommunicationEdge(props: EdgeProps) {
             gap: 3,
           }}
         >
-          {isNotIncluded && (
-            <svg width="8" height="8" viewBox="0 0 10 10" fill="none" style={{ flexShrink: 0 }}>
-              <path d="M2 2l6 6M8 2l-6 6" stroke="#ef4444" strokeWidth="1.8" strokeLinecap="round" />
-            </svg>
-          )}
-          <span title={isNotIncluded ? undefined : description}>{label}</span>
+          <span title={description}>{label}</span>
         </div>
       </foreignObject>
       {/* Tooltip shown on hover when the comm line is inactive */}

--- a/frontend/src/hooks/useAssistantDraft.ts
+++ b/frontend/src/hooks/useAssistantDraft.ts
@@ -98,6 +98,8 @@ interface ChatRequestBase {
   maxTokens?: number;
   /** Sampling temperature for the provider (0-2). Omit for provider default. */
   temperature?: number;
+  /** Tool-calling protocol override: 'auto' (scheme split), 'native', 'text'. */
+  toolProtocol?: 'auto' | 'native' | 'text';
   /** Loaded user-config content for the backend config-grounding fallback. */
   contextFiles?: Record<string, { content: string; label: string }>;
   /** Full-rewrite guard state — sent to the backend to select prompt wording. */

--- a/frontend/src/hooks/useAssistantDraft.ts
+++ b/frontend/src/hooks/useAssistantDraft.ts
@@ -210,19 +210,30 @@ export function useAssistantDraft() {
         // existing section, materialize the full section from the current file
         // text BEFORE parsing. Unchanged lines (including Jinja tags in macros)
         // are preserved verbatim from the base file, so the model can never
-        // drop them. If the edit cannot be applied (e.g. the section is not in
-        // the base file), fall back to the raw block so the normal parse and
-        // validation feedback handles it.
+        // drop them. If the edit cannot be applied, fall back to the model's
+        // block as a FULL section write (markers stripped) — never to the raw
+        // text with markers, which would leak literal '-'/'+' lines into the
+        // parsed config (visible as broken gcode in the merged draft).
         let draftConfigText = configText;
         const blockIsMiniDiff = isMiniDiffBlock(draftConfigText);
+        let miniDiffApplyFailed = false;
         if (blockIsMiniDiff) {
           const baseFileText = await getConfigText(assistantParseFilename);
           if (baseFileText) {
             const applied = applyMiniDiffBlock(draftConfigText, baseFileText);
             if (applied.applied) {
               draftConfigText = applied.text;
+            } else {
+              miniDiffApplyFailed = true;
             }
           }
+        }
+        if (miniDiffApplyFailed) {
+          console.warn('[AIDraft] Mini-diff could not be applied against the base file — treating it as a full section write (markers stripped). Review the diff before accepting.');
+          draftConfigText = draftConfigText
+            .split(/\r?\n/)
+            .map((line) => line.replace(/^(\s*)[-+][ \t]?/, '$1'))
+            .join('\n');
         }
 
         // Phase 4 deterministic auto-repair: when the model rewrote a macro
@@ -250,7 +261,7 @@ export function useAssistantDraft() {
           throw new Error('Unable to determine which config file should receive the assistant changes.');
         }
 
-        if (!blockIsMiniDiff) {
+        if (!blockIsMiniDiff || miniDiffApplyFailed) {
           for (const section of assistantResult.config.sections) {
             fullRewriteSections.push({ filename: targetFile, fullHeader: section.full_header });
           }

--- a/frontend/src/hooks/useAssistantDraft.ts
+++ b/frontend/src/hooks/useAssistantDraft.ts
@@ -45,7 +45,7 @@ import {
 import type { AssistantDraftChange } from '../utils/assistantDraftMerge';
 import { mergeAssistantSectionsIntoConfig, preprocessDeleteMarkers } from '../utils/assistantDraftMerge';
 import { normalizeDiffText } from '../utils/configDiff';
-import { isMiniDiffBlock, applyMiniDiffBlock } from '../utils/miniDiff';
+import { isMiniDiffBlock, applyMiniDiffBlock, stripMiniDiffMarkers } from '../utils/miniDiff';
 import { repairUnclosedJinjaInConfigText } from '../utils/jinjaBlockRepair';
 import type { ReplyValidator } from '../utils/replyValidation';
 
@@ -232,10 +232,7 @@ export function useAssistantDraft() {
         }
         if (miniDiffApplyFailed) {
           console.warn('[AIDraft] Mini-diff could not be applied against the base file — treating it as a full section write (markers stripped). Review the diff before accepting.');
-          draftConfigText = draftConfigText
-            .split(/\r?\n/)
-            .map((line) => line.replace(/^(\s*)[-+][ \t]?/, '$1'))
-            .join('\n');
+          draftConfigText = stripMiniDiffMarkers(draftConfigText);
         }
 
         // Phase 4 deterministic auto-repair: when the model rewrote a macro

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -814,6 +814,8 @@ export interface AiChatRequest {
   maxTokens?: number;
   /** Sampling temperature for the provider (0-2). Omit for provider default. */
   temperature?: number;
+  /** Tool-calling protocol override: 'auto' (scheme split), 'native', 'text'. */
+  toolProtocol?: 'auto' | 'native' | 'text';
   /**
    * Loaded user-config content (filename -> {content, label}) for the
    * backend's config-grounding fallback. Held server-side only — it is NOT

--- a/frontend/src/stores/aiStore.ts
+++ b/frontend/src/stores/aiStore.ts
@@ -35,6 +35,12 @@ export interface AiSettings {
   maxTokens: number;
   /** Sampling temperature for AI responses (0-2; 0.7 default). */
   temperature: number;
+  /**
+   * Tool-calling protocol for openai-compatible providers:
+   * 'auto' (default) keeps the scheme split — plain http → text ```tool,
+   * https → native function calling; 'native'/'text' force either.
+   */
+  toolProtocol: 'auto' | 'native' | 'text';
 }
 
 interface PersistedAiState {
@@ -179,6 +185,7 @@ const DEFAULT_SETTINGS: AiSettings = {
   port: '11434',
   maxTokens: 4096,
   temperature: 0.7,
+  toolProtocol: 'auto',
 };
 
 export const useAiStore = create<AiState>()((set, get) => {

--- a/frontend/src/stores/graphStore.ts
+++ b/frontend/src/stores/graphStore.ts
@@ -131,7 +131,7 @@ function matchesSectionRef(section: { full_header: string; line_number: number }
   return section.line_number === ref.sectionLineNumber;
 }
 
-function sectionIdentity(sectionHeader: string, sectionLineNumber?: number): string {
+export function sectionIdentity(sectionHeader: string, sectionLineNumber?: number): string {
   return `${sectionHeader}#${sectionLineNumber ?? 0}`;
 }
 

--- a/frontend/src/utils/__tests__/layoutPersistence.test.ts
+++ b/frontend/src/utils/__tests__/layoutPersistence.test.ts
@@ -1,0 +1,541 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ConfigFile, ConfigSection } from '@/types/config';
+import {
+  applySavedEdgeLayout,
+  applySavedNodePositions,
+  buildLayoutPayload,
+  computeLogicalKey,
+  normalizeSavedLayout,
+  type SavedLayout,
+} from '../layoutPersistence';
+
+/**
+ * Layout persistence tests — the contract for card positions and wire
+ * routing surviving page refreshes AND in-session graph rebuilds.
+ *
+ * Uses the REAL graph store + REAL project builder; "page refresh" is
+ * simulated with vi.resetModules(), which resets the module-level
+ * node/edge id counters the same way a browser reload does.
+ */
+
+// ── Fixtures ─────────────────────────────────────────────────────────
+
+const sec = (
+  section_type: string,
+  full_header: string,
+  section_name = '',
+): ConfigSection => ({
+  section_type,
+  section_name,
+  full_header,
+  line_number: 1,
+  params: [],
+  header_comments: [],
+  trailing_comments: [],
+  is_commented_out: false,
+});
+
+const TRIDENT_CONFIGS: Record<string, ConfigFile> = {
+  'printer.cfg': {
+    filename: 'printer.cfg',
+    sections: [
+      sec('mcu', 'mcu'),
+      sec('mcu', 'mcu EBBCan', 'EBBCan'),
+      sec('include', 'include hotkey.cfg'),
+    ],
+    includes: ['hotkey.cfg'],
+    header_comments: [],
+    raw_text: '',
+  },
+  'hotkey.cfg': {
+    filename: 'hotkey.cfg',
+    sections: [
+      sec('fan', 'fan'),
+      sec('bed_mesh', 'bed_mesh'),
+    ],
+    includes: [],
+    header_comments: [],
+    raw_text: '',
+  },
+};
+
+const SCHEMAS = {
+  mcu: { section_type: 'mcu', display_name: 'MCU', category: 'sub_component', component_group: 'mcu', is_named: true, description: '', max_instances: 5, requires: [], params: [] },
+  fan: { section_type: 'fan', display_name: 'Fan', category: 'sub_component', component_group: 'fan', is_named: false, description: '', max_instances: 1, requires: [], params: [] },
+  bed_mesh: { section_type: 'bed_mesh', display_name: 'Bed Mesh', category: 'feature', component_group: 'bed_mesh', is_named: false, description: '', max_instances: 1, requires: [], params: [] },
+  output_pin: { section_type: 'output_pin', display_name: 'Output Pin', category: 'sub_component', component_group: 'other', is_named: false, description: '', max_instances: 99, requires: [], params: [] },
+} as never;
+
+/** Add a section to hotkey.cfg BEFORE the fan (shifts the node id
+ *  sequence for every card built after it — the classic trigger). */
+function tridentWithOutputPinBefore(): Record<string, ConfigFile> {
+  return {
+    ...TRIDENT_CONFIGS,
+    'hotkey.cfg': {
+      ...TRIDENT_CONFIGS['hotkey.cfg'],
+      sections: [
+        sec('output_pin', 'output_pin'),
+        ...TRIDENT_CONFIGS['hotkey.cfg'].sections,
+      ],
+    },
+  };
+}
+
+function threeOutputPinsBefore(): Record<string, ConfigFile> {
+  return {
+    ...TRIDENT_CONFIGS,
+    'hotkey.cfg': {
+      ...TRIDENT_CONFIGS['hotkey.cfg'],
+      sections: [
+        sec('output_pin', 'output_pin'),
+        sec('output_pin', 'output_pin: led'),
+        sec('output_pin', 'output_pin: aux'),
+        ...TRIDENT_CONFIGS['hotkey.cfg'].sections,
+      ],
+    },
+  };
+}
+
+/**
+ * A NEW board whose config file comes FIRST in build order — hardware
+ * boards are created in file-iteration order (SBC first, then MCUs per
+ * file), so this shifts the id of every hardware node after it. Edge
+ * endpoints reference hardware nodes, so this is what exercises wire
+ * endpoint remapping across a refresh.
+ */
+function tridentWithExtraBoardFirst(): Record<string, ConfigFile> {
+  return {
+    'can2.cfg': {
+      filename: 'can2.cfg',
+      sections: [sec('mcu', 'mcu can2', 'can2')],
+      includes: [],
+      header_comments: [],
+      raw_text: '',
+    },
+    ...TRIDENT_CONFIGS,
+  };
+}
+
+// ── Refresh simulation ───────────────────────────────────────────────
+
+interface FreshModules {
+  graph: typeof import('@/stores/graphStore').useGraphStore;
+  buildProjectGraph: typeof import('@/utils/graphBuilder').buildProjectGraph;
+  config: typeof import('@/stores/configStore').useConfigStore;
+}
+
+async function freshModules(): Promise<FreshModules> {
+  vi.resetModules();
+  const graphMod = await import('@/stores/graphStore');
+  const builderMod = await import('@/utils/graphBuilder');
+  const configMod = await import('@/stores/configStore');
+  return {
+    graph: graphMod.useGraphStore,
+    buildProjectGraph: builderMod.buildProjectGraph,
+    config: configMod.useConfigStore,
+  };
+}
+
+/** Simulate the user arranging cards: give every node a distinct position. */
+function arrangeAll(m: FreshModules): void {
+  const g = m.graph.getState();
+  g.setNodes(g.nodes.map((n, i) => ({
+    ...n,
+    position: { x: 1000 + i * 50, y: 500 + i * 30 },
+  }) as never) as never);
+}
+
+/**
+ * Positions keyed by content identity (logical key; node id for keyless
+ * nodes like customGroup). Label-keying collides — a two-MCU build has two
+ * "MCU" cards.
+ */
+function keyedPositions(nodes: Array<{ id: string; position: { x: number; y: number }; type: string; data: Record<string, unknown> }>): Map<string, { x: number; y: number }> {
+  const out = new Map<string, { x: number; y: number }>();
+  for (const n of nodes) {
+    out.set(computeLogicalKey(n) ?? n.id, { ...n.position });
+  }
+  return out;
+}
+
+/** Every pre-existing card (by identity) must own its saved position after
+ *  the rebuild; new cards must not squat on a saved spot. */
+function checkPositionsRestored(
+  beforeNodes: Array<{ id: string; position: { x: number; y: number }; type: string; data: Record<string, unknown> }>,
+  afterNodes: Array<{ id: string; position: { x: number; y: number }; type: string; data: Record<string, unknown> }>,
+): void {
+  const before = keyedPositions(beforeNodes);
+  const after = keyedPositions(afterNodes);
+  const problems: string[] = [];
+  for (const [key, pos] of before) {
+    const got = after.get(key);
+    if (!got) continue; // card removed — allowed
+    if (JSON.stringify(got) !== JSON.stringify(pos)) {
+      problems.push(`card ${key}: saved ${JSON.stringify(pos)}, got ${JSON.stringify(got)}`);
+    }
+  }
+  // New cards (absent from the save) must not claim a saved position
+  const savedPos = new Set([...before.values()].map((p) => JSON.stringify(p)));
+  for (const [key, pos] of after) {
+    if (before.has(key)) continue;
+    if (savedPos.has(JSON.stringify(pos))) {
+      problems.push(`new card ${key} squatting on a saved position ${JSON.stringify(pos)}`);
+    }
+  }
+  expect(problems, problems.join('\n')).toEqual([]);
+}
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+// ── computeLogicalKey ────────────────────────────────────────────────
+
+describe('computeLogicalKey', () => {
+  it('derives stable keys per node type', () => {
+    expect(computeLogicalKey({
+      type: 'hardware',
+      data: { hardwareType: 'sbc', configFile: '', mcuName: '' },
+    })).toBe('sbc|singleton');
+
+    expect(computeLogicalKey({
+      type: 'hardware',
+      data: { hardwareType: 'toolhead', configFile: 'ebbcan.cfg', mcuName: 'EBBCan' },
+    })).toBe('hw|toolhead|ebbcan.cfg|EBBCan');
+
+    expect(computeLogicalKey({
+      type: 'feature',
+      data: { configFile: 'hotkey.cfg', sectionHeader: 'bed_mesh', sectionLineNumber: 12 },
+    })).toBe('sec|hotkey.cfg|bed_mesh#12');
+
+    expect(computeLogicalKey({
+      type: 'group',
+      data: {
+        configFile: 'hotkey.cfg',
+        componentGroup: 'other',
+        isFeature: false,
+        children: [
+          { sectionHeader: 'output_pin: aux', sectionLineNumber: 3 },
+          { sectionHeader: 'output_pin', sectionLineNumber: 1 },
+        ],
+      },
+    })).toBe('grp|hotkey.cfg|other|c|output_pin#1,output_pin: aux#3');
+
+    // Child order must not change the group identity
+    const reversed = computeLogicalKey({
+      type: 'group',
+      data: {
+        configFile: 'hotkey.cfg',
+        componentGroup: 'other',
+        isFeature: false,
+        children: [
+          { sectionHeader: 'output_pin', sectionLineNumber: 1 },
+          { sectionHeader: 'output_pin: aux', sectionLineNumber: 3 },
+        ],
+      },
+    });
+    expect(reversed).toBe('grp|hotkey.cfg|other|c|output_pin#1,output_pin: aux#3');
+
+    expect(computeLogicalKey({
+      type: 'customGroup',
+      data: { label: 'My Group' },
+    })).toBeNull();
+  });
+
+  it('distinguishes two boards in the same multi-MCU file by mcuName', () => {
+    const a = computeLogicalKey({
+      type: 'hardware',
+      data: { hardwareType: 'mainboard', configFile: 'printer.cfg', mcuName: '' },
+    });
+    const b = computeLogicalKey({
+      type: 'hardware',
+      data: { hardwareType: 'toolhead', configFile: 'printer.cfg', mcuName: 'EBBCan' },
+    });
+    expect(a).not.toBe(b);
+  });
+});
+
+// ── normalizeSavedLayout / buildLayoutPayload ────────────────────────
+
+describe('saved layout (de)serialization', () => {
+  it('normalizes legacy shapes (full nodes / endpoint-less edges)', () => {
+    const raw = {
+      graphNodes: [
+        // legacy native save: FULL node objects (no logicalKey)
+        {
+          id: 'node_1',
+          position: { x: 10, y: 20 },
+          type: 'feature',
+          data: { configFile: 'hotkey.cfg', sectionHeader: 'bed_mesh', sectionLineNumber: 12 },
+        },
+        // current compact save
+        { id: 'node_2', position: { x: 30, y: 40 }, logicalKey: 'sbc|singleton' },
+        // malformed entries — dropped, never thrown
+        null,
+        { id: 'node_3' },
+        { position: { x: 1, y: 2 } },
+      ],
+      graphEdges: [
+        { id: 'edge_1', data: { edgeType: 'communication' }, sourceHandle: 'top' },
+        { id: 'edge_2', source: 'node_1', target: 'node_3', data: { edgeType: 'configuration' } },
+        'garbage',
+      ],
+      macroDesigner: null,
+    };
+    const norm = normalizeSavedLayout(raw);
+    expect(norm.graphNodes).toHaveLength(2);
+    // logical key computed from the legacy full-node data
+    expect(norm.graphNodes[0].logicalKey).toBe('sec|hotkey.cfg|bed_mesh#12');
+    expect(norm.graphNodes[1].logicalKey).toBe('sbc|singleton');
+    expect(norm.graphEdges[0]).toMatchObject({ id: 'edge_1', sourceHandle: 'top' });
+    expect(norm.graphEdges[0].source).toBeUndefined();
+    expect(norm.graphEdges[1]).toMatchObject({ source: 'node_1', target: 'node_3' });
+  });
+
+  it('round-trips buildLayoutPayload through normalizeSavedLayout', () => {
+    const nodes = [
+      {
+        id: 'node_1', type: 'hardware' as never, position: { x: 1, y: 2 },
+        data: { hardwareType: 'sbc', configFile: '', mcuName: '' } as never,
+      },
+    ] as never[];
+    const edges = [{ id: 'edge_1', source: 'node_1', target: 'node_2', data: { edgeType: 'communication' } }] as never[];
+    const payload = buildLayoutPayload(nodes, edges, null);
+    const norm = normalizeSavedLayout(payload);
+    expect(norm.graphNodes[0]).toEqual({ id: 'node_1', position: { x: 1, y: 2 }, logicalKey: 'sbc|singleton' });
+    expect(norm.graphEdges[0]).toMatchObject({
+      id: 'edge_1', source: 'node_1', target: 'node_2',
+    });
+  });
+});
+
+// ── Refresh scenarios (the original bug) ─────────────────────────────
+
+describe('refresh persistence (real store + builder, module-counter reset)', () => {
+  it('plain refresh: every card keeps its position', async () => {
+    const m1 = await freshModules();
+    m1.graph.getState().clearGraph();
+    m1.buildProjectGraph(TRIDENT_CONFIGS, m1.graph.getState(), SCHEMAS);
+    arrangeAll(m1);
+    const before = m1.graph.getState().nodes.map((n) => ({ ...n, data: { ...n.data } }));
+    const saved = buildLayoutPayload(m1.graph.getState().nodes, m1.graph.getState().edges, null);
+
+    // page refresh → module counters reset
+    const m2 = await freshModules();
+    m2.graph.getState().clearGraph();
+    m2.buildProjectGraph(TRIDENT_CONFIGS, m2.graph.getState(), SCHEMAS);
+    const g2 = m2.graph.getState();
+    g2.setNodes(applySavedNodePositions(g2.nodes, saved.graphNodes) as never);
+    // Re-read state — the g2 snapshot is stale after setNodes
+    checkPositionsRestored(before, m2.graph.getState().nodes);
+  });
+
+  it('add section to earlier-sorted file, then refresh: every pre-existing card keeps ITS OWN position', async () => {
+    const m1 = await freshModules();
+    m1.graph.getState().clearGraph();
+    m1.buildProjectGraph(TRIDENT_CONFIGS, m1.graph.getState(), SCHEMAS);
+    arrangeAll(m1);
+    const before = m1.graph.getState().nodes.map((n) => ({ ...n, data: { ...n.data } }));
+    const saved = buildLayoutPayload(m1.graph.getState().nodes, m1.graph.getState().edges, null);
+
+    // user adds [output_pin] to hotkey.cfg BEFORE fan/bed_mesh → the
+    // rebuilt id sequence shifts (this is the original repro: cards
+    // silently fell back to auto-arranged positions)
+    const m2 = await freshModules();
+    m2.graph.getState().clearGraph();
+    m2.buildProjectGraph(tridentWithOutputPinBefore(), m2.graph.getState(), SCHEMAS);
+    const g2 = m2.graph.getState();
+    g2.setNodes(applySavedNodePositions(g2.nodes, saved.graphNodes) as never);
+    checkPositionsRestored(before, m2.graph.getState().nodes);
+  });
+
+  it('legacy save (id + position only, no logicalKey) survives the shift via id fallback OR key-less no-op', async () => {
+    // A save written by the OLD browser code: {id, position} only.
+    // After the id shift, no keyed match exists — ids don't line up, so
+    // cards keep auto-arranged positions instead of the WRONG card's
+    // position (never worse than before; new-format saves match by key).
+    const m1 = await freshModules();
+    m1.graph.getState().clearGraph();
+    m1.buildProjectGraph(TRIDENT_CONFIGS, m1.graph.getState(), SCHEMAS);
+    const legacy = m1.graph.getState().nodes.map((n) => ({ id: n.id, position: n.position }));
+
+    const m2 = await freshModules();
+    m2.graph.getState().clearGraph();
+    m2.buildProjectGraph(tridentWithOutputPinBefore(), m2.graph.getState(), SCHEMAS);
+    const g2 = m2.graph.getState();
+    g2.setNodes(applySavedNodePositions(g2.nodes, legacy as never) as never);
+
+    // The critical safety property: where a legacy id still names the SAME
+    // card in both rebuilds, the restored position must be that card's own
+    // saved position (never a foreign card's). Legacy + shifted ids simply
+    // leave later cards auto-arranged — same as today's exact-id restore.
+    const g2fresh = m2.graph.getState();
+    const byKeyAfter = keyedPositions(g2fresh.nodes);
+    const savedById = new Map(legacy.map((s) => [s.id, s.position]));
+    const m1nodeById = new Map(m1.graph.getState().nodes.map((n) => [n.id, n]));
+    const g2nodeById = new Map(g2fresh.nodes.map((n) => [n.id, n]));
+    for (const [id, pos] of savedById) {
+      const oldNode = m1nodeById.get(id);
+      const newNode = g2nodeById.get(id);
+      if (!oldNode || !newNode) continue;
+      const oldKey = computeLogicalKey(oldNode);
+      const newKey = computeLogicalKey(newNode);
+      if (!newKey || oldKey !== newKey) continue; // card identity changed at this id
+      const applied = byKeyAfter.get(newKey);
+      if (applied && JSON.stringify(applied) !== JSON.stringify(pos)) {
+        throw new Error(`id ${id}: card ${newKey} got a foreign position`);
+      }
+    }
+    expect(g2fresh.nodes.length).toBeGreaterThan(0);
+  });
+
+  it('group-threshold collapse (3+ sections) does not poison other cards', async () => {
+    const m1 = await freshModules();
+    m1.graph.getState().clearGraph();
+    m1.buildProjectGraph(TRIDENT_CONFIGS, m1.graph.getState(), SCHEMAS);
+    arrangeAll(m1);
+    const before = m1.graph.getState().nodes.map((n) => ({ ...n, data: { ...n.data } }));
+    const saved = buildLayoutPayload(m1.graph.getState().nodes, m1.graph.getState().edges, null);
+
+    const m2 = await freshModules();
+    m2.graph.getState().clearGraph();
+    m2.buildProjectGraph(threeOutputPinsBefore(), m2.graph.getState(), SCHEMAS);
+    const g2 = m2.graph.getState();
+    g2.setNodes(applySavedNodePositions(g2.nodes, saved.graphNodes) as never);
+    const g2fresh = m2.graph.getState();
+
+    // The three output_pins collapsed into one group card under EBBCan
+    const hotkeyGroups = g2fresh.nodes.filter((n) => (n.data as Record<string, unknown>).configFile === 'hotkey.cfg' && n.type === 'group');
+    expect(hotkeyGroups.length).toBeGreaterThanOrEqual(1);
+
+    // Every surviving card keeps its own saved position; the new group
+    // card must not squat on a saved spot (checkPositionsRestored also
+    // asserts the squatting direction)
+    checkPositionsRestored(before, g2fresh.nodes);
+  });
+});
+
+// ── Wire routing across a rebuild ────────────────────────────────────
+
+describe('edge routing restoration across id shift', () => {
+  it('remaps saved wire endpoints through logical keys after the id sequence shifts', async () => {
+    const m1 = await freshModules();
+    m1.graph.getState().clearGraph();
+    m1.buildProjectGraph(TRIDENT_CONFIGS, m1.graph.getState(), SCHEMAS);
+
+    // User routes the SBC↔EBBCan communication wire (the builder may
+    // already have created it — use it; otherwise draw one) and bends it
+    const g1 = m1.graph.getState();
+    const sbc = g1.nodes.find((n) => (n.data as Record<string, unknown>).hardwareType === 'sbc')!;
+    const ebbc = g1.nodes.find((n) => (n.data as Record<string, unknown>).mcuName === 'EBBCan' && n.type === 'hardware')!;
+    const existing = g1.edges.find((e) =>
+      (e.data as Record<string, unknown>).edgeType === 'communication'
+      && ((e.source === sbc.id && e.target === ebbc.id) || (e.source === ebbc.id && e.target === sbc.id)));
+    const edgeId = existing?.id ?? m1.graph.getState().addCommunicationEdge(sbc.id, ebbc.id, 'canbus');
+    m1.graph.getState().updateEdgeData(edgeId, { customMiddlePoints: [{ x: 77, y: 88 }] } as never);
+    // Connection sides (what the user picks when drawing)
+    m1.graph.getState().setEdges(
+      m1.graph.getState().edges.map((e) =>
+        e.id === edgeId ? { ...e, sourceHandle: 'top', targetHandle: 'bottom' } : e) as never);
+    arrangeAll(m1);
+
+    // Re-read state (zustand snapshots are immutable — the g1 above is stale)
+    const g1fresh = m1.graph.getState();
+    const saved = buildLayoutPayload(g1fresh.nodes, g1fresh.edges, null) as SavedLayout;
+    const savedEdge = saved.graphEdges.find((e) => e.id === edgeId)!;
+    expect(savedEdge.source).toBe(sbc.id);
+    expect(savedEdge.target).toBe(ebbc.id);
+
+    // Refresh + a new board created before the existing ones → the
+    // hardware node ids shift
+    const m2 = await freshModules();
+    m2.graph.getState().clearGraph();
+    m2.buildProjectGraph(tridentWithExtraBoardFirst(), m2.graph.getState(), SCHEMAS);
+    const g2 = m2.graph.getState();
+
+    // EBBCan's hardware id differs from the saved one (SBC stays first)
+    const newEbbc = g2.nodes.find((n) => n.type === 'hardware' && (n.data as Record<string, unknown>).mcuName === 'EBBCan')!;
+    expect(newEbbc.id).not.toBe(ebbc.id);
+    void newEbbc;
+
+    g2.setEdges(applySavedEdgeLayout(g2.edges, saved.graphEdges, g2.nodes, saved.graphNodes) as never);
+
+    // The rebuilt SBC→EBBCan wire (new endpoint ids) must carry the saved
+    // routing + handles (re-read state — the g2 snapshot is stale)
+    const g2fresh = m2.graph.getState();
+    const newSbc = g2fresh.nodes.find((n) => (n.data as Record<string, unknown>).hardwareType === 'sbc')!;
+    const newEbbc2 = g2fresh.nodes.find((n) => n.type === 'hardware' && (n.data as Record<string, unknown>).mcuName === 'EBBCan')!;
+    const routed = g2fresh.edges.find((e) =>
+      (e.data as Record<string, unknown>).edgeType === 'communication'
+      && e.source === newSbc.id && e.target === newEbbc2.id);
+    expect(routed).toBeDefined();
+    const d = routed!.data as Record<string, unknown>;
+    expect(d.customMiddlePoints).toEqual([{ x: 77, y: 88 }]);
+    expect(routed!.sourceHandle).toBe('top');
+    expect(routed!.targetHandle).toBe('bottom');
+  });
+});
+
+// ── In-session rebuild (the clobber bug) ─────────────────────────────
+
+describe('in-session full rebuild (reference-add / import / revert)', () => {
+  it('full rebuild after adding a reference config preserves existing cards + positions', async () => {
+    const m = await freshModules();
+    // Seed the config store the way startup would (updateConfigFile path
+    // is what TextEditor uses for the new reference file)
+    m.config.getState().loadConfigs(TRIDENT_CONFIGS as never);
+    m.graph.getState().clearGraph();
+    m.buildProjectGraph(TRIDENT_CONFIGS, m.graph.getState(), SCHEMAS);
+    arrangeAll(m);
+    const before = m.graph.getState().nodes.map((n) => ({ ...n, data: { ...n.data } }));
+    const saved = buildLayoutPayload(m.graph.getState().nodes, m.graph.getState().edges, null);
+    const beforeCount = m.graph.getState().nodes.length;
+
+    // The FIXED reference-add path: updateConfigFile(new file) + clearGraph
+    // + buildProjectGraph over ALL files (NOT syncGraphWithConfig, which
+    // can't recreate deleted hardware nodes)
+    const referenceFile: ConfigFile = {
+      filename: 'reference.cfg',
+      // Real reference configs carry their own [mcu] section — that's what
+      // turns the file into a board in the graph
+      sections: [
+        sec('mcu', 'mcu refmcu', 'refmcu'),
+        sec('output_pin', 'output_pin: ref'),
+      ],
+      includes: [],
+      header_comments: [],
+      raw_text: '',
+    };
+    m.config.getState().updateConfigFile('reference.cfg', referenceFile as never);
+    const g = m.graph.getState();
+    g.clearGraph();
+    const cs = m.config.getState();
+    m.buildProjectGraph(cs.configFiles, g, SCHEMAS, cs.validation);
+    // Then re-apply the saved layout (restoreLayoutAfterRebuild in the app)
+    const g2 = m.graph.getState();
+    g2.setNodes(applySavedNodePositions(g2.nodes, saved.graphNodes) as never);
+    g2.setEdges(applySavedEdgeLayout(g2.edges, saved.graphEdges, g2.nodes, saved.graphNodes) as never);
+    // Re-read state — the g2 snapshot is stale after setNodes/setEdges
+    const g2fresh = m.graph.getState();
+
+    // Nothing was wiped: every pre-existing card is back with its saved
+    // position (and new cards don't squat on saved spots)
+    checkPositionsRestored(before, g2fresh.nodes);
+    // …and the new file's board is present
+    expect(g2fresh.nodes.length).toBeGreaterThan(beforeCount);
+    expect(g2fresh.nodes.some((n) => n.type === 'hardware' && (n.data as Record<string, unknown>).mcuName === 'refmcu')).toBe(true);
+  });
+
+  it('documents why the OLD reference-add path emptied the canvas', async () => {
+    const m = await freshModules();
+    m.config.getState().loadConfigs(TRIDENT_CONFIGS as never);
+    m.graph.getState().clearGraph();
+    m.buildProjectGraph(TRIDENT_CONFIGS, m.graph.getState(), SCHEMAS);
+    expect(m.graph.getState().nodes.length).toBeGreaterThan(0);
+
+    // OLD path: clearGraph + syncGraphWithConfig(newFile)
+    m.graph.getState().clearGraph();
+    m.graph.getState().syncGraphWithConfig('printer.cfg');
+    expect(m.graph.getState().nodes.length).toBe(0);
+  });
+});

--- a/frontend/src/utils/__tests__/miniDiff.test.ts
+++ b/frontend/src/utils/__tests__/miniDiff.test.ts
@@ -468,6 +468,55 @@ algorithm: bicubic
     expect(result.applied).toBe(true);
     expect(result.text).toBe(`[gcode_macro X]\ngcode:\n    G28\n    M117 done\n\n`);
   });
+
+  it('matches a gcode body line ignoring the base line trailing # comment', () => {
+    // Regression: gcode lines frequently carry trailing comments that the
+    // model omits when copying a line into the mini-diff. Without this the
+    // removal failed, the block fell back to the RAW text and the literal
+    // '- SET_LED ...' line leaked into the merged config as gcode.
+    const base = `[gcode_macro Chamber_LEDs]\ngcode:\n    SET_LED LED="Chamber_LEDs" RED=0.0 GREEN=0.0 BLUE=0.0 SYNC=0 TRANSMIT=1 # turn off\n    M104 S0\n`;
+    const result = applyMiniDiffBlock(
+      '[gcode_macro Chamber_LEDs]\n- SET_LED LED="Chamber_LEDs" RED=0.0 GREEN=0.0 BLUE=0.0 SYNC=0 TRANSMIT=1\n+ _LED LED="Chamber_LEDs" RED=0.0 GREEN=0.0 BLUE=0.0 SYNC=0 TRANSMIT=1',
+      base,
+    );
+    expect(result.applied).toBe(true);
+    expect(result.text).toContain('    _LED LED="Chamber_LEDs"');
+    // The removed line's trailing comment is dropped with the replaced line.
+    expect(result.text).not.toContain('SET_LED LED="Chamber_LEDs"');
+    // Unchanged lines survive.
+    expect(result.text).toContain('    M104 S0');
+  });
+
+  it('does not use comment-tolerant matching on plain (non-gcode) sections', () => {
+    const base = `[printer]\nmax_accel: 15500 #Ellis Tuned\n`;
+    const result = applyMiniDiffBlock(
+      '[printer]\n-max_accel: 15500\n+max_accel: 18000',
+      base,
+    );
+    expect(result.applied).toBe(false);
+  });
+
+  it('fails the WHOLE block when one section cannot be applied (atomicity)', () => {
+    // Regression: partial application silently DROPPED the failed section from
+    // the output while claiming applied=true — the failed section's edit never
+    // appeared in the review. A block must either apply fully or fall back.
+    const base = `[gcode_macro A]\ngcode:\n    G28\n\n[gcode_macro B]\ngcode:\n    M104 S0\n`;
+    const result = applyMiniDiffBlock(
+      '[gcode_macro A]\n-    G28\n+    G28 X0\n\n[gcode_macro B]\n-    M999\n+    M104 S0',
+      base,
+    );
+    expect(result.applied).toBe(false);
+    expect(result.text).toContain('-    G28');
+  });
+
+  it('fails the whole block when a section in the block is not in the base file', () => {
+    const base = `[gcode_macro A]\ngcode:\n    G28\n`;
+    const result = applyMiniDiffBlock(
+      '[gcode_macro A]\n-    G28\n+    G28 X0\n\n[gcode_macro NEW_MACRO]\n-    M104\n+    M104 S0',
+      base,
+    );
+    expect(result.applied).toBe(false);
+  });
 });
 
 describe('fenceUnfencedMiniDiffs', () => {

--- a/frontend/src/utils/__tests__/miniDiff.test.ts
+++ b/frontend/src/utils/__tests__/miniDiff.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isMiniDiffBlock, applyMiniDiffBlock, classifyMiniDiffLine, fenceUnfencedMiniDiffs } from '../miniDiff';
+import { isMiniDiffBlock, applyMiniDiffBlock, classifyMiniDiffLine, fenceUnfencedMiniDiffs, stripMiniDiffMarkers } from '../miniDiff';
 
 const LEVEL_BED_SECTION = `[gcode_macro Level_Bed]
 #rename_existing: _BED_MESH_CALIBRATE
@@ -516,6 +516,39 @@ algorithm: bicubic
       base,
     );
     expect(result.applied).toBe(false);
+  });
+});
+
+describe('stripMiniDiffMarkers', () => {
+  it('strips markers from a mixed block, preserving gcode indentation', () => {
+    const block = '[gcode_macro Level_Bed]\n-    G28\n+    G28 X0\n+    M104 S0\n    M84';
+    expect(stripMiniDiffMarkers(block)).toBe(
+      '[gcode_macro Level_Bed]\n    G28\n    G28 X0\n    M104 S0\n    M84',
+    );
+  });
+
+  it('strips ALL separator spaces from param-shaped lines (no stray indent)', () => {
+    // Regression: the old fallback strip ate exactly one separator char, so a
+    // model emitting `-  max_accel: 15500` (marker, two spaces, column-0 param)
+    // left ` max_accel: 15500` — a leading space the parser folds into the
+    // PREVIOUS param's multi-line value, silently corrupting the config.
+    expect(stripMiniDiffMarkers('[printer]\n-  max_accel: 15500\n+  max_accel: 18000')).toBe(
+      '[printer]\nmax_accel: 15500\nmax_accel: 18000',
+    );
+  });
+
+  it('keeps one-separator stripping for non-param lines (jinja indent preserved)', () => {
+    // `{% set x = 1 %}` is not param-shaped — strip exactly one separator and
+    // keep the line's own indentation (multi-line jinja blocks).
+    expect(stripMiniDiffMarkers('[gcode_macro A]\ngcode:\n-    {% set x = 1 %}\n+    {% set x = 2 %}')).toBe(
+      '[gcode_macro A]\ngcode:\n    {% set x = 1 %}\n    {% set x = 2 %}',
+    );
+  });
+
+  it('leaves context (unmarked) lines untouched', () => {
+    expect(stripMiniDiffMarkers('# file: printer.cfg\n[bed_mesh]\n    algorithm: bicubic')).toBe(
+      '# file: printer.cfg\n[bed_mesh]\n    algorithm: bicubic',
+    );
   });
 });
 

--- a/frontend/src/utils/layoutPersistence.ts
+++ b/frontend/src/utils/layoutPersistence.ts
@@ -1,0 +1,410 @@
+import type { AppEdge, AppNode } from '../types/graph';
+import { sectionIdentity } from '../stores/graphStore';
+import * as api from '../services/api';
+
+/**
+ * Layout persistence helpers shared by the startup restore paths (App.tsx)
+ * and the in-session rebuild paths (Import/Revert/OpenFromPi/AI-accept/
+ * TextEditor reference-add).
+ *
+ * WHY LOGICAL KEYS
+ * Node ids come from a module-level counter (`node_${++n}`) that resets on
+ * every page load. Two rebuilds only produce the SAME id sequence when the
+ * config produced the exact same nodes in the exact same order — adding a
+ * section to an earlier-sorted file, an MCU rename, a group-threshold flip
+ * (3+ sections collapse into one group card) all shift the sequence.
+ * Positions saved under the old ids then silently fall back to
+ * auto-arranged. This module keys positions and edge routing by stable
+ * content identity (file + section header, board identity) so a card
+ * reclaims ITS OWN saved spot regardless of rebuild ordering. Exact-id
+ * match is kept as a fast path for unchanged configs (and for legacy saves
+ * that predate logical keys).
+ *
+ * SAVED SHAPES
+ * All save paths now write the same payload (see buildLayoutPayload).
+ * Older saves exist in the wild in two shapes — native mode used to store
+ * FULL node objects, and browser mode stored edges WITHOUT source/target.
+ * normalizeSavedLayout accepts both and upgrades them to the current shape
+ * (computing logical keys from full node data where absent).
+ */
+
+export const LAYOUT_STORAGE_KEY = 'kwc.graphLayout';
+
+/** Minimal saved node — identity fields plus position. `logicalKey` is
+ *  optional: saves written before the key existed only match by id. */
+export interface SavedLayoutNode {
+  id: string;
+  position: { x: number; y: number };
+  logicalKey?: string;
+}
+
+/** Saved edge routing entry. `source`/`target` are node ids from the save
+ *  moment — they may not exist in the rebuilt graph and must be remapped
+ *  through logical keys before pair-matching (same counter-reset problem
+ *  as node positions). */
+export interface SavedLayoutEdge {
+  id: string;
+  source?: string;
+  target?: string;
+  data?: Record<string, unknown>;
+  sourceHandle?: string;
+  targetHandle?: string;
+}
+
+/** Full layout payload shared by the backend (layout.json) and the
+ *  browser localStorage fallback. */
+export interface SavedLayout {
+  graphNodes: SavedLayoutNode[];
+  graphEdges: SavedLayoutEdge[];
+  macroDesigner?: unknown;
+}
+
+/**
+ * Stable content identity for a graph node, independent of the ephemeral
+ * `node_N` id:
+ *  - hardware: board type + config file + MCU name (a multi-MCU file hosts
+ *    several boards; the SBC is a singleton)
+ *  - subComponent/feature: config file + section header (`sectionIdentity`,
+ *    the same helper the rest of the app uses to mean "the same section" —
+ *    header-based, so line-number drift inside the file doesn't break it)
+ *  - group: config file + group name + feature flag + the SET of section
+ *    headers the group collapses (sorted, order-insensitive — sibling
+ *    re-ordering must not change the group's identity)
+ *  - customGroup: user-drawn grouping container with no config backing —
+ *    no stable identity; falls back to id matching.
+ */
+export function computeLogicalKey(node: { type: string; data: Record<string, unknown> }): string | null {
+  const d = node.data;
+  const str = (v: unknown): string | undefined => (typeof v === 'string' && v ? v : undefined);
+
+  if (node.type === 'hardware') {
+    const hwType = str(d.hardwareType);
+    if (!hwType) return null;
+    if (hwType === 'sbc') return 'sbc|singleton';
+    const configFile = str(d.configFile) ?? '';
+    const mcuName = str(d.mcuName) ?? '';
+    return `hw|${hwType}|${configFile}|${mcuName}`;
+  }
+
+  if (node.type === 'subComponent' || node.type === 'feature') {
+    const configFile = str(d.configFile) ?? '';
+    const sectionHeader = str(d.sectionHeader);
+    if (!sectionHeader) return null;
+    const line = typeof d.sectionLineNumber === 'number' ? d.sectionLineNumber : undefined;
+    return `sec|${configFile}|${sectionIdentity(sectionHeader, line)}`;
+  }
+
+  if (node.type === 'group') {
+    const componentGroup = str(d.componentGroup);
+    if (!componentGroup) return null;
+    const children = Array.isArray(d.children)
+      ? (d.children as Array<{ sectionHeader?: string; sectionLineNumber?: number }>)
+      : [];
+    const childIds = children
+      .map((c) => sectionIdentity(c.sectionHeader ?? '', c.sectionLineNumber))
+      .sort();
+    const configFile = str(d.configFile) ?? '';
+    return `grp|${configFile}|${componentGroup}|${d.isFeature ? 'f' : 'c'}|${childIds.join(',')}`;
+  }
+
+  return null;
+}
+
+/**
+ * Map logical key → current node id (first node wins). Used to remap saved
+ * edge endpoints (save-moment ids) onto rebuilt node ids.
+ */
+export function nodeKeyToId(nodes: readonly AppNode[]): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const n of nodes) {
+    const key = computeLogicalKey(n);
+    if (key && !map.has(key)) map.set(key, n.id);
+  }
+  return map;
+}
+
+/** Old (save-moment) node id → new (rebuilt) node id.
+ *
+ * Keyed saves (current format): remap through the saved node table's
+ * logical keys — never assume an old id that happens to exist in the
+ * rebuilt graph is the same node (ids are recycled: node_3 at save time
+ * may be a different board after the rebuild).
+ *
+ * Legacy saves (no logicalKey anywhere): id identity is only safe when
+ * the saved id set is a bijection of the current id set (no shift);
+ * otherwise old ids can't be trusted and are left unmapped. */
+export function buildIdRemap(
+  savedNodes: readonly SavedLayoutNode[],
+  currentNodes: readonly AppNode[],
+): Map<string, string> {
+  const remap = new Map<string, string>();
+  const keyToNewId = nodeKeyToId(currentNodes);
+  const currentIds = new Set(currentNodes.map((n) => n.id));
+  const savedIds = new Set(savedNodes.map((s) => s.id));
+  const legacyBijection = savedNodes.length === currentNodes.length
+    && currentNodes.every((n) => savedIds.has(n.id));
+  for (const s of savedNodes) {
+    if (s.logicalKey) {
+      const newId = keyToNewId.get(s.logicalKey);
+      if (newId) remap.set(s.id, newId);
+    } else if (legacyBijection && currentIds.has(s.id)) {
+      remap.set(s.id, s.id);
+    }
+  }
+  return remap;
+}
+
+/**
+ * Coerce any shape of stored layout into the canonical SavedLayout:
+ *  - graphNodes: compact entries ({id, position, logicalKey}) OR legacy
+ *    full AppNode objects (keys computed from type+data)
+ *  - graphEdges: entries with or without source/target (legacy browser
+ *    saves omitted them — those degrade to id-matching only)
+ * Malformed entries are dropped, never thrown.
+ */
+export function normalizeSavedLayout(raw: unknown): SavedLayout {
+  const graphNodes: SavedLayoutNode[] = [];
+  const graphEdges: SavedLayoutEdge[] = [];
+  if (!raw || typeof raw !== 'object') return { graphNodes, graphEdges };
+  const r = raw as Record<string, unknown>;
+
+  if (Array.isArray(r.graphNodes)) {
+    for (const entry of r.graphNodes) {
+      if (!entry || typeof entry !== 'object') continue;
+      const n = entry as Record<string, unknown>;
+      if (typeof n.id !== 'string') continue;
+      const p = n.position as { x?: unknown; y?: unknown } | undefined;
+      if (!p || typeof p.x !== 'number' || typeof p.y !== 'number') continue;
+      let logicalKey = typeof n.logicalKey === 'string' && n.logicalKey ? n.logicalKey : undefined;
+      if (!logicalKey && typeof n.type === 'string' && n.data && typeof n.data === 'object') {
+        logicalKey = computeLogicalKey({ type: n.type, data: n.data as Record<string, unknown> }) ?? undefined;
+      }
+      graphNodes.push({ id: n.id, position: { x: p.x, y: p.y }, logicalKey });
+    }
+  }
+
+  if (Array.isArray(r.graphEdges)) {
+    for (const entry of r.graphEdges) {
+      if (!entry || typeof entry !== 'object') continue;
+      const e = entry as Record<string, unknown>;
+      if (typeof e.id !== 'string') continue;
+      graphEdges.push({
+        id: e.id,
+        source: typeof e.source === 'string' ? e.source : undefined,
+        target: typeof e.target === 'string' ? e.target : undefined,
+        data: e.data && typeof e.data === 'object' ? e.data as Record<string, unknown> : undefined,
+        sourceHandle: typeof e.sourceHandle === 'string' ? e.sourceHandle : undefined,
+        targetHandle: typeof e.targetHandle === 'string' ? e.targetHandle : undefined,
+      });
+    }
+  }
+
+  return { graphNodes, graphEdges, macroDesigner: r.macroDesigner ?? null };
+}
+
+/**
+ * Canonical payload for BOTH save modes (native layout.json and browser
+ * localStorage). Nodes are stored compact (id + position + logical key —
+ * positions are all restore needs); edges carry endpoints so routing can
+ * be remapped across rebuilds even when the id sequence shifted.
+ */
+export function buildLayoutPayload(
+  nodes: readonly AppNode[],
+  edges: readonly AppEdge[],
+  macroDesigner: unknown,
+): SavedLayout {
+  return {
+    graphNodes: nodes.map((n) => ({
+      id: n.id,
+      position: n.position,
+      logicalKey: computeLogicalKey(n) ?? undefined,
+    })),
+    graphEdges: edges.map((e) => ({
+      id: e.id,
+      source: e.source,
+      target: e.target,
+      data: e.data as Record<string, unknown>,
+      sourceHandle: e.sourceHandle ?? undefined,
+      targetHandle: e.targetHandle ?? undefined,
+    })),
+    macroDesigner,
+  };
+}
+
+/**
+ * Overlay saved node positions onto the current (rebuilt) graph nodes.
+ *
+ * Matching order per rebuilt node:
+ *   1. saved entry carrying the node's logical key (content identity)
+ *   2. saved entry with the same id (fast path / legacy saves)
+ *
+ * Logical key wins on conflict: ids are ephemeral, content is not.
+ */
+export function applySavedNodePositions(
+  currentNodes: readonly AppNode[],
+  savedNodes: readonly SavedLayoutNode[],
+): AppNode[] {
+  if (savedNodes.length === 0) return [...currentNodes];
+
+  const byKey = new Map<string, SavedLayoutNode>();
+  const byId = new Map<string, SavedLayoutNode>();
+  for (const s of savedNodes) {
+    if (s.logicalKey) {
+      if (!byKey.has(s.logicalKey)) byKey.set(s.logicalKey, s);
+    }
+    if (!byId.has(s.id)) byId.set(s.id, s);
+  }
+
+  // Legacy saves (no logicalKey anywhere) carry no identity — id matching is
+  // only trustworthy when the saved id set is exactly the current id set
+  // (no shift). If the sets differ, a shifted legacy id could name a
+  // DIFFERENT card than it did at save time, so legacy id matches for
+  // key-able nodes are skipped (they keep auto-arranged positions) rather
+  // than risk one card wearing another's saved spot.
+  const savedIds = new Set(savedNodes.map((s) => s.id));
+  const legacyBijection = savedNodes.length === currentNodes.length
+    && currentNodes.every((n) => savedIds.has(n.id));
+
+  return currentNodes.map((node) => {
+    const key = computeLogicalKey(node);
+    if (key) {
+      const keyed = byKey.get(key);
+      if (keyed) return { ...node, position: keyed.position } as AppNode;
+      // Id fallback is only allowed when it cannot be STALE:
+      //  - keyed saves: the entry must carry the SAME card identity
+      //    (a shifted id naming a different card is exactly the bug this
+      //    module prevents — fall through to auto-arranged instead)
+      //  - legacy saves: only when ids are a bijection (no shift possible)
+      const byIdMatch = byId.get(node.id);
+      if (byIdMatch) {
+        const safe = byIdMatch.logicalKey
+          ? byIdMatch.logicalKey === key
+          : legacyBijection;
+        if (safe) return { ...node, position: byIdMatch.position } as AppNode;
+      }
+      return node;
+    }
+    // No content identity (customGroup / unknown node) → exact id only, and
+    // only when the saved entry is keyless too (or the save is a verified
+    // bijection) — a shifted id could otherwise hand a user-drawn group the
+    // saved position of a card that no longer lives at that id.
+    const byIdMatch = byId.get(node.id);
+    if (byIdMatch) {
+      const safe = !byIdMatch.logicalKey || legacyBijection;
+      if (safe) return { ...node, position: byIdMatch.position } as AppNode;
+    }
+    return node;
+  });
+}
+
+/**
+ * Overlay saved edge routing (custom bend points + connection-side handles)
+ * onto the rebuilt graph's edges.
+ *
+ * Saved endpoints are save-moment node ids — after a rebuild the same wire
+ * may connect `node_2 → node_5` instead of the saved `node_1 → node_3`.
+ * Endpoints are remapped through logical keys first; a saved edge whose
+ * endpoints can't be resolved (its cards no longer exist) is skipped by
+ * pair-matching but still eligible via exact id. Pair match is
+ * (source, target, edgeType), direction-agnostic — comm edges always
+ * rebuild SBC → hardware but the user may have drawn the opposite way.
+ */
+export function applySavedEdgeLayout(
+  currentEdges: readonly AppEdge[],
+  savedEdges: readonly SavedLayoutEdge[],
+  currentNodes: readonly AppNode[],
+  savedNodes: readonly SavedLayoutNode[],
+): AppEdge[] {
+  if (savedEdges.length === 0) return [...currentEdges];
+
+  const idRemap = buildIdRemap(savedNodes, currentNodes);
+  // Old endpoint → rebuilt node id. No "id still exists → same node"
+  // shortcut: ids are recycled across rebuilds, so only the remap (keyed
+  // by content identity, or bijection-verified legacy ids) is trusted.
+  const resolve = (id: string | undefined): string | undefined =>
+    id ? idRemap.get(id) : undefined;
+
+  const edgeTypeOf = (e: { data?: Record<string, unknown> }): string | undefined =>
+    (e.data as Record<string, unknown> | undefined)?.edgeType as string | undefined;
+  const pairKey = (sourceId: string | undefined, targetId: string | undefined, edgeType: string | undefined): string | null => {
+    if (!sourceId || !targetId) return null;
+    const [a, b] = [sourceId, targetId].sort();
+    return [a, b, edgeType ?? ''].join('|');
+  };
+
+  const savedByPair = new Map<string, SavedLayoutEdge>();
+  const savedById = new Map<string, SavedLayoutEdge>();
+  for (const s of savedEdges) {
+    const k = pairKey(resolve(s.source), resolve(s.target), edgeTypeOf(s));
+    if (k && !savedByPair.has(k)) savedByPair.set(k, s);
+    if (!savedById.has(s.id)) savedById.set(s.id, s);
+  }
+
+  return currentEdges.map((edge) => {
+    const found =
+      savedByPair.get(pairKey(edge.source, edge.target, edgeTypeOf(edge)) ?? '')
+      ?? savedById.get(edge.id);
+    if (!found) return edge;
+    const next: Record<string, unknown> = { ...edge };
+    if (found.data) {
+      next.data = {
+        ...edge.data,
+        ...found.data,
+        customMiddlePoints: (found.data as Record<string, unknown>).customMiddlePoints,
+      } as unknown as AppEdge['data'];
+    }
+    if (found.sourceHandle) next.sourceHandle = found.sourceHandle;
+    if (found.targetHandle) next.targetHandle = found.targetHandle;
+    return next as AppEdge;
+  });
+}
+
+/** Read the saved layout from wherever this mode persists it: backend
+ *  layout.json (native) or localStorage (browser). Returns null when absent
+ *  or unreadable — callers keep auto-arranged positions. */
+export async function loadSavedLayout(isNative: boolean | null): Promise<SavedLayout | null> {
+  if (isNative === null) return null; // status check still in flight
+  if (isNative) {
+    try {
+      const res = await api.loadNativeLayout();
+      return normalizeSavedLayout(res.layout);
+    } catch {
+      return null;
+    }
+  }
+  try {
+    const raw = localStorage.getItem(LAYOUT_STORAGE_KEY);
+    if (!raw) return null;
+    return normalizeSavedLayout(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Re-apply the saved layout after an in-session full rebuild
+ * (Import / Revert / Open-from-Pi / AI draft accept / TextEditor
+ * reference-add). Without this, every rebuild auto-arranges and the 3s
+ * autosave timer then persists that auto-arrangement OVER the user's saved
+ * layout.
+ *
+ * Content-key matching means this is a no-op (except for genuinely new
+ * cards, which keep their auto-arranged slot) when the config is
+ * unchanged, and restores the user's arrangement when the rebuild shifted
+ * node ids.
+ */
+export async function restoreLayoutAfterRebuild(
+  graphStore: {
+    nodes: AppNode[];
+    edges: AppEdge[];
+    setNodes: (n: AppNode[]) => void;
+    setEdges: (e: AppEdge[]) => void;
+  },
+  isNative: boolean | null,
+): Promise<void> {
+  const saved = await loadSavedLayout(isNative);
+  if (!saved) return;
+  const fresh = graphStore;
+  fresh.setNodes(applySavedNodePositions(fresh.nodes, saved.graphNodes));
+  fresh.setEdges(applySavedEdgeLayout(fresh.edges, saved.graphEdges, fresh.nodes, saved.graphNodes));
+}

--- a/frontend/src/utils/miniDiff.ts
+++ b/frontend/src/utils/miniDiff.ts
@@ -230,6 +230,36 @@ export function isMiniDiffBlock(configText: string): boolean {
   return hasHeader && hasMarker;
 }
 
+/**
+ * Strip the `-`/`+` mini-diff markers from a block, producing plain section
+ * text (used when the mini-diff cannot be applied against the base file and
+ * the block is treated as a FULL section write instead).
+ *
+ * Content handling follows the same convention as the apply path
+ * (MINI_DIFF_REMOVAL_RE): everything after the marker is the line's own
+ * content, indent included — that is how removals are matched against the
+ * base file. On top of that:
+ * - param-shaped lines (`key: value` / `key= value`, column 0 in Klipper
+ *   params) — trim to column 0. A model emitting `-  max_accel: 15500` must
+ *   NOT leave the leading space: an indented line is folded into the
+ *   PREVIOUS param's multi-line value by the parser, silently corrupting
+ *   the config.
+ * - all other lines (gcode bodies, jinja, comments) — kept verbatim, indent
+ *   included (harmless for gcode, keeps multi-line jinja indented blocks).
+ */
+export function stripMiniDiffMarkers(blockText: string): string {
+  return blockText
+    .split(/\r?\n/)
+    .map((line) => {
+      const marker = /^(\s*)[-+](.*)$/.exec(line);
+      if (!marker) return line;
+      const content = marker[2];
+      const trimmed = content.trimStart();
+      return PARAM_LINE_RE.test(trimmed) ? trimmed : content;
+    })
+    .join('\n');
+}
+
 /** Extract the operations for one section header from the block's lines. */
 function extractSectionOps(
   lines: string[],

--- a/frontend/src/utils/miniDiff.ts
+++ b/frontend/src/utils/miniDiff.ts
@@ -295,6 +295,7 @@ function applyOpsToSection(
       continue;
     }
     const normalizedRemoval = normalizeLine(op.removal);
+    const strippedRemoval = normalizedRemoval.trimStart();
     let matchIndex = base.findIndex(
       (line, index) => !used.has(index) && line === normalizedRemoval,
     );
@@ -304,10 +305,22 @@ function applyOpsToSection(
       // (e.g. 4-space indent emitted for a column-0 [printer] line) must still
       // match. Only leading whitespace is ignored — a real content mismatch
       // still returns null and the caller falls back to legacy handling.
-      const strippedRemoval = normalizedRemoval.trimStart();
       matchIndex = base.findIndex(
         (line, index) => !used.has(index) && line.trimStart() === strippedRemoval,
       );
+    }
+    if (matchIndex === -1 && sectionHasGcodeBody(sectionLines) && strippedRemoval.trim() !== '') {
+      // gcode-body lines frequently carry trailing `# comments` that the model
+      // omits when it copies a line into the mini-diff. Klipper strips `#`
+      // comments unconditionally, so a match ignoring the base line's trailing
+      // comment is faithful. Only applies to gcode-like bodies and to non-
+      // comment removals (a removal of a comment line matches exactly above).
+      const noCommentRemoval = strippedRemoval.split('#')[0].trimEnd();
+      if (noCommentRemoval !== '') {
+        matchIndex = base.findIndex(
+          (line, index) => !used.has(index) && line.trimStart().split('#')[0].trimEnd() === noCommentRemoval,
+        );
+      }
     }
     if (matchIndex === -1) return null;
     used.add(matchIndex);
@@ -398,6 +411,12 @@ export function applyMiniDiffBlock(
   const blockLines = configText.split(/\r?\n/);
   const baseLines = baseFileText.split(/\r?\n/);
   const outputSections: string[] = [];
+  // Atomicity: if ANY section in the block cannot be applied (removal not
+  // matched, or the section is not in the base file), fail the WHOLE block so
+  // the caller can fall back to the model's block as a full section write.
+  // Partial application would silently drop the failed sections (or, with the
+  // raw fallback, leak the literal `-`/`+` markers into the config as gcode).
+  let anyFailed = false;
 
   for (let blockIndex = 0; blockIndex < blockLines.length; blockIndex += 1) {
     if (!SECTION_HEADER_RE.test(blockLines[blockIndex])) continue;
@@ -409,7 +428,10 @@ export function applyMiniDiffBlock(
       (baseLine) => SECTION_HEADER_RE.test(baseLine)
         && SECTION_HEADER_RE.exec(baseLine)![1] === header,
     );
-    if (headerIndex === -1) continue; // section not in base — fall back
+    if (headerIndex === -1) {
+      anyFailed = true;
+      continue; // section not in base — caller falls back
+    }
 
     // Section extent: from the header line to the next section header, then
     // trimmed to the section's own content (trailing comment banners belong
@@ -424,12 +446,15 @@ export function applyMiniDiffBlock(
 
     const sectionLines = baseLines.slice(headerIndex, sectionContentEnd(baseLines, headerIndex, endIndex));
     const reconstructed = applyOpsToSection(sectionLines, ops);
-    if (!reconstructed) continue;
+    if (!reconstructed) {
+      anyFailed = true;
+      continue;
+    }
 
     outputSections.push(reconstructed.join('\n'));
   }
 
-  if (outputSections.length === 0) {
+  if (anyFailed || outputSections.length === 0) {
     return { applied: false, text: configText };
   }
   return { applied: true, text: outputSections.join('\n\n') };

--- a/scripts/ai_chat_accuracy_test.py
+++ b/scripts/ai_chat_accuracy_test.py
@@ -952,6 +952,26 @@ def build_trident_questions() -> list[TestQuestion]:
             ),
         ),
         TestQuestion(
+            qid="TRIDENT-16",
+            title="Real file: idle_timeout all LEDs (no file attached)",
+            text=("Can you edit my idle_timeout in my printer.cfg so it times "
+                  "out after 5 minutes and has gcode to turn off all of my LEDs?"),
+            # Harder variant of TRIDENT-15: NOTHING is attached — the model
+            # must discover printer.cfg's idle_timeout AND all three LED
+            # sections (SB_LEDs in EBB.cfg, Chamber_LEDs in printer.cfg,
+            # hotkey_leds in Hotkey.cfg) purely via tools.
+            context_files=(),
+            expected_tools=("read_user_config", "list_user_configs"),
+            require_tool=True,
+            criteria=(
+                ("regex", r"#\s*file\s*:\s*printer\.cfg"),
+                ("regex", r"timeout\s*:\s*300\b"),
+                ("contains", "SB_LEDs"),
+                ("contains", "Chamber_LEDs"),
+                ("contains", "hotkey_leds"),
+            ),
+        ),
+        TestQuestion(
             qid="MINIDIFF-01",
             title="Mini-diff: level_bed adaptive (endif invariant)",
             text=("Modify my level_bed macro in printer.cfg to call "

--- a/scripts/ai_chat_accuracy_test.py
+++ b/scripts/ai_chat_accuracy_test.py
@@ -932,6 +932,26 @@ def build_trident_questions() -> list[TestQuestion]:
             ),
         ),
         TestQuestion(
+            qid="TRIDENT-15",
+            title="Real file: idle_timeout turns off all LEDs",
+            text=("Can you edit my idle_timeout in my printer.cfg so it times "
+                  "out after 5 minutes and has gcode to turn off all of my LEDs?"),
+            # Only printer.cfg is attached — Chamber_LEDs is visible there, but
+            # SB_LEDs (EBB.cfg) and hotkey_leds (Hotkey.cfg) must be discovered
+            # via read_user_config (the backend user_configs mirror has all
+            # three files).
+            context_files=printer_cfg,
+            expected_tools=("read_user_config",),
+            require_tool=True,
+            criteria=(
+                ("regex", r"#\s*file\s*:\s*printer\.cfg"),
+                ("regex", r"timeout\s*:\s*300\b"),
+                ("contains", "SB_LEDs"),
+                ("contains", "Chamber_LEDs"),
+                ("contains", "hotkey_leds"),
+            ),
+        ),
+        TestQuestion(
             qid="MINIDIFF-01",
             title="Mini-diff: level_bed adaptive (endif invariant)",
             text=("Modify my level_bed macro in printer.cfg to call "
@@ -2012,6 +2032,12 @@ def main() -> int:
     log.write(f"Answer accuracy: {len([r for r in results if r.answer_ok])}/{len(results)}")
     log.write(f"Tool-usage accuracy: {len([r for r in results if r.tool_ok])}/{len(results)}")
     truncated_results = [r for r in results if (r.usage or {}).get("truncated")]
+    token_values: list[int] = []
+    for r in results:
+        tok = (r.usage or {}).get("completionTokens")
+        if isinstance(tok, int):
+            token_values.append(tok)
+    avg_tokens = (sum(token_values) / len(token_values)) if token_values else None
     log.write("")
     log.write(f"{'QID':<5} {'STATUS':<15} {'ANSWER':<7} {'TOOL':<7} {'TURNS':<6} {'TOKENS':<8} TOOLS USED")
     for r in results:
@@ -2029,6 +2055,9 @@ def main() -> int:
             usage = r.usage or {}
             log.write(f"  {r.qid} {r.title} (tokens={usage.get('completionTokens')} "
                       f"reasoning={usage.get('reasoningTokens')})")
+    if avg_tokens is not None:
+        log.write(f"Average completion tokens per question: {avg_tokens:.0f} "
+                  f"(over {len(token_values)} questions reporting usage)")
     if no_tool or wrong_tool:
         log.write("")
         log.write("Conditional passes (correct answer, tool requirement missed):")
@@ -2105,6 +2134,8 @@ def main() -> int:
     if truncated_results:
         print(f"Truncated (hit max_tokens): {len(truncated_results)} "
               f"-> {', '.join(r.qid for r in truncated_results)}")
+    if avg_tokens is not None:
+        print(f"Average tokens per question: {avg_tokens:.0f} (over {len(token_values)} questions)")
     marks = {"PASS": "PASS", "PASS_NO_TOOL": "PASS*", "PASS_WRONG_TOOL": "PASS+",
              "ERROR": "ERR "}
     for r in results:

--- a/scripts/ai_chat_accuracy_test.py
+++ b/scripts/ai_chat_accuracy_test.py
@@ -1481,6 +1481,7 @@ class QuestionResult:
     error: str = ""
     checks: list[tuple[str, str, bool]] = field(default_factory=list)
     duration_s: float = 0.0
+    usage: dict | None = None
 
 
 # ── HTTP helpers (stdlib only) ─────────────────────────────────────────
@@ -1651,9 +1652,20 @@ def run_one_question(
         result.tool_names = list(response.get("mcpToolNames", []) or [])
         result.tool_turns = int(response.get("mcpToolTurns", 0) or 0)
         result.tool_calls = list(response.get("toolCalls", []) or [])
+        result.usage = response.get("usage")
 
         log.write(f"Response mcpToolTurns={result.tool_turns} "
                   f"mcpToolNames={result.tool_names}")
+        if result.usage:
+            log.write(
+                "Usage: completion_tokens=%s reasoning_tokens=%s truncated=%s "
+                "events=%s" % (
+                    result.usage.get("completionTokens"),
+                    result.usage.get("reasoningTokens"),
+                    result.usage.get("truncated"),
+                    json.dumps(result.usage.get("events", []))[:500],
+                )
+            )
         log.write(f"Raw response keys: {sorted(response.keys())}")
         log.write(f"Answer ({len(result.response)} chars):")
         log.write(result.response)
@@ -1999,11 +2011,24 @@ def main() -> int:
                   f"{len(wrong_tool)} correct-but-wrong-tool")
     log.write(f"Answer accuracy: {len([r for r in results if r.answer_ok])}/{len(results)}")
     log.write(f"Tool-usage accuracy: {len([r for r in results if r.tool_ok])}/{len(results)}")
+    truncated_results = [r for r in results if (r.usage or {}).get("truncated")]
     log.write("")
-    log.write(f"{'QID':<5} {'STATUS':<15} {'ANSWER':<7} {'TOOL':<7} {'TURNS':<6} TOOLS USED")
+    log.write(f"{'QID':<5} {'STATUS':<15} {'ANSWER':<7} {'TOOL':<7} {'TURNS':<6} {'TOKENS':<8} TOOLS USED")
     for r in results:
+        usage = r.usage or {}
+        tokens = usage.get("completionTokens")
+        tok_s = str(tokens) if tokens is not None else "-"
+        if usage.get("truncated"):
+            tok_s += "*"  # * = hit max_tokens (finish_reason=length), possibly truncated
         log.write(f"{r.qid:<5} {r.status:<15} {str(r.answer_ok):<7} {str(r.tool_ok):<7} "
-                  f"{r.tool_turns:<6} {','.join(r.tool_names) or '-'}")
+                  f"{r.tool_turns:<6} {tok_s:<8} {','.join(r.tool_names) or '-'}")
+    if truncated_results:
+        log.write("")
+        log.write(f"Truncated (hit max_tokens budget, finish_reason=length): {len(truncated_results)}")
+        for r in truncated_results:
+            usage = r.usage or {}
+            log.write(f"  {r.qid} {r.title} (tokens={usage.get('completionTokens')} "
+                      f"reasoning={usage.get('reasoningTokens')})")
     if no_tool or wrong_tool:
         log.write("")
         log.write("Conditional passes (correct answer, tool requirement missed):")
@@ -2077,11 +2102,20 @@ def main() -> int:
           + (f", {len(conditional)} conditional" if conditional else "") + ")")
     print(f"Answer accuracy: {len([r for r in results if r.answer_ok])}/{len(results)}")
     print(f"Tool-usage accuracy: {len([r for r in results if r.tool_ok])}/{len(results)}")
+    if truncated_results:
+        print(f"Truncated (hit max_tokens): {len(truncated_results)} "
+              f"-> {', '.join(r.qid for r in truncated_results)}")
     marks = {"PASS": "PASS", "PASS_NO_TOOL": "PASS*", "PASS_WRONG_TOOL": "PASS+",
              "ERROR": "ERR "}
     for r in results:
         mark = marks.get(r.status, "FAIL")
-        print(f"  {r.qid} {mark}  tools=[{','.join(r.tool_names) or '-'}]  {r.title}")
+        usage = r.usage or {}
+        tok = usage.get("completionTokens")
+        tok_s = f" tok={tok}" if tok is not None else ""
+        if usage.get("truncated"):
+            tok_s += " TRUNC"
+        print(f"  {r.qid} {mark}  tools=[{','.join(r.tool_names) or '-'}]"
+              f"{tok_s}  {r.title}")
     if conditional:
         print("  * = correct answer, required tool not called "
               "| + = correct answer, wrong tool called")

--- a/scripts/ai_chat_accuracy_test.py
+++ b/scripts/ai_chat_accuracy_test.py
@@ -43,6 +43,9 @@ in logs and are never written to output files.
 Other useful flags:
     --questions 1-5,8     run only a subset of questions
     --start N             start at question N (runs N..end); ignored when --questions is set
+    --question TEXT       run ONE ad-hoc question of your own instead of the bank
+                          (takes priority over --questions/--start); repeatable
+                          --check TEXT adds case-insensitive pass criteria
     --list-questions      print the question bank and exit (no API calls)
     --output-dir DIR      where to write the log (default reports/ai-chat-accuracy)
     --include-memory      also test printer-memory auto-fill (MEMORY-01..03); the backend's
@@ -1917,6 +1920,15 @@ def main() -> int:
     parser.add_argument("--start", default=0, type=int,
                         help="Start at question N (1-based), running N..end. "
                              "Ignored when --questions is set.")
+    parser.add_argument("--question", action="append", default=[], metavar="TEXT",
+                        help="Ad-hoc question to run INSTEAD of the bank (repeatable "
+                             "for several one-offs). Takes priority over --questions "
+                             "and --start. QID: AD-01, AD-02, ...")
+    parser.add_argument("--check", action="append", default=[], metavar="TEXT",
+                        help="Case-insensitive substring the answer must contain "
+                             "(repeatable). With one --question every --check "
+                             "applies to it; with several, check N pairs with "
+                             "question N.")
     parser.add_argument("--list-questions", action="store_true",
                         help="Print the question bank and exit")
     parser.add_argument("--output-dir", default=str(DEFAULT_OUTPUT_DIR),
@@ -1941,8 +1953,43 @@ def main() -> int:
             print(f"{q.qid:<5} {tools:<45} {q.title}")
         return 0
 
+    # Ad-hoc one-off questions (--question) are appended to the bank so they
+    # flow through the exact same request/eval path as bank questions. When
+    # any are given they take priority over --questions and --start: only the
+    # ad-hoc questions run.
+    #
+    # --check criteria pairing:
+    #   * exactly one --question  -> every --check applies to it (the common
+    #     "one prompt, several required substrings" case);
+    #   * several --question      -> check[i] pairs with question[i]; a question
+    #     with no check has no criteria (always passes, manual review).
+    # Without any --check the question always passes and the full answer +
+    # tools land in the log for manual review.
+    adhoc: list[TestQuestion] = []
+    for i, text in enumerate(args.question, start=1):
+        if not text.strip():
+            parser.error("--question requires non-empty text")
+        if len(args.question) == 1:
+            checks = args.check
+        else:
+            checks = [args.check[i - 1]] if i - 1 < len(args.check) else []
+        criteria = tuple(("contains", c) for c in checks)
+        adhoc.append(TestQuestion(
+            qid=f"AD-{i:02d}",
+            title=text.strip().splitlines()[0][:60],
+            text=text.strip(),
+            require_tool=False,
+            criteria=criteria,
+        ))
+    if len(args.question) > 1 and len(args.check) > len(args.question):
+        parser.error(f"--check given without a matching --question "
+                     f"({len(args.check)} checks for {len(args.question)} questions)")
+    if adhoc:
+        questions += adhoc
+
     # Validate --start before any interactive prompts so bad values fail fast.
-    if args.start and not args.questions and (args.start < 1 or args.start > len(questions)):
+    if args.start and not args.questions and not args.question \
+            and (args.start < 1 or args.start > len(questions)):
         parser.error(f"--start must be between 1 and {len(questions)}")
 
     settings = resolve_settings(args)
@@ -1982,7 +2029,10 @@ def main() -> int:
         print(msg, file=sys.stderr)
         return 1
 
-    if args.questions:
+    if adhoc:
+        # Ad-hoc questions only — the bank is listed in the log but not run.
+        selected = list(range(len(questions) - len(adhoc), len(questions)))
+    elif args.questions:
         selected = parse_question_filter(args.questions, len(questions))
     elif args.start:
         selected = list(range(args.start - 1, len(questions)))

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -211,17 +211,39 @@ edit_mainsail_navi() {
     cat > "$py_script" <<'PYEOF'
 import json
 import os
+import shutil
 import sys
 
 action, path, url = sys.argv[1], sys.argv[2], sys.argv[3]
 
+# Load existing entries. A pre-existing navi.json must never be destroyed:
+# when the current content is not a parseable list (corrupt JSON or a
+# non-array shape), back it up before we replace it (add) or leave it alone
+# (remove).
+existing_raw = None
+entries = []
+parseable = True
 try:
     with open(path, encoding="utf-8") as fh:
-        entries = json.load(fh)
-    if not isinstance(entries, list):
-        entries = []
+        existing_raw = fh.read()
+    parsed = json.loads(existing_raw)
+    if not isinstance(parsed, list):
+        parseable = False
+    else:
+        entries = parsed
 except (OSError, ValueError):
-    entries = []
+    parseable = False
+
+if not parseable:
+    # Don't touch a corrupt/unexpected file on remove.
+    if action == "remove":
+        sys.exit(0)
+    # Preserve the original before replacing it on add.
+    if existing_raw is not None:
+        try:
+            shutil.copy2(path, path + ".bak")
+        except OSError:
+            pass
 
 entries = [
     e for e in entries

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -176,12 +176,15 @@ entries = [
 ]
 
 if action == "add":
+    # KWC favicon mark (frontend/public/favicon.svg) converted to a single
+    # filled SVG path: the 4-spoke asterisk + tip dots, background square
+    # dropped (nav icons render monochrome with the sidebar text color).
     entries.append({
         "title": "KWC",
         "href": url,
         "target": "_blank",
         "position": 95,
-        "icon": "M21.71 20.29L20.29 21.71A1 1 0 0 1 18.88 21.71L7 9.85A3.81 3.81 0 0 1 6 10A4 4 0 0 1 2.22 4.7L4.76 7.24L5.29 6.71L6.71 5.29L7.24 4.76L4.7 2.22A4 4 0 0 1 10 6A3.81 3.81 0 0 1 9.85 7L21.71 18.88A1 1 0 0 1 21.71 20.29M2.29 18.88A1 1 0 0 0 2.29 20.29L3.71 21.71A1 1 0 0 0 5.12 21.71L10.59 16.25L7.76 13.42M20 2L16 4V6L13.83 8.17L15.83 10.17L18 8H20L22 4Z",
+        "icon": "M8 17L24 17A1 1 0 0 1 24 15L8 15A1 1 0 0 1 8 17ZM15 8L15 24A1 1 0 0 1 17 24L17 8A1 1 0 0 1 15 8ZM9.293 10.707L21.293 22.707A1 1 0 0 1 22.707 21.293L10.707 9.293A1 1 0 0 1 9.293 10.707ZM21.293 9.293L9.293 21.293A1 1 0 0 1 10.707 22.707L22.707 10.707A1 1 0 0 1 21.293 9.293ZM6 16a2 2 0 1 0 4 0a2 2 0 1 0 -4 0ZM22 16a2 2 0 1 0 4 0a2 2 0 1 0 -4 0ZM14 8a2 2 0 1 0 4 0a2 2 0 1 0 -4 0ZM14 24a2 2 0 1 0 4 0a2 2 0 1 0 -4 0Z",
     })
 
 with open(path, "w", encoding="utf-8") as fh:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -136,13 +136,26 @@ append_line_elevated() {
     return 1
 }
 
+# Best-effort: restart Moonraker so update_manager picks up config changes.
+# Only restarts when the unit exists and is active; never aborts the install.
+restart_moonraker() {
+    if systemctl list-unit-files moonraker.service > /dev/null 2>&1 && \
+       systemctl is-active --quiet moonraker; then
+        if sudo systemctl restart moonraker 2>/dev/null; then
+            info "Moonraker restarted to pick up update_manager changes."
+        else
+            warn "Could not restart moonraker automatically — restart it manually (systemctl restart moonraker) for update_manager changes to take effect."
+        fi
+    fi
+}
+
 # Add KWC to Moonraker's update manager so updates show up in Mainsail /
 # Fluidd. Writes a dedicated include file (same pattern as obico's
 # moonraker-obico-update.cfg) and adds a single [include] line to
 # moonraker.conf — the user's other sections are left untouched. Best-effort:
 # failures warn and return 0 so the install never aborts over this.
 install_moonraker_updater() {
-    local config_dir moonraker_conf include_file content
+    local config_dir moonraker_conf include_file content changed=0
     config_dir="$(resolve_moonraker_config_dir)" || return 0
     moonraker_conf="$config_dir/moonraker.conf"
     [ -f "$moonraker_conf" ] || return 0
@@ -166,10 +179,18 @@ install_moonraker_updater() {
         echo "info_tags:"
         printf '\tdesc=Klipper Wire Configurator\n'
     )"
-    write_file_elevated "$include_file" "$content" || return 0
+    # Idempotent: only rewrite + restart when the include file differs.
+    if [ ! -f "$include_file" ] || ! cmp -s "$include_file" <(printf '%s' "$content") 2>/dev/null; then
+        write_file_elevated "$include_file" "$content" || return 0
+        changed=1
+    fi
 
     if ! grep -q '^\[include klipper-wire-configurator-update\.cfg\]' "$moonraker_conf"; then
         append_line_elevated "$moonraker_conf" "[include klipper-wire-configurator-update.cfg]" || true
+        changed=1
+    fi
+    if [ "$changed" -eq 1 ]; then
+        restart_moonraker
     fi
     return 0
 }
@@ -177,7 +198,7 @@ install_moonraker_updater() {
 # Remove the KWC update_manager include (file + include line) from the
 # Moonraker config directory. Best-effort.
 remove_moonraker_updater() {
-    local config_dir moonraker_conf include_file
+    local config_dir moonraker_conf include_file changed=0
     config_dir="$(resolve_moonraker_config_dir)" || return 0
     moonraker_conf="$config_dir/moonraker.conf"
     include_file="$config_dir/klipper-wire-configurator-update.cfg"
@@ -186,11 +207,22 @@ remove_moonraker_updater() {
         if ! rm -f "$include_file" 2>/dev/null; then
             sudo rm -f "$include_file" 2>/dev/null || true
         fi
+        changed=1
     fi
     if [ -f "$moonraker_conf" ]; then
+        local had_line=0
+        if grep -q '^\[include klipper-wire-configurator-update\.cfg\]' "$moonraker_conf"; then
+            had_line=1
+        fi
         if ! sed -i '/^\[include klipper-wire-configurator-update\.cfg\]$/d' "$moonraker_conf" 2>/dev/null; then
             sudo sed -i '/^\[include klipper-wire-configurator-update\.cfg\]$/d' "$moonraker_conf" 2>/dev/null || true
         fi
+        if [ "$had_line" -eq 1 ]; then
+            changed=1
+        fi
+    fi
+    if [ "$changed" -eq 1 ]; then
+        restart_moonraker
     fi
     return 0
 }
@@ -276,12 +308,15 @@ if action == "add":
     # KWC favicon mark (frontend/public/favicon.svg) converted to a single
     # filled SVG path: the 4-spoke asterisk + tip dots, background square
     # dropped (nav icons render monochrome with the sidebar text color).
+    # Coordinates shifted (-2,-4) from the favicon so the whole mark sits
+    # inside the 24x24 viewBox with margin — the original touched the right
+    # edge and overflowed the bottom, clipping the tip dots.
     entries.append({
         "title": "KWC",
         "href": url,
         "target": "_blank",
         "position": 95,
-        "icon": "M8 17L24 17A1 1 0 0 1 24 15L8 15A1 1 0 0 1 8 17ZM15 8L15 24A1 1 0 0 1 17 24L17 8A1 1 0 0 1 15 8ZM9.293 10.707L21.293 22.707A1 1 0 0 1 22.707 21.293L10.707 9.293A1 1 0 0 1 9.293 10.707ZM21.293 9.293L9.293 21.293A1 1 0 0 1 10.707 22.707L22.707 10.707A1 1 0 0 1 21.293 9.293ZM6 16a2 2 0 1 0 4 0a2 2 0 1 0 -4 0ZM22 16a2 2 0 1 0 4 0a2 2 0 1 0 -4 0ZM14 8a2 2 0 1 0 4 0a2 2 0 1 0 -4 0ZM14 24a2 2 0 1 0 4 0a2 2 0 1 0 -4 0Z",
+        "icon": "M6 13L22 13A1 1 0 0 1 22 11L6 11A1 1 0 0 1 6 13ZM13 4L13 20A1 1 0 0 1 15 20L15 4A1 1 0 0 1 13 4ZM7.293 6.707L19.293 18.707A1 1 0 0 1 20.707 17.293L8.707 5.293A1 1 0 0 1 7.293 6.707ZM19.293 5.293L7.293 17.293A1 1 0 0 1 8.707 18.707L20.707 6.707A1 1 0 0 1 19.293 5.293ZM4 12a2 2 0 1 0 4 0a2 2 0 1 0 -4 0ZM20 12a2 2 0 1 0 4 0a2 2 0 1 0 -4 0ZM12 4a2 2 0 1 0 4 0a2 2 0 1 0 -4 0ZM12 20a2 2 0 1 0 4 0a2 2 0 1 0 -4 0Z",
     })
 
 with open(path, "w", encoding="utf-8") as fh:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -735,9 +735,16 @@ fi
 # Mainsail tab is preserved.
 if mainsail_installed; then
     if resolve_mainsail_theme_dir > /dev/null; then
-        info "Mainsail detected - adding KWC link to its sidebar (navi.json)..."
-        edit_mainsail_navi add
-        ok "Mainsail sidebar link configured."
+        if [ -z "$IP_ADDR" ] || [ "$IP_ADDR" = "<your-pi-ip>" ]; then
+            # Never write a link with a placeholder URL — a navi.json entry
+            # pointing at "<your-pi-ip>" would silently 404 with no signal.
+            warn "Could not detect the Pi's IP address; skipping the Mainsail sidebar link."
+            warn "Add it later manually: a KWC entry in the .theme folder of your Klipper config dir (see README 'Mainsail sidebar link')."
+        else
+            info "Mainsail detected - adding KWC link to its sidebar (navi.json)..."
+            edit_mainsail_navi add
+            ok "Mainsail sidebar link configured."
+        fi
     else
         warn "Mainsail detected but no Klipper config directory found; skipping sidebar link."
     fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -98,12 +98,44 @@ resolve_moonraker_config_dir() {
     return 1
 }
 
+# Write a file, escalating to sudo when the current user lacks write access
+# (the Moonraker config dir is sometimes root-owned). Ownership is returned
+# to the invoking user so moonraker/Mainsail can keep managing the file.
+write_file_elevated() {
+    local target="$1" content="$2"
+    if printf '%s' "$content" > "$target" 2>/dev/null; then
+        return 0
+    fi
+    warn "No write access to $target, retrying with sudo..."
+    if printf '%s' "$content" | sudo tee "$target" > /dev/null 2>&1; then
+        sudo chown "$USER" "$target" 2>/dev/null || true
+        return 0
+    fi
+    warn "Could not write $target (permission denied). Skipping."
+    return 1
+}
+
+# Append a line to a file, escalating to sudo when needed.
+append_line_elevated() {
+    local target="$1" line="$2"
+    if printf '%s\n' "$line" >> "$target" 2>/dev/null; then
+        return 0
+    fi
+    warn "No write access to $target, retrying with sudo..."
+    if printf '%s\n' "$line" | sudo tee -a "$target" > /dev/null 2>&1; then
+        return 0
+    fi
+    warn "Could not append to $target (permission denied). Skipping."
+    return 1
+}
+
 # Add KWC to Moonraker's update manager so updates show up in Mainsail /
 # Fluidd. Writes a dedicated include file (same pattern as obico's
 # moonraker-obico-update.cfg) and adds a single [include] line to
-# moonraker.conf — the user's other sections are left untouched.
+# moonraker.conf — the user's other sections are left untouched. Best-effort:
+# failures warn and return 0 so the install never aborts over this.
 install_moonraker_updater() {
-    local config_dir moonraker_conf include_file
+    local config_dir moonraker_conf include_file content
     config_dir="$(resolve_moonraker_config_dir)" || return 0
     moonraker_conf="$config_dir/moonraker.conf"
     [ -f "$moonraker_conf" ] || return 0
@@ -114,7 +146,7 @@ install_moonraker_updater() {
         return 0
     fi
 
-    {
+    content="$(
         echo "[update_manager klipper-wire-configurator]"
         echo "type: git_repo"
         echo "channel: dev"
@@ -126,37 +158,48 @@ install_moonraker_updater() {
         echo "managed_services: klipper-wire-configurator"
         echo "info_tags:"
         printf '\tdesc=Klipper Wire Configurator\n'
-    } > "$include_file"
+    )"
+    write_file_elevated "$include_file" "$content" || return 0
 
     if ! grep -q '^\[include klipper-wire-configurator-update\.cfg\]' "$moonraker_conf"; then
-        printf '\n[include klipper-wire-configurator-update.cfg]\n' >> "$moonraker_conf"
+        append_line_elevated "$moonraker_conf" "" || true
+        append_line_elevated "$moonraker_conf" "[include klipper-wire-configurator-update.cfg]" || true
     fi
+    return 0
 }
 
 # Remove the KWC update_manager include (file + include line) from the
-# Moonraker config directory.
+# Moonraker config directory. Best-effort.
 remove_moonraker_updater() {
     local config_dir moonraker_conf include_file
     config_dir="$(resolve_moonraker_config_dir)" || return 0
     moonraker_conf="$config_dir/moonraker.conf"
     include_file="$config_dir/klipper-wire-configurator-update.cfg"
 
-    rm -f "$include_file"
+    rm -f "$include_file" 2>/dev/null || true
     if [ -f "$moonraker_conf" ]; then
-        sed -i '/^\[include klipper-wire-configurator-update\.cfg\]$/d' "$moonraker_conf"
+        if ! sed -i '/^\[include klipper-wire-configurator-update\.cfg\]$/d' "$moonraker_conf" 2>/dev/null; then
+            sudo sed -i '/^\[include klipper-wire-configurator-update\.cfg\]$/d' "$moonraker_conf" 2>/dev/null || true
+        fi
     fi
+    return 0
 }
 
 # Merge (or remove) the KWC entry in Mainsail's navi.json. Keeps any other
-# custom navigation entries the user already has.
+# custom navigation entries the user already has. Best-effort: failures warn
+# and return 0 so the install never aborts over this.
 edit_mainsail_navi() {
     local action="$1"  # add | remove
-    local theme_dir navi_path kwc_url
+    local theme_dir navi_path kwc_url py_script
     theme_dir="$(resolve_mainsail_theme_dir)" || return 0
-    mkdir -p "$theme_dir"
+    if ! mkdir -p "$theme_dir" 2>/dev/null; then
+        sudo mkdir -p "$theme_dir" 2>/dev/null || return 0
+    fi
     navi_path="$theme_dir/navi.json"
     kwc_url="http://${IP_ADDR:-localhost}:${KWC_PORT}"
-    python3 - "$action" "$navi_path" "$kwc_url" <<'PYEOF'
+
+    py_script="$(mktemp)"
+    cat > "$py_script" <<'PYEOF'
 import json
 import sys
 
@@ -191,6 +234,17 @@ with open(path, "w", encoding="utf-8") as fh:
     json.dump(entries, fh, indent=2)
     fh.write("\n")
 PYEOF
+
+    if ! python3 "$py_script" "$action" "$navi_path" "$kwc_url" 2>/dev/null; then
+        warn "No write access to $navi_path, retrying with sudo..."
+        if sudo python3 "$py_script" "$action" "$navi_path" "$kwc_url" 2>/dev/null; then
+            sudo chown "$USER" "$navi_path" 2>/dev/null || true
+        else
+            warn "Could not update $navi_path (permission denied). Skipping."
+        fi
+    fi
+    rm -f "$py_script"
+    return 0
 }
 
 on_error() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -84,6 +84,69 @@ resolve_mainsail_theme_dir() {
     return 1
 }
 
+# Locate the Moonraker config directory (kiauh layout). Used for the
+# update_manager include file and Mainsail's .theme folder.
+resolve_moonraker_config_dir() {
+    if [ -d "$HOME/printer_data/config" ]; then
+        echo "$HOME/printer_data/config"
+        return 0
+    fi
+    if [ -d "$HOME/klipper_config" ]; then
+        echo "$HOME/klipper_config"
+        return 0
+    fi
+    return 1
+}
+
+# Add KWC to Moonraker's update manager so updates show up in Mainsail /
+# Fluidd. Writes a dedicated include file (same pattern as obico's
+# moonraker-obico-update.cfg) and adds a single [include] line to
+# moonraker.conf — the user's other sections are left untouched.
+install_moonraker_updater() {
+    local config_dir moonraker_conf include_file
+    config_dir="$(resolve_moonraker_config_dir)" || return 0
+    moonraker_conf="$config_dir/moonraker.conf"
+    [ -f "$moonraker_conf" ] || return 0
+    include_file="$config_dir/klipper-wire-configurator-update.cfg"
+
+    # If the user manages KWC directly in moonraker.conf, don't duplicate.
+    if grep -q '^\[update_manager klipper-wire-configurator\]' "$moonraker_conf"; then
+        return 0
+    fi
+
+    {
+        echo "[update_manager klipper-wire-configurator]"
+        echo "type: git_repo"
+        echo "channel: dev"
+        echo "path: $INSTALL_DIR"
+        echo "origin: $REPO_URL"
+        echo "primary_branch: main"
+        echo "virtualenv: $INSTALL_DIR/venv"
+        echo "requirements: backend/requirements.txt"
+        echo "managed_services: klipper-wire-configurator"
+        echo "info_tags:"
+        printf '\tdesc=Klipper Wire Configurator\n'
+    } > "$include_file"
+
+    if ! grep -q '^\[include klipper-wire-configurator-update\.cfg\]' "$moonraker_conf"; then
+        printf '\n[include klipper-wire-configurator-update.cfg]\n' >> "$moonraker_conf"
+    fi
+}
+
+# Remove the KWC update_manager include (file + include line) from the
+# Moonraker config directory.
+remove_moonraker_updater() {
+    local config_dir moonraker_conf include_file
+    config_dir="$(resolve_moonraker_config_dir)" || return 0
+    moonraker_conf="$config_dir/moonraker.conf"
+    include_file="$config_dir/klipper-wire-configurator-update.cfg"
+
+    rm -f "$include_file"
+    if [ -f "$moonraker_conf" ]; then
+        sed -i '/^\[include klipper-wire-configurator-update\.cfg\]$/d' "$moonraker_conf"
+    fi
+}
+
 # Merge (or remove) the KWC entry in Mainsail's navi.json. Keeps any other
 # custom navigation entries the user already has.
 edit_mainsail_navi() {
@@ -211,6 +274,9 @@ if [ "${1:-}" = "--uninstall" ]; then
         info "Removing KWC entry from Mainsail sidebar..."
         edit_mainsail_navi remove
     fi
+
+    # Remove the Moonraker update_manager include (file + include line).
+    remove_moonraker_updater
 
     ok "Klipper Wire Configurator has been uninstalled."
     echo ""
@@ -529,6 +595,15 @@ if mainsail_installed; then
     else
         warn "Mainsail detected but no Klipper config directory found; skipping sidebar link."
     fi
+fi
+
+# --- Moonraker update_manager entry ---
+# Register KWC with Moonraker's update manager so updates are visible in
+# Mainsail/Fluidd. Skips when there is no moonraker.conf (standalone SBC).
+if resolve_moonraker_config_dir > /dev/null && [ -f "$(resolve_moonraker_config_dir)/moonraker.conf" ]; then
+    info "Adding KWC to Moonraker update_manager..."
+    install_moonraker_updater
+    ok "Moonraker update_manager configured."
 fi
 
 # --- Done! ---

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -45,6 +45,88 @@ is_system_service_active() {
     sudo systemctl is-active --quiet "$SERVICE_NAME" 2>/dev/null
 }
 
+# Detect Mainsail so we can drop a sidebar link to KWC in its theme folder.
+# Fluidd and OctoPrint have no custom-navigation equivalent, so navi.json is
+# only written when Mainsail is actually present.
+mainsail_installed() {
+    if [ -d "$HOME/mainsail" ]; then
+        return 0
+    fi
+    local moonraker_conf
+    for moonraker_conf in "$HOME/printer_data/config/moonraker.conf" "$HOME/klipper_config/moonraker.conf"; do
+        if [ -f "$moonraker_conf" ] && grep -q '^\[update_manager mainsail\]' "$moonraker_conf"; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Locate Mainsail's .theme folder (inside the Klipper/Moonraker config dir).
+# Prefers an existing .theme folder; falls back to creating one in the
+# detected config directory.
+resolve_mainsail_theme_dir() {
+    if [ -d "$HOME/printer_data/config/.theme" ]; then
+        echo "$HOME/printer_data/config/.theme"
+        return 0
+    fi
+    if [ -d "$HOME/klipper_config/.theme" ]; then
+        echo "$HOME/klipper_config/.theme"
+        return 0
+    fi
+    if [ -d "$HOME/printer_data/config" ]; then
+        echo "$HOME/printer_data/config/.theme"
+        return 0
+    fi
+    if [ -d "$HOME/klipper_config" ]; then
+        echo "$HOME/klipper_config/.theme"
+        return 0
+    fi
+    return 1
+}
+
+# Merge (or remove) the KWC entry in Mainsail's navi.json. Keeps any other
+# custom navigation entries the user already has.
+edit_mainsail_navi() {
+    local action="$1"  # add | remove
+    local theme_dir navi_path kwc_url
+    theme_dir="$(resolve_mainsail_theme_dir)" || return 0
+    mkdir -p "$theme_dir"
+    navi_path="$theme_dir/navi.json"
+    kwc_url="http://${IP_ADDR:-localhost}:${KWC_PORT}"
+    python3 - "$action" "$navi_path" "$kwc_url" <<'PYEOF'
+import json
+import sys
+
+action, path, url = sys.argv[1], sys.argv[2], sys.argv[3]
+
+try:
+    with open(path, encoding="utf-8") as fh:
+        entries = json.load(fh)
+    if not isinstance(entries, list):
+        entries = []
+except (OSError, ValueError):
+    entries = []
+
+entries = [
+    e for e in entries
+    if not (isinstance(e, dict) and e.get("title") == "KWC")
+]
+
+if action == "add":
+    entries.append({
+        "title": "KWC",
+        "href": url,
+        "target": "_blank",
+        "position": 95,
+        "icon": "M21.71 20.29L20.29 21.71A1 1 0 0 1 18.88 21.71L7 9.85A3.81 3.81 0 0 1 6 10A4 4 0 0 1 2.22 4.7L4.76 7.24L5.29 6.71L6.71 5.29L7.24 4.76L4.7 2.22A4 4 0 0 1 10 6A3.81 3.81 0 0 1 9.85 7L21.71 18.88A1 1 0 0 1 21.71 20.29M2.29 18.88A1 1 0 0 0 2.29 20.29L3.71 21.71A1 1 0 0 0 5.12 21.71L10.59 16.25L7.76 13.42M20 2L16 4V6L13.83 8.17L15.83 10.17L18 8H20L22 4Z",
+    })
+
+with open(path, "w", encoding="utf-8") as fh:
+    json.dump(entries, fh, indent=2)
+    fh.write("\n")
+PYEOF
+}
+
 on_error() {
     local line_no="$1"
     local exit_code="$2"
@@ -121,6 +203,13 @@ if [ "${1:-}" = "--uninstall" ]; then
     if [ -d "$INSTALL_DIR" ]; then
         info "Removing installation directory: $INSTALL_DIR"
         rm -rf "$INSTALL_DIR"
+    fi
+
+    # Remove the KWC entry from Mainsail's navi.json (keeps any other custom
+    # navigation entries the user added). Best-effort — no config dir, no problem.
+    if mainsail_installed; then
+        info "Removing KWC entry from Mainsail sidebar..."
+        edit_mainsail_navi remove
     fi
 
     ok "Klipper Wire Configurator has been uninstalled."
@@ -425,6 +514,21 @@ fi
 IP_ADDR="$(hostname -I 2>/dev/null | awk '{print $1}')"
 if [ -z "$IP_ADDR" ]; then
     IP_ADDR="<your-pi-ip>"
+fi
+
+# --- Mainsail sidebar link (navi.json) ---
+# Mainsail supports custom sidebar entries via navi.json in its .theme folder
+# (inside the Klipper config dir). Fluidd and OctoPrint have no equivalent, so
+# this only runs when Mainsail is detected. The link targets _blank so the
+# Mainsail tab is preserved.
+if mainsail_installed; then
+    if resolve_mainsail_theme_dir > /dev/null; then
+        info "Mainsail detected - adding KWC link to its sidebar (navi.json)..."
+        edit_mainsail_navi add
+        ok "Mainsail sidebar link configured."
+    else
+        warn "Mainsail detected but no Klipper config directory found; skipping sidebar link."
+    fi
 fi
 
 # --- Done! ---

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -162,7 +162,6 @@ install_moonraker_updater() {
     write_file_elevated "$include_file" "$content" || return 0
 
     if ! grep -q '^\[include klipper-wire-configurator-update\.cfg\]' "$moonraker_conf"; then
-        append_line_elevated "$moonraker_conf" "" || true
         append_line_elevated "$moonraker_conf" "[include klipper-wire-configurator-update.cfg]" || true
     fi
     return 0
@@ -176,7 +175,11 @@ remove_moonraker_updater() {
     moonraker_conf="$config_dir/moonraker.conf"
     include_file="$config_dir/klipper-wire-configurator-update.cfg"
 
-    rm -f "$include_file" 2>/dev/null || true
+    if [ -e "$include_file" ]; then
+        if ! rm -f "$include_file" 2>/dev/null; then
+            sudo rm -f "$include_file" 2>/dev/null || true
+        fi
+    fi
     if [ -f "$moonraker_conf" ]; then
         if ! sed -i '/^\[include klipper-wire-configurator-update\.cfg\]$/d' "$moonraker_conf" 2>/dev/null; then
             sudo sed -i '/^\[include klipper-wire-configurator-update\.cfg\]$/d' "$moonraker_conf" 2>/dev/null || true
@@ -192,15 +195,22 @@ edit_mainsail_navi() {
     local action="$1"  # add | remove
     local theme_dir navi_path kwc_url py_script
     theme_dir="$(resolve_mainsail_theme_dir)" || return 0
-    if ! mkdir -p "$theme_dir" 2>/dev/null; then
-        sudo mkdir -p "$theme_dir" 2>/dev/null || return 0
-    fi
     navi_path="$theme_dir/navi.json"
     kwc_url="http://${IP_ADDR:-localhost}:${KWC_PORT}"
+
+    # Nothing to clean if the navi file was never written.
+    if [ "$action" = "remove" ] && [ ! -f "$navi_path" ]; then
+        return 0
+    fi
+    # Only create the theme dir when adding — remove must not leave one behind.
+    if [ "$action" = "add" ] && ! mkdir -p "$theme_dir" 2>/dev/null; then
+        sudo mkdir -p "$theme_dir" 2>/dev/null || return 0
+    fi
 
     py_script="$(mktemp)"
     cat > "$py_script" <<'PYEOF'
 import json
+import os
 import sys
 
 action, path, url = sys.argv[1], sys.argv[2], sys.argv[3]
@@ -217,6 +227,21 @@ entries = [
     e for e in entries
     if not (isinstance(e, dict) and e.get("title") == "KWC")
 ]
+
+if action == "remove":
+    # Delete the file when the KWC entry was the only custom entry; keep it
+    # (minus KWC) when the user has other custom navigation entries.
+    if entries:
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(entries, fh, indent=2)
+            fh.write("\n")
+    else:
+        try:
+            os.remove(path)
+        except OSError:
+            # Signal failure so the caller retries under sudo.
+            sys.exit(1)
+    sys.exit(0)
 
 if action == "add":
     # KWC favicon mark (frontend/public/favicon.svg) converted to a single

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,6 +7,13 @@
 # Or if you've already cloned the repo:
 #   bash scripts/install.sh
 #
+# IMPORTANT: run WITHOUT sudo. The installer escalates internally wherever
+# elevated access is needed (apt, systemd, and writes into the Moonraker
+# config dir). Running `sudo bash scripts/install.sh` resets $HOME to /root,
+# so the Moonraker config directory is not found and the update_manager /
+# Mainsail sidebar setup is silently skipped (and the app installs into
+# /root instead of your user's home).
+#
 # Uninstall:
 #   bash scripts/install.sh --uninstall
 

--- a/tests/test_ai_chat_routes.py
+++ b/tests/test_ai_chat_routes.py
@@ -750,6 +750,12 @@ def test_chat_proxy_local_openai_compatible_allows_missing_key(monkeypatch):
         'mcpToolNames': [],
         'toolCalls': [],
         'repromptCount': 0,
+        'usage': {
+            'completionTokens': 0,
+            'reasoningTokens': 0,
+            'events': [],
+            'truncated': False,
+        },
     }
     # The local URL is POSTed verbatim and no Authorization header is added
     # when no key was provided.
@@ -854,7 +860,77 @@ def test_chat_proxy_returns_plain_content(monkeypatch):
         'mcpToolNames': [],
         'toolCalls': [],
         'repromptCount': 0,
+        'usage': {
+            'completionTokens': 0,
+            'reasoningTokens': 0,
+            'events': [],
+            'truncated': False,
+        },
     }
+
+
+def test_extract_usage_info_captures_tokens_and_reasoning():
+    info = ai_routes._extract_usage_info({
+        'choices': [{'message': {'content': 'x'}, 'finish_reason': 'stop'}],
+        'usage': {
+            'completion_tokens': 1234,
+            'completion_tokens_details': {'reasoning_tokens': 700},
+        },
+    })
+    assert info == {
+        'completionTokens': 1234,
+        'reasoningTokens': 700,
+        'finishReason': 'stop',
+    }
+
+
+def test_extract_usage_info_none_without_usage():
+    assert ai_routes._extract_usage_info({'choices': [{'message': {'content': 'x'}}]}) is None
+    assert ai_routes._extract_usage_info({}) is None
+
+
+def test_chat_proxy_reports_usage_and_truncation(monkeypatch):
+    # A provider response that burned the whole max_tokens budget
+    # (finish_reason=length) must surface in /ai/chat as truncated so the
+    # harness can distinguish budget exhaustion from a wrong answer.
+    monkeypatch.setattr(ai_routes, 'load_printer_memory', lambda: PrinterMemory())
+    monkeypatch.setattr(ai_routes, '_auto_search_context', lambda query: None)
+
+    def fake_post(url, headers, payload):
+        return DummyResponse(
+            {
+                'choices': [{
+                    'message': {'content': 'The answer got cut off mid-sent'},
+                    'finish_reason': 'length',
+                }],
+                'usage': {
+                    'completion_tokens': 4096,
+                    'completion_tokens_details': {'reasoning_tokens': 2500},
+                },
+            },
+            url=url,
+        )
+
+    monkeypatch.setattr(httpx, 'AsyncClient', lambda *args, **kwargs: FakeAsyncClient(post_handler=fake_post))
+
+    response = client.post(
+        '/ai/chat',
+        json={
+            'messages': [{'role': 'user', 'content': 'Explain everything about Klipper.'}],
+            'apiKey': 'openai-token',
+            'model': 'gpt-4o',
+            'apiUrl': 'https://api.openai.com/v1/chat/completions',
+            'apiProvider': 'chatgpt',
+        },
+    )
+
+    assert response.status_code == 200
+    usage = response.json()['usage']
+    assert usage['completionTokens'] == 4096
+    assert usage['reasoningTokens'] == 2500
+    assert usage['truncated'] is True
+    assert usage['events'][0]['finishReason'] == 'length'
+    assert usage['events'][0]['context'] == 'initial'
 
 
 def test_chat_proxy_auto_search_fallback_injects_docs(monkeypatch):

--- a/tests/test_mcp_tool_calling.py
+++ b/tests/test_mcp_tool_calling.py
@@ -29,6 +29,7 @@ from api.ai_routes import (  # noqa: E402
     _extract_native_tool_calls,
     _extract_tool_calls,
     _parse_kwargs,
+    _strip_bracket_tool_calls,
 )
 
 
@@ -90,6 +91,58 @@ def test_extract_tool_calls_llamacpp_tool_call_prefix_with_space():
         "name": "read_klipper_doc",
         "arguments": {"doc": "Pressure_Advance.md"},
     }]
+
+
+def test_extract_tool_calls_bracket_syntax_known_tool():
+    # Models sometimes emit OpenAI-style [tool(args)] calls as plain text —
+    # e.g. [read_user_config(filename=Hotkey.cfg)] — instead of the
+    # configured ```tool JSON block. Format 7 must recover them so the
+    # call executes instead of leaking into the chat (2026-08 user report).
+    text = "I need to check the LED names:\n[read_user_config(filename=Hotkey.cfg)]\n"
+    calls = _extract_tool_calls(text)
+    assert calls == [{"name": "read_user_config", "arguments": {"filename": "Hotkey.cfg"}}]
+
+
+def test_extract_tool_calls_bracket_syntax_multi_arg():
+    text = "[read_user_config(filename=printer.cfg, section=idle_timeout)]"
+    calls = _extract_tool_calls(text)
+    assert calls == [{
+        "name": "read_user_config",
+        "arguments": {"filename": "printer.cfg", "section": "idle_timeout"},
+    }]
+
+
+def test_extract_tool_calls_bracket_syntax_unknown_name_not_extracted():
+    # G-code commands and config headers are NOT tools — bracket calls for
+    # them must stay as text (format 7 gates on known tool names so the
+    # hallucinated-tool guard keeps working as designed for other formats).
+    text = "[set_fan_speed(0.5)]\n[probe]\n[include printer.cfg]"
+    calls = _extract_tool_calls(text)
+    assert calls == []
+
+
+def test_extract_tool_calls_bracket_syntax_config_sections_untouched():
+    # Regression guard: config section headers ([bed_mesh], [mcu]) and
+    # jinja bodies must never extract as bracket calls.
+    text = "[bed_mesh]\n[gcode_macro PRINT_START]\n{% set x = 1 %}"
+    calls = _extract_tool_calls(text)
+    assert calls == []
+
+
+def test_strip_bracket_tool_calls_removes_known_keeps_unknown():
+    # Cleanup is name-gated: a real tool's bracket call is removed from the
+    # visible reply, but config headers and non-tool names survive.
+    text = (
+        "Now let me check your Hotkey config:\n"
+        "[read_user_config(filename=Hotkey.cfg)]\n"
+        "Also note [probe] and [set_fan_speed(0.5)] are not tools.\n"
+    )
+    cleaned = _strip_bracket_tool_calls(text)
+    assert "read_user_config(filename=Hotkey.cfg)" not in cleaned
+    assert "[probe]" in cleaned
+    assert "[set_fan_speed(0.5)]" in cleaned
+    assert "Now let me check your Hotkey config:" in cleaned
+    assert "are not tools" in cleaned
 
 
 def test_extract_tool_calls_ignores_klipper_macro_jinja():

--- a/tests/test_warning_acknowledgments.py
+++ b/tests/test_warning_acknowledgments.py
@@ -553,11 +553,15 @@ def test_unknown_section_warning_can_be_acknowledged():
             del os.environ['KWC_LAYOUT_DIR']
 
 
-def test_unknown_section_warning_with_multiline_param_can_be_acknowledged():
-    """Regression: a section with a multi-line (indented continuation) param
-    value, e.g. moonraker's `[update_manager moonraker-obico]`, could never be
-    acknowledged because canonicalize re-indented continuation lines and the
-    stored snippet never matched the live canonical form.
+def test_update_manager_section_is_recognized():
+    """[update_manager <name>] is a known Moonraker section type — it must NOT
+    produce an unknown-section warning.
+
+    This test originally asserted the warning for `[update_manager
+    moonraker-obico]` (a multiline-param ack regression: the stored snippet
+    never matched the canonical form). Once update_manager is registered as a
+    known named section the warning is gone by construction, so the ack path
+    is moot — assert recognition directly.
     """
     with tempfile.TemporaryDirectory() as temp_dir:
         os.environ['KWC_LAYOUT_DIR'] = temp_dir
@@ -576,13 +580,15 @@ def test_unknown_section_warning_with_multiline_param_can_be_acknowledged():
             )
 
             before = validate_config(config)
-            assert before.has_warnings
-            assert any(
+            assert not any(
                 error.severity == 'warning'
-                and "Unknown section type 'update_manager moonraker-obico'" in error.message
+                and 'Unknown section type' in error.message
                 for error in before.errors
             )
+            assert not before.has_warnings
 
+            # The acknowledgment path remains a safe no-op for recognized
+            # sections (no snippet to store, no warning to clear).
             acknowledge_warning_for_section(config.sections[0])
 
             after = validate_config(config)

--- a/tests/test_warning_acknowledgments.py
+++ b/tests/test_warning_acknowledgments.py
@@ -553,6 +553,44 @@ def test_unknown_section_warning_can_be_acknowledged():
             del os.environ['KWC_LAYOUT_DIR']
 
 
+def test_unknown_section_warning_with_multiline_param_can_be_acknowledged():
+    """Regression: a section with a multi-line (indented continuation) param
+    value, e.g. moonraker's `[update_manager moonraker-obico]`, could never be
+    acknowledged because canonicalize re-indented continuation lines and the
+    stored snippet never matched the live canonical form.
+    """
+    with tempfile.TemporaryDirectory() as temp_dir:
+        os.environ['KWC_LAYOUT_DIR'] = temp_dir
+        try:
+            config = parse_config(
+                '[update_manager moonraker-obico]\n'
+                'type: git_repo\n'
+                'path: /home/clifgall/moonraker-obico\n'
+                'origin: https://github.com/TheSpaghettiDetective/moonraker-obico.git\n'
+                'env: /home/clifgall/moonraker-obico/../moonraker-obico-env/bin/python\n'
+                'requirements: requirements.txt\n'
+                'install_script: install.sh\n'
+                'managed_services:\n'
+                '  moonraker-obico\n',
+                'moonraker.conf',
+            )
+
+            before = validate_config(config)
+            assert before.has_warnings
+            assert any(
+                error.severity == 'warning'
+                and "Unknown section type 'update_manager moonraker-obico'" in error.message
+                for error in before.errors
+            )
+
+            acknowledge_warning_for_section(config.sections[0])
+
+            after = validate_config(config)
+            assert not after.has_warnings
+        finally:
+            del os.environ['KWC_LAYOUT_DIR']
+
+
 def test_duplicate_exact_stepper_section_across_active_files_is_warning():
     results = _validate_project({
         'printer.cfg': (


### PR DESCRIPTION
## Summary

This PR bundles fixes across multiple areas discovered during user validation and iteration.

### Validation
- **Canonicalized acknowledged-warning format** — round-trip stable so the validator doesn't re-notify on re-parse
- **update_manager recognized** — no spurious "unknown section" warning for `update_manager` blocks
- **TRIDENT-16** — idle_timeout LED test with no file attached (reproducible crash)
- Average token usage summary added to harness

### Install
- **Mainsail sidebar icon** — KWC favicon displayed in Mainsail nav
- **Moonraker update_manager registration** — KWC managed via Moonraker's update manager
- **Navij.json protection** — never destroy pre-existing navi.json; uninstall fully cleans up
- **Permission-tolerant writes** — graceful fallback when config writes lack sudo access
- **Explicit sudo note** — docs clarify installer doesn't need sudo

### AI Chat
- **OpenAI-compatible provider dropdown** — Tool Format selector for provider configuration
- **Per-turn token usage reporting** — token counts + truncation info shown in chat responses
- **Bracket-wrapped tool call recovery** — handles `[name(k=v)]` format from models that wrap in brackets

### Performance
- **Config restore gating** — only restores config when native status is available
- **Jinja macro compile caching** — skips plain-text macro bodies on validation