### PR TITLE
fix: native include-closure load + update_manager schema completeness

### DIFF
--- a/backend/api/native_routes.py
+++ b/backend/api/native_routes.py
@@ -1,6 +1,8 @@
 """API routes for native Raspberry Pi features."""
 from __future__ import annotations
 
+import glob
+import os
 from pathlib import Path
 
 from fastapi import APIRouter, HTTPException
@@ -166,6 +168,44 @@ def read_config_files(data: dict):
         configs[fn] = config
         raw_texts[fn] = text
         board_infos[fn] = detect_board_from_config(config)
+
+    # Expand to the on-disk include closure. list_config_files hides files
+    # whose symlink target escapes the config root (traversal guard), but
+    # Klipper follows include symlinks wherever they point at load
+    # (configfile.py _resolve_include: os.path.join(dirname, include_spec)
+    # then a plain open). Third-party configs (KAMP, moonraker-obico,
+    # mainsail macros) are commonly symlinked INTO the config dir from
+    # elsewhere, so a native project must load them or every such include
+    # becomes a false "missing include" error on a config Klipper loads fine.
+    # Includes resolve relative to the directory of the INCLUDING file —
+    # mirroring Klipper. Only ACTIVE (non-commented) includes are followed;
+    # globs are skipped (never resolvable in-memory, legal when empty).
+    pending = list(configs)
+    while pending:
+        fn = pending.pop()
+        for include_spec in configs[fn].includes:
+            spec = include_spec.strip()
+            if not spec or glob.has_magic(spec):
+                continue
+            inc_dir = os.path.dirname(fn.replace("\\", "/"))
+            rel = os.path.normpath(
+                os.path.join(inc_dir, spec) if inc_dir else spec
+            )
+            # The include ENTRY must stay lexically inside the config dir (the
+            # same boundary read_config_files enforces for requested names);
+            # its symlink target may live anywhere, exactly like Klipper.
+            if os.path.isabs(rel) or Path(rel).parts[0] == "..":
+                continue
+            if rel in configs:
+                continue
+            file_path = base / rel
+            if not file_path.exists():  # follows symlinks
+                continue
+            text = read_config_file(str(file_path))
+            configs[rel] = parse_config(text, rel)
+            raw_texts[rel] = text
+            board_infos[rel] = detect_board_from_config(configs[rel])
+            pending.append(rel)
 
     validations = validate_project_configs(configs)
     results = {

--- a/backend/parser/config_schema.py
+++ b/backend/parser/config_schema.py
@@ -2180,7 +2180,7 @@ _register(SectionDef(
     is_named=True,
     description="Moonraker update_manager entry (git_repo/web/command...) — validated by Moonraker, not Klipper",
     params=[
-        _str("type", "Update source type (git_repo, web, command, zip, json_file)"),
+        _str("type", "Update source type (web, git_repo, zip, executable, python)"),
         _str("repo", "GitHub repo (owner/name)"),
         _str("path", "Local path of the installed software"),
         _str("origin", "Git remote origin URL"),
@@ -2192,7 +2192,19 @@ _register(SectionDef(
         _str("system_dependencies", "System packages to install"),
         _str("virtualenv", "Path to the virtualenv to update"),
         _str("env", "Environment variables for the update command"),
+        _str("venv_args", "Extra arguments passed to the virtualenv creation"),
         _str("info_tags", "Tags shown in the update manager UI (key=value lines)"),
+        _bool("enable_node_updates", "Run npm ci --only=prod when package-lock.json changes"),
+        _bool("is_system_service", "Treat the section name as the managed service (default True)"),
+        _str("pinned_commit", "Git commit hash to pin updates to"),
+        _bool("report_anomalies", "Report detected anomalies to frontends (default True)"),
+        _str("persistent_files", "Files preserved across web/zip updates"),
+        _str("moved_origin", "Previous origin URL Moonraker updates from"),
+        # Primary `[update_manager]` (unnamed) section options — valid only
+        # there, but modeled so a primary section in a loaded .cfg doesn't warn.
+        _bool("enable_auto_refresh", "Periodically fetch update state (primary section)"),
+        _bool("enable_system_updates", "Allow system package updates (primary section)"),
+        _str("refresh_window", "Hours for periodic checks, e.g. 0-5 (primary section)"),
         _int("refresh_interval", "Update check interval (hours)"),
     ],
 ))

--- a/backend/parser/config_schema.py
+++ b/backend/parser/config_schema.py
@@ -2192,6 +2192,7 @@ _register(SectionDef(
         _str("system_dependencies", "System packages to install"),
         _str("virtualenv", "Path to the virtualenv to update"),
         _str("env", "Environment variables for the update command"),
+        _str("info_tags", "Tags shown in the update manager UI (key=value lines)"),
         _int("refresh_interval", "Update check interval (hours)"),
     ],
 ))

--- a/reference/schema.json
+++ b/reference/schema.json
@@ -21044,7 +21044,7 @@
           "type": "string",
           "required": false,
           "default": null,
-          "description": "Update source type (git_repo, web, command, zip, json_file)",
+          "description": "Update source type (web, git_repo, zip, executable, python)",
           "enum_values": [],
           "unit": ""
         },
@@ -21148,11 +21148,101 @@
           "unit": ""
         },
         {
+          "name": "venv_args",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Extra arguments passed to the virtualenv creation",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
           "name": "info_tags",
           "type": "string",
           "required": false,
           "default": null,
           "description": "Tags shown in the update manager UI (key=value lines)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "enable_node_updates",
+          "type": "bool",
+          "required": false,
+          "default": null,
+          "description": "Run npm ci --only=prod when package-lock.json changes",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "is_system_service",
+          "type": "bool",
+          "required": false,
+          "default": null,
+          "description": "Treat the section name as the managed service (default True)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "pinned_commit",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Git commit hash to pin updates to",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "report_anomalies",
+          "type": "bool",
+          "required": false,
+          "default": null,
+          "description": "Report detected anomalies to frontends (default True)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "persistent_files",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Files preserved across web/zip updates",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "moved_origin",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Previous origin URL Moonraker updates from",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "enable_auto_refresh",
+          "type": "bool",
+          "required": false,
+          "default": null,
+          "description": "Periodically fetch update state (primary section)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "enable_system_updates",
+          "type": "bool",
+          "required": false,
+          "default": null,
+          "description": "Allow system package updates (primary section)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "refresh_window",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Hours for periodic checks, e.g. 0-5 (primary section)",
           "enum_values": [],
           "unit": ""
         },

--- a/reference/schema.json
+++ b/reference/schema.json
@@ -21148,6 +21148,15 @@
           "unit": ""
         },
         {
+          "name": "info_tags",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Tags shown in the update manager UI (key=value lines)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
           "name": "refresh_interval",
           "type": "int",
           "required": false,

--- a/tests/test_error_codes.py
+++ b/tests/test_error_codes.py
@@ -143,6 +143,48 @@ def test_unknown_param_carries_code():
     assert all('Unknown parameter' in e.message for e in unknowns)
 
 
+def test_update_manager_info_tags_is_known():
+    # Moonraker update_manager (validated by Moonraker, not Klipper): the
+    # common option set must not produce unknown_param warnings. Regression:
+    # KWC's own klipper-wire-configurator-update.cfg ships `info_tags:` with
+    # a continuation value, which the schema previously didn't model.
+    result = _validate(
+        '[update_manager klipper-wire-configurator]\n'
+        'type: git_repo\n'
+        'channel: dev\n'
+        'path: /home/clifgall/Klipper-Wire-Configurator\n'
+        'origin: https://github.com/SartorialGrunt0/Klipper-Wire-Configurator.git\n'
+        'primary_branch: main\n'
+        'virtualenv: /home/clifgall/Klipper-Wire-Configurator/venv\n'
+        'requirements: backend/requirements.txt\n'
+        'managed_services: klipper-wire-configurator\n'
+        'info_tags:\n'
+        '\tdesc=Klipper Wire Configurator\n'
+    )
+    unknowns = [e for e in result.errors if e.param == 'info_tags']
+    assert not unknowns, (
+        "info_tags is a real Moonraker update_manager option "
+        f"(app_deploy.py getlist) — got: {[e.message for e in unknowns]}"
+    )
+    assert not _with_code(result.errors, 'unknown_param'), (
+        f"no option in the shipped update_manager file should be unknown; "
+        f"got: {[e.message for e in result.errors]}"
+    )
+
+
+def test_update_manager_bogus_param_still_warns():
+    # Adding real options must not loosen the advisory unknown-param check.
+    result = _validate(
+        '[update_manager klipper-wire-configurator]\n'
+        'type: git_repo\n'
+        'totally_fake_option: 1\n'
+    )
+    unknowns = _with_code(result.errors, 'unknown_param')
+    assert any('totally_fake_option' in e.message for e in unknowns), (
+        "bogus update_manager option must still warn"
+    )
+
+
 # ── Messages with no consumer regex stay codeless ──────────────────
 
 def test_required_param_error_has_no_code():

--- a/tests/test_error_codes.py
+++ b/tests/test_error_codes.py
@@ -185,6 +185,62 @@ def test_update_manager_bogus_param_still_warns():
     )
 
 
+def test_update_manager_full_moonraker_option_set_known():
+    # Every option Moonraker reads for named [update_manager <name>]
+    # extension sections (source: components/update_manager/{update_manager,
+    # git_deploy, app_deploy}.py + docs/configuration.md) must be modeled —
+    # no unknown_param warnings on a config Moonraker accepts.
+    result = _validate(
+        '[update_manager my_ext]\n'
+        'type: git_repo\n'
+        'channel: beta\n'
+        'path: ~/my_ext\n'
+        'origin: https://github.com/owner/repo.git\n'
+        'primary_branch: main\n'
+        'virtualenv: ~/my_ext/venv\n'
+        'env: ~/my_ext/venv/bin/python\n'
+        'venv_args: --system-site-packages\n'
+        'requirements: requirements.txt\n'
+        'system_dependencies: system_dependencies.json\n'
+        'install_script: install.sh\n'
+        'enable_node_updates: True\n'
+        'is_system_service: False\n'
+        'managed_services: klipper\n'
+        'info_tags:\n'
+        '\tdesc=My Extension\n'
+        '\taction=webcam_restart\n'
+        'pinned_commit: 79930ed99a1fc284f41af5755908aa1fab948ce1\n'
+        'report_anomalies: False\n'
+        'persistent_files:\n'
+        '\tdata.json\n'
+        'refresh_interval: 168\n'
+        # web-type form of repo + python-type options also ride the same set
+        'repo: owner/repo\n'
+    )
+    unknowns = _with_code(result.errors, 'unknown_param')
+    assert not unknowns, (
+        f"all real Moonraker update_manager options must be modeled; "
+        f"got: {sorted(e.param for e in unknowns)}"
+    )
+
+
+def test_update_manager_primary_section_options_known():
+    # The unnamed primary [update_manager] section options are modeled too,
+    # so a primary section in a loaded .cfg doesn't warn.
+    result = _validate(
+        '[update_manager]\n'
+        'enable_auto_refresh: False\n'
+        'enable_system_updates: True\n'
+        'refresh_window: 0-5\n'
+        'refresh_interval: 672\n'
+    )
+    unknowns = _with_code(result.errors, 'unknown_param')
+    assert not unknowns, (
+        f"primary update_manager options must be modeled; "
+        f"got: {sorted(e.param for e in unknowns)}"
+    )
+
+
 # ── Messages with no consumer regex stay codeless ──────────────────
 
 def test_required_param_error_has_no_code():

--- a/tests/test_native_read_include_closure.py
+++ b/tests/test_native_read_include_closure.py
@@ -1,0 +1,161 @@
+"""
+Native read must expand the requested file set to the ON-DISK include
+closure, mirroring Klipper's configfile.py _resolve_include (includes resolve
+relative to the including file's directory and symlinks are followed freely).
+
+Real-world bug (V2.6.0, 2026-09): third-party installs (KAMP, moonraker-obico,
+mainsail macros) commonly symlink their .cfg files *into*
+/printer_data/config from elsewhere. list_config_files deliberately hides
+files whose symlink target escapes the config root (traversal guard), so the
+native auto-read never loads them — and the missing-include ERROR then fires
+on printer.cfg / KAMP_Settings.cfg include lines even though Klipper will
+load those symlinked files fine at startup. The project KWC builds must be
+what Klipper actually loads.
+"""
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'backend'))
+
+import api.native_routes as native_routes  # noqa: E402
+from main import app  # noqa: E402
+from services.native_services import list_config_files  # noqa: E402
+
+client = TestClient(app)
+
+pytestmark = pytest.mark.skipif(
+    not hasattr(os, 'symlink'),
+    reason='needs symlink support',
+)
+
+_MAINSAIL = '[virtual_sdcard]\npath: ~/printer_data/gcodes\n'
+_OBICO_MACROS = '[gcode_macro OBICO_HELPER]\ngcode:\n    RESPOND MSG="ok"\n'
+_KAMP_MESH = '[gcode_macro KAMP_MESHING]\ngcode:\n    G28\n'
+_KAMP_PURGE = '[gcode_macro LINE_PURGE]\ngcode:\n    G28\n'
+_KAMP_PARK = '[gcode_macro SMART_PARK]\ngcode:\n    G28\n'
+
+
+def _missing_include_messages(body: dict) -> list[str]:
+    out = []
+    for filename, file_result in body['files'].items():
+        for err in file_result['validation'].get('errors', []):
+            if err.get('code') == 'missing_include':
+                out.append(f"{filename}: {err['message']}")
+    return out
+
+
+def _make_fixture(tmp_path: Path):
+    """Build a config dir whose include targets are symlinked outside the root.
+
+    Returns (config_dir, visible_filenames) where visible_filenames are the
+    names list_config_files offers (the symlinked targets are hidden).
+    """
+    external = tmp_path / 'external'
+    (external / 'KAMP').mkdir(parents=True)
+    (external / 'mainsail.cfg').write_text(_MAINSAIL, encoding='utf-8')
+    (external / 'moonraker_obico_macros.cfg').write_text(_OBICO_MACROS, encoding='utf-8')
+    (external / 'KAMP' / 'Adaptive_Meshing.cfg').write_text(_KAMP_MESH, encoding='utf-8')
+    (external / 'KAMP' / 'Line_Purge.cfg').write_text(_KAMP_PURGE, encoding='utf-8')
+    (external / 'KAMP' / 'Smart_Park.cfg').write_text(_KAMP_PARK, encoding='utf-8')
+
+    config_dir = tmp_path / 'config'
+    config_dir.mkdir()
+    (config_dir / 'printer.cfg').write_text(
+        '[include moonraker_obico_macros.cfg]\n'
+        '[include mainsail.cfg]\n'
+        '[include aux_fan.cfg]\n'
+        '[include KAMP_Settings.cfg]\n'
+        '[printer]\nkinematics: cartesian\n',
+        encoding='utf-8',
+    )
+    (config_dir / 'KAMP_Settings.cfg').write_text(
+        '[include ./KAMP/Adaptive_Meshing.cfg]\n'
+        '[include ./KAMP/Line_Purge.cfg]\n'
+        '[include ./KAMP/Smart_Park.cfg]\n',
+        encoding='utf-8',
+    )
+    (config_dir / 'aux_fan.cfg').write_text(
+        '[gcode_macro AUX_FAN]\ngcode:\n    G28\n', encoding='utf-8',
+    )
+    # Symlink the include targets to live OUTSIDE the config root — the
+    # traversal guard in list_config_files hides these from the listing.
+    os.symlink(external / 'mainsail.cfg', config_dir / 'mainsail.cfg')
+    os.symlink(external / 'moonraker_obico_macros.cfg', config_dir / 'moonraker_obico_macros.cfg')
+    os.symlink(external / 'KAMP', config_dir / 'KAMP')
+
+    visible = [f['name'] for f in list_config_files(str(config_dir))]
+    return config_dir, visible
+
+
+def test_listing_hides_symlinked_include_targets(tmp_path):
+    """Precondition: the traversal guard drops the symlinked files."""
+    config_dir, visible = _make_fixture(tmp_path)
+    assert 'mainsail.cfg' not in visible
+    assert 'moonraker_obico_macros.cfg' not in visible
+    assert not any(name.startswith('KAMP/') for name in visible)
+
+
+def test_native_read_expands_to_disk_include_closure(monkeypatch, tmp_path):
+    """Read returns the include closure even for files hidden from the listing,
+    so no missing_include error fires for on-disk include targets."""
+    monkeypatch.setattr(native_routes, 'is_native_platform', lambda: True)
+    config_dir, visible = _make_fixture(tmp_path)
+
+    response = client.post('/api/native/config-files/read', json={
+        'config_path': str(config_dir),
+        'filenames': visible,
+    })
+
+    assert response.status_code == 200
+    body = response.json()
+
+    loaded = set(body['files'].keys())
+    for expected in (
+        'mainsail.cfg',
+        'moonraker_obico_macros.cfg',
+        'KAMP/Adaptive_Meshing.cfg',
+        'KAMP/Line_Purge.cfg',
+        'KAMP/Smart_Park.cfg',
+    ):
+        assert expected in loaded, (
+            f"include target {expected!r} must be loaded from disk even when "
+            f"the listing hides it; loaded: {sorted(loaded)}"
+        )
+
+    missing = _missing_include_messages(body)
+    assert not missing, (
+        "on-disk include targets must not be reported missing; "
+        f"got: {missing}"
+    )
+
+
+def test_native_read_still_flags_genuinely_missing_include(monkeypatch, tmp_path):
+    """A truly absent include target keeps its missing_include error."""
+    monkeypatch.setattr(native_routes, 'is_native_platform', lambda: True)
+    config_dir = tmp_path / 'config'
+    config_dir.mkdir()
+    (config_dir / 'printer.cfg').write_text(
+        '[include aux_fan.cfg]\n'
+        '[include gone.cfg]\n'
+        '[printer]\nkinematics: cartesian\n',
+        encoding='utf-8',
+    )
+    (config_dir / 'aux_fan.cfg').write_text(
+        '[gcode_macro AUX_FAN]\ngcode:\n    G28\n', encoding='utf-8',
+    )
+
+    response = client.post('/api/native/config-files/read', json={
+        'config_path': str(config_dir),
+        'filenames': ['printer.cfg', 'aux_fan.cfg'],
+    })
+
+    assert response.status_code == 200
+    body = response.json()
+    missing = _missing_include_messages(body)
+    assert any('gone.cfg' in message for message in missing), (
+        f"genuinely absent include must still error; got: {missing}"
+    )


### PR DESCRIPTION
## Summary
- **Native include closure** (`5210780`): `config-files/read` now expands the requested set to the on-disk include closure (Klipper semantics). Fixes false `missing_include` ERRORS on the real Trident where KAMP/moonraker-obico/mainsail macros are symlinked into `/printer_data/config` from elsewhere — `list_config_files` hides symlink-escaped files (traversal guard), so they were never loaded and V2.6.0's new check flagged them.
- **update_manager schema** (`6615d0e`, `0e3c5d5`): audit vs Moonraker source (`components/update_manager/*`) + docs — added the 12 missing `[update_manager]` options (`info_tags`, `enable_node_updates`, `is_system_service`, `pinned_commit`, `report_anomalies`, `persistent_files`, `moved_origin`, `venv_args`, `enable_auto_refresh`, `enable_system_updates`, `refresh_window`) and corrected the `type` description.

## Tests
- New `tests/test_native_read_include_closure.py` (symlink-escape fixture reproduces the exact Trident symptom; RED before fix)
- Full-option-set + primary-section update_manager regression tests in `tests/test_error_codes.py`
- Backend suite: 2943 passed