### PR TITLE
fix(validation,installer): config validation false positives + Mainsail sidebar self-heal

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ cd Klipper-Wire-Configurator
 bash scripts/install.sh
 ```
 
-Run **without sudo** — the installer escalates internally wherever needed (apt, systemd, and writes into the Moonraker config dir). `sudo bash scripts/install.sh` resets `$HOME` to `/root`, so the Moonraker config directory isn't found, the update_manager/Mainsail sidebar setup is silently skipped, and the app installs into `/root` instead of your user's home.
+Run **without sudo** — the installer escalates internally wherever needed (apt, systemd, and writes into the Moonraker config dir). `sudo bash scripts/install.sh` resets `$HOME` to `/root`, so the Moonraker config directory isn't found, the update_manager/Mainsail sidebar setup is silently skipped, and the app installs into `/root` instead of your user's home. If you do run it with sudo anyway, the installer detects this and re-runs itself as your real user. (`curl ... | sudo bash` can't recover the invoking user and is rejected outright.)
 
 Note: On 32-bit Raspberry Pi OS (`armv7` / `armhf`), the installer automatically uses the distro `nodejs` package.
 A successful install ends by checking the service health and printing the installer log path under `/tmp/klipper-wire-configurator-install-*.log`.

--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -23,6 +23,7 @@ from parser.config_parser import (
     ConfigFile,
     ConfigParam,
     ConfigSection,
+    find_save_config_sections,
     find_unclosed_headers,
     parse_config,
 )
@@ -707,6 +708,14 @@ def _config_update_to_config_file(data: ConfigUpdate) -> ConfigFile:
         )
         sections.append(section)
 
+    # Same contract for the #*# SAVE_CONFIG tail: Klipper appends the
+    # autosave data into the loaded config, so its values satisfy required
+    # params. Dropped here, delta/vendor configs with tail-only
+    # position_endstop/arm_length/delta_radius false-error
+    # "Required parameter is missing".
+    save_start, save_sections = (
+        find_save_config_sections(data.raw_text) if data.raw_text else (0, [])
+    )
     return ConfigFile(
         filename=data.filename,
         sections=sections,
@@ -718,6 +727,8 @@ def _config_update_to_config_file(data: ConfigUpdate) -> ConfigFile:
         # validation endpoints otherwise reconstruct the file without it and
         # the malformed-header check would silently never run.
         unclosed_headers=find_unclosed_headers(data.raw_text) if data.raw_text else [],
+        save_config_start_line=save_start,
+        save_config_sections=save_sections,
     )
 
 

--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -23,8 +23,6 @@ from parser.config_parser import (
     ConfigFile,
     ConfigParam,
     ConfigSection,
-    find_save_config_sections,
-    find_unclosed_headers,
     parse_config,
 )
 from parser.config_schema import (
@@ -682,6 +680,38 @@ async def load_saved_configs():
 # ── Helpers ─────────────────────────────────────────────────────
 
 
+def _reconcile_param_lines(sections: list[ConfigSection], originals: list[ConfigSection]) -> None:
+    """Restore param line numbers onto rebuilt sections from a fresh parse.
+
+    ParamUpdate cannot carry line_number (and to_dict() never serialized
+    params' lines), so every reconstructed param is 0. Section-level errors
+    survive, but findings computed FROM a param's line — macro Jinja body
+    offsets (param.line + body offset) above all — produce a confident but
+    wrong line_number (offset-only), which the frontend treats as fresh and
+    authoritative and paints on the wrong line. Re-match each rebuilt section
+    to its original (by line number, falling back to header order) and copy
+    param lines while the key order agrees; renamed/inserted params stay 0
+    and the frontend heuristic re-resolves them as designed.
+    """
+    by_header: dict[str, list[ConfigSection]] = {}
+    for sec in originals:
+        by_header.setdefault(sec.full_header, []).append(sec)
+    consumed: set[int] = set()
+    for sec in sections:
+        pool = [s for s in by_header.get(sec.full_header, []) if id(s) not in consumed]
+        if not pool:
+            continue
+        original = next(
+            (s for s in pool if sec.line_number and s.line_number == sec.line_number),
+            pool[0],
+        )
+        consumed.add(id(original))
+        for param, orig_param in zip(sec.params, original.params):
+            if param.key != orig_param.key:
+                break
+            param.line_number = orig_param.line_number
+
+
 def _config_update_to_config_file(data: ConfigUpdate) -> ConfigFile:
     """Convert API model to parser model."""
     sections = []
@@ -708,14 +738,19 @@ def _config_update_to_config_file(data: ConfigUpdate) -> ConfigFile:
         )
         sections.append(section)
 
-    # Same contract for the #*# SAVE_CONFIG tail: Klipper appends the
-    # autosave data into the loaded config, so its values satisfy required
-    # params. Dropped here, delta/vendor configs with tail-only
-    # position_endstop/arm_length/delta_radius false-error
-    # "Required parameter is missing".
-    save_start, save_sections = (
-        find_save_config_sections(data.raw_text) if data.raw_text else (0, [])
-    )
+    # Parse-time fields do not survive the API model: to_dict() drops the
+    # #*# SAVE_CONFIG tail and ParamUpdate has no line_number. Klipper
+    # appends the autosave data into the loaded config (its values satisfy
+    # required params), so dropping the tail made delta/vendor configs with
+    # tail-only position_endstop/arm_length/delta_radius false-error
+    # "Required parameter is missing". And param-anchored findings (macro
+    # Jinja body offsets especially) collapse to a confident wrong line
+    # when param lines are 0. Re-derive both from ONE fresh parse of the raw
+    # text; params that only exist in the submitted model (graph-editor
+    # additions) stay at line 0 so the frontend heuristic resolves them.
+    rederived = parse_config(data.raw_text, data.filename) if data.raw_text else None
+    if rederived is not None:
+        _reconcile_param_lines(sections, rederived.sections)
     return ConfigFile(
         filename=data.filename,
         sections=sections,
@@ -726,9 +761,9 @@ def _config_update_to_config_file(data: ConfigUpdate) -> ConfigFile:
         # serialize, so re-derive it from the raw text when present — the
         # validation endpoints otherwise reconstruct the file without it and
         # the malformed-header check would silently never run.
-        unclosed_headers=find_unclosed_headers(data.raw_text) if data.raw_text else [],
-        save_config_start_line=save_start,
-        save_config_sections=save_sections,
+        unclosed_headers=rederived.unclosed_headers if rederived else [],
+        save_config_start_line=rederived.save_config_start_line if rederived else 0,
+        save_config_sections=rederived.save_config_sections if rederived else [],
     )
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,6 @@
 """Klipper Wire Configurator - Backend Application"""
 import os
+from contextlib import asynccontextmanager
 from pathlib import Path
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -12,9 +13,26 @@ from api.ai_routes import router as ai_router
 from api.printer_memory_routes import router as printer_memory_router
 from api.macro_log_routes import router as macro_log_router
 from mcp_server import McpServer, get_index
+from services.mainsail_sidebar import self_heal_sidebar
 from fastapi.responses import JSONResponse
 
-app = FastAPI(title="Klipper Wire Configurator", version="1.0.0")
+
+@asynccontextmanager
+async def _app_lifespan(app: FastAPI):
+    """Re-assert the Mainsail sidebar entry on every service start.
+
+    Moonraker's update_manager never runs install.sh on update (git_repo
+    type = git pull + pip + managed_services restart), so the sidebar link
+    — which lives in the Moonraker config dir, outside the repo — can only
+    self-repair here. Best-effort: self_heal_sidebar never raises.
+    """
+    status = self_heal_sidebar()
+    if status in ("added", "updated"):
+        print(f"[startup] Mainsail sidebar entry {status}.")
+    yield
+
+
+app = FastAPI(title="Klipper Wire Configurator", version="1.0.0", lifespan=_app_lifespan)
 
 app.add_middleware(
     CORSMiddleware,

--- a/backend/parser/config_parser.py
+++ b/backend/parser/config_parser.py
@@ -251,20 +251,6 @@ def _parse_save_config_sections(lines: list[str]) -> tuple[int, list[ConfigSecti
     return save_config_start, sections
 
 
-def find_save_config_sections(text: str) -> tuple[int, list[ConfigSection]]:
-    """Re-derive the ``#*#`` SAVE_CONFIG tail from raw text.
-
-    Same contract as find_unclosed_headers: the validation API endpoints
-    reconstruct ConfigFile from the serialized model, and to_dict() does not
-    carry save_config_sections. Without re-derivation the reconstructed file
-    looks like it has no autosave tail, so required-param checks that Klipper
-    satisfies from SAVE_CONFIG values (delta position_endstop/arm_length,
-    delta_radius, bed_mesh defaults, ...) fire false "Required parameter is
-    missing" errors. Returns (start_line, sections); (0, []) when absent.
-    """
-    return _parse_save_config_sections(text.splitlines())
-
-
 def parse_config(text: str, filename: str = "printer.cfg") -> ConfigFile:
     """Parse a Klipper config file from text content.
 

--- a/backend/parser/config_parser.py
+++ b/backend/parser/config_parser.py
@@ -251,6 +251,20 @@ def _parse_save_config_sections(lines: list[str]) -> tuple[int, list[ConfigSecti
     return save_config_start, sections
 
 
+def find_save_config_sections(text: str) -> tuple[int, list[ConfigSection]]:
+    """Re-derive the ``#*#`` SAVE_CONFIG tail from raw text.
+
+    Same contract as find_unclosed_headers: the validation API endpoints
+    reconstruct ConfigFile from the serialized model, and to_dict() does not
+    carry save_config_sections. Without re-derivation the reconstructed file
+    looks like it has no autosave tail, so required-param checks that Klipper
+    satisfies from SAVE_CONFIG values (delta position_endstop/arm_length,
+    delta_radius, bed_mesh defaults, ...) fire false "Required parameter is
+    missing" errors. Returns (start_line, sections); (0, []) when absent.
+    """
+    return _parse_save_config_sections(text.splitlines())
+
+
 def parse_config(text: str, filename: str = "printer.cfg") -> ConfigFile:
     """Parse a Klipper config file from text content.
 

--- a/backend/parser/config_parser.py
+++ b/backend/parser/config_parser.py
@@ -146,6 +146,9 @@ NAMED_SECTION_TYPES = {
     "stepper", "carriage", "extra_carriage", "dual_carriage",
     "stepper_z1", "stepper_z2", "stepper_z3",
     "ad5206", "mcp4451", "mcp4728", "mcp4018",
+    # load_config_prefix modules missing above: dac084S085.py (Alligator
+    # digipot) and canbus_stats.py (CAN traffic stats).
+    "dac084S085", "canbus_stats",
     "sx1509", "samd_sercom", "adc_scaled", "ads1x1x",
     "load_cell", "load_cell_probe",
     "adxl345", "lis2dw", "lis3dh", "bmi160", "mpu9250", "icm20948",

--- a/backend/parser/config_schema.py
+++ b/backend/parser/config_schema.py
@@ -267,6 +267,8 @@ _register(SectionDef(
         _float("shoulder_height", "Rotary delta shoulder height", unit="mm", strict_above=0),
         _float("minimum_cruise_ratio", "Minimum cruise ratio", default="0.5", min_val=0, strict_below=1),
         _float("square_corner_velocity", "Square corner velocity", default="5.0", unit="mm/s", min_val=0),
+        # polar kinematics only (kinematics/polar.py:52 getfloat, above=0, default 0).
+        _float("max_angular_velocity", "Maximum angular velocity", default="0", strict_above=0),
     ],
 ))
 
@@ -880,7 +882,9 @@ _register(SectionDef(
     component_group="homing",
     is_named=True,
     params=[
-        _int("endstop_accuracy", "Endstop accuracy", strict_above=0),
+        # klippy endstop_phase.py:78 reads it with config.getfloat (mm,
+        # fractional values like .200 are the norm).
+        _float("endstop_accuracy", "Endstop accuracy (mm)", strict_above=0),
         _str("trigger_phase", "Trigger phase"),
         _bool("endstop_align_zero", "Align endstop to zero"),
     ],
@@ -1023,6 +1027,12 @@ _register(SectionDef(
         _pin("spi_software_sclk_pin", "Software SPI clock"),
         _pin("spi_software_mosi_pin", "Software SPI MOSI"),
         _pin("spi_software_miso_pin", "Software SPI MISO"),
+        # I2C sensor chips (HTU21D/LM75/BME280/...) configure their bus here
+        # (Config_Reference: HTU21D section -> common I2C settings).
+        *I2C_BUS_PARAMS,
+        _bool("htu21d_hold_master", "HTU21D clock-stretch hold during read"),
+        # htu21d.py:38-43 HTU21D_RESOLUTIONS keys (default TEMP12_HUM08).
+        _enum("htu21d_resolution", ["TEMP14_HUM12", "TEMP13_HUM10", "TEMP12_HUM08", "TEMP11_HUM11"], "HTU21D measurement resolution", default="TEMP12_HUM08"),
         _float("min_temp", "Minimum temperature", default="0", min_val=-273.15),
         _float("max_temp", "Maximum temperature", default="100"),
         _str("gcode_id", "G-code ID for temperature reporting"),
@@ -1862,6 +1872,25 @@ _register(SectionDef(
 # ── Digipot/DAC ──
 # ad5206 is SPI-only (bus.MCU_SPI_from_config); mcp4728 is I2C-only
 # (bus.MCU_I2C_from_config, default_addr=0x60). Model each with its real bus.
+_register(SectionDef(
+    section_type="dac084S085",
+    display_name="DAC084S085",
+    category="sub_component",
+    component_group="stepper_driver",
+    is_named=True,
+    description="DAC084S085 SPI digipot (stepper current reference), e.g. Alligator r2/r3",
+    # klippy/extras/dac084S085.py: MCU_SPI_from_config with pin_option
+    # "enable_pin", scale float (amps), channel_A..D each 0..scale.
+    params=[
+        _pin("enable_pin", "CS/enable pin (SPI chip select role)"),
+        *SPI_BUS_PARAMS,
+        _float("scale", "Channel value scale (amps)", default="1.0", strict_above=0),
+        _float("channel_A", "Channel A value (0..scale)", min_val=0),
+        _float("channel_B", "Channel B value (0..scale)", min_val=0),
+        _float("channel_C", "Channel C value (0..scale)", min_val=0),
+        _float("channel_D", "Channel D value (0..scale)", min_val=0),
+    ],
+))
 _register(SectionDef(
     section_type="ad5206",
     display_name="AD5206",

--- a/backend/parser/config_schema.py
+++ b/backend/parser/config_schema.py
@@ -195,9 +195,12 @@ RTD_TC_PARAMS = [
     _int("rtd_num_of_wires", "RTD wire count (2/3/4)"),
     _float("rtd_reference_r", "RTD reference wire resistance (ohms)", strict_above=0),
     _bool("rtd_use_50Hz_filter", "Enable RTD 50 Hz noise filter"),
-    _str("tc_type", "Thermocouple type (K/J/T/E/N/R/S/B)"),
+    # tc_type / tc_averaging_count are getchoice-read by MAX31856
+    # (spi_temperature.py:165-184): an invalid value is a config-load
+    # hard-fail, so they must be enums, not free-form str/int.
+    _enum("tc_type", ["B", "E", "J", "K", "N", "R", "S", "T"], "Thermocouple type", default="K"),
     _bool("tc_use_50Hz_filter", "Enable TC 50 Hz noise filter"),
-    _int("tc_averaging_count", "TC sample averaging count"),
+    _enum("tc_averaging_count", ["1", "2", "4", "8", "16"], "TC sample averaging count", default="1"),
 ]
 
 # Full SPI bus parameter family, mirroring bus.py MCU_SPI_from_config:
@@ -393,6 +396,7 @@ _register(SectionDef(
         _enum("sensor_type", SENSOR_TYPE_ENUM, "Temperature sensor type", required=True),
         _pin("sensor_pin", "Sensor analog pin"),
         _str("spi_bus", "SPI bus (for SPI sensors)"),
+        _int("spi_speed", "SPI bus clock speed", min_val=100000),
         _pin("spi_software_sclk_pin", "Software SPI clock"),
         _pin("spi_software_mosi_pin", "Software SPI MOSI"),
         _pin("spi_software_miso_pin", "Software SPI MISO"),
@@ -1075,6 +1079,7 @@ _register(SectionDef(
         _float("pullup_resistor", "Sensor pullup resistor", default="4700", strict_above=0),
         _float("inline_resistor", "Sensor inline resistor", default="0", min_val=0),
         _str("spi_bus", "SPI bus (for SPI sensors)"),
+        _int("spi_speed", "SPI bus clock speed", min_val=100000),
         _pin("spi_software_sclk_pin", "Software SPI clock"),
         _pin("spi_software_mosi_pin", "Software SPI MOSI"),
         _pin("spi_software_miso_pin", "Software SPI MISO"),
@@ -2165,9 +2170,11 @@ _register(SectionDef(
         _int("rtd_num_of_wires", "RTD wire count (2/3/4)"),
         _float("rtd_reference_r", "RTD reference wire resistance (ohms)", strict_above=0),
         _bool("rtd_use_50Hz_filter", "Enable RTD 50 Hz noise filter"),
-        _str("tc_type", "Thermocouple type (K/J/T/E/N/R/S/B)"),
+        # getchoice-read by MAX31856 (spi_temperature.py:165-184) — invalid
+        # value = config-load hard-fail, so modeled as enums.
+        _enum("tc_type", ["B", "E", "J", "K", "N", "R", "S", "T"], "Thermocouple type", default="K"),
         _bool("tc_use_50Hz_filter", "Enable TC 50 Hz noise filter"),
-        _int("tc_averaging_count", "TC sample averaging count"),
+        _enum("tc_averaging_count", ["1", "2", "4", "8", "16"], "TC sample averaging count", default="1"),
         # ADS1220 amplifier (PT100 / PT1000)
         _str("gain", "ADS1220 PGA gain"),
         _str("sample_rate", "ADS1220 sample rate"),

--- a/backend/parser/config_schema.py
+++ b/backend/parser/config_schema.py
@@ -181,6 +181,25 @@ SENSOR_TYPE_ENUM = [
     "DS18B20", "temperature_combined",
 ]
 
+# RTD / thermocouple sensor-class params (spi_temperature.py MAX31865/MAX31856).
+# A sensor class is instantiated with the config of WHATEVER section declares
+# it: heaters.py Heater.__init__ -> setup_sensor(config) (heaters.py:280-300)
+# passes the SAME section to the sensor factory, so [extruder] with
+# sensor_type: MAX31865 reads rtd_nominal_r / rtd_reference_r (:285-286),
+# rtd_use_50Hz_filter (:334) and rtd_num_of_wires (:336) right there. Spread
+# into every section whose sensor_type takes the generic SENSOR_TYPE_ENUM —
+# NOT into fixed-enum sections ([angle], [load_cell], [probe_eddy_current],
+# [load_cell_probe]), which cannot host an RTD/TC chip.
+RTD_TC_PARAMS = [
+    _float("rtd_nominal_r", "RTD nominal resistance at 0°C (ohms)", strict_above=0),
+    _int("rtd_num_of_wires", "RTD wire count (2/3/4)"),
+    _float("rtd_reference_r", "RTD reference wire resistance (ohms)", strict_above=0),
+    _bool("rtd_use_50Hz_filter", "Enable RTD 50 Hz noise filter"),
+    _str("tc_type", "Thermocouple type (K/J/T/E/N/R/S/B)"),
+    _bool("tc_use_50Hz_filter", "Enable TC 50 Hz noise filter"),
+    _int("tc_averaging_count", "TC sample averaging count"),
+]
+
 # Full SPI bus parameter family, mirroring bus.py MCU_SPI_from_config:
 # hardware bus (spi_bus) OR software bus (the three spi_software_* pins) plus
 # optional chip select and clock speed. Reused by every SPI-bus section so the
@@ -394,6 +413,7 @@ _register(SectionDef(
         _float("max_temp", "Maximum allowed temperature", required=True, unit="°C"),
         _float("pressure_advance", "Pressure advance coefficient", default="0", min_val=0),
         _float("pressure_advance_smooth_time", "Pressure advance smooth time", default="0.040", unit="s", strict_above=0),
+        *RTD_TC_PARAMS,
     ],
 ))
 
@@ -434,6 +454,10 @@ _register(SectionDef(
         _float("pwm_cycle_time", "PWM cycle time", default="0.100", unit="s", strict_above=0),
         _float("smooth_time", "Temperature smoothing window", default="1.0", unit="s", strict_above=0),
         _float("pullup_resistor", "Pullup resistor", default="4700", strict_above=0),
+        # SPI sensor chips (MAX31865/MAX31856) read their bus from THIS section
+        # (heaters.py setup_sensor passes the heater config to the factory).
+        *SPI_BUS_PARAMS,
+        *RTD_TC_PARAMS,
     ],
 ))
 
@@ -461,6 +485,9 @@ _register(SectionDef(
         _float("max_power", "Maximum heater power", default="1.0", max_val=1, strict_above=0),
         _float("max_delta", "Max temperature delta for watermark control", default="2.0", strict_above=0),
         _float("pwm_cycle_time", "PWM cycle time", default="0.100", unit="s", strict_above=0),
+        # SPI sensor chips read their bus from this section (setup_sensor).
+        *SPI_BUS_PARAMS,
+        *RTD_TC_PARAMS,
     ],
 ))
 
@@ -644,6 +671,9 @@ _register(SectionDef(
         _float("pid_Kd", "PID derivative"),
         _float("pid_deriv_time", "PID derivative time", default="2.0", strict_above=0),
         _str("gcode_id", "G-code temperature report ID"),
+        # SPI sensor chips read their bus from this section (setup_sensor).
+        *SPI_BUS_PARAMS,
+        *RTD_TC_PARAMS,
     ],
 ))
 
@@ -1057,6 +1087,7 @@ _register(SectionDef(
         _float("min_temp", "Minimum temperature", default="0", min_val=-273.15),
         _float("max_temp", "Maximum temperature", default="100"),
         _str("gcode_id", "G-code ID for temperature reporting"),
+        *RTD_TC_PARAMS,
     ],
 ))
 
@@ -1764,6 +1795,9 @@ _register(SectionDef(
         _float("smooth_time", "Smooth time", default="2.0", strict_above=0),
         _float("min_temp", "Min temp", default="0", min_val=-273.15),
         _float("max_temp", "Max temp", default="100"),
+        # SPI sensor chips read their bus from this section (setup_sensor).
+        *SPI_BUS_PARAMS,
+        *RTD_TC_PARAMS,
     ],
 ))
 

--- a/backend/parser/config_schema.py
+++ b/backend/parser/config_schema.py
@@ -489,6 +489,27 @@ for tmc_type in ["tmc2130", "tmc2240", "tmc5160"]:
         params=TMC_SPI_PARAMS[:],
     ))
 
+# tmc2240 is dual-mode (tmc2240.py:352): with uart_pin present it talks over
+# the bit-banged TMC UART (tmc_uart.MCU_TMC_uart, max_addr=7 — uart_address
+# goes 0..7, wider than the 2208/2209's 0..3) and NEVER reads cs_pin;
+# without uart_pin it is the plain SPI path above. cs_pin's requiredness is
+# conditional, enforced in validator._skip_missing_required_param.
+_register(SectionDef(
+    section_type="tmc2240",
+    display_name="TMC2240",
+    category="sub_component",
+    component_group="stepper_driver",
+    is_named=True,
+    name_references="stepper",
+    description="TMC2240 stepper driver (SPI, or UART when uart_pin is set)",
+    params=TMC_SPI_PARAMS[:] + [
+        _pin("uart_pin", "UART RX pin (switches the driver to UART mode)"),
+        _pin("tx_pin", "UART TX pin (if separate)"),
+        _str("select_pins", "Select pins for UART mux"),
+        _int("uart_address", "UART address (0-7)", default="0", min_val=0, max_val=7),
+    ],
+))
+
 _register(SectionDef(
     section_type="tmc2660",
     display_name="TMC2660",

--- a/backend/parser/validator.py
+++ b/backend/parser/validator.py
@@ -176,7 +176,13 @@ def _get_printer_kinematics(config: ConfigFile) -> str | None:
 def _normalize_pin_values(value: str) -> list[str]:
     pins: list[str] = []
     for raw_pin in value.split(","):
-        clean_pin = re.sub(r"\s*:\s*", ":", raw_pin.lstrip("!^~").strip())
+        # Mirror klippy/pins.py parse_pin order: strip whitespace, THEN drop
+        # the pullup/invert prefixes, then whitespace again (pins.py:66-76).
+        # Order matters: a comma list puts a leading space on every element
+        # after the first (" ^menu:PA0"), and lstrip("!^~") before the
+        # whitespace strip leaves "^menu" to be checked as the chip name
+        # (V2.6.0 false "Unknown pin chip name '^menu'" on encoder_pins).
+        clean_pin = re.sub(r"\s*:\s*", ":", raw_pin.strip().lstrip("!^~").strip())
         if clean_pin and not clean_pin.startswith("<"):
             pins.append(clean_pin)
     return pins

--- a/backend/parser/validator.py
+++ b/backend/parser/validator.py
@@ -87,6 +87,10 @@ class PinUse:
     param: str
     line_number: int = 0
     filename: str = ""
+    # cs_pin of a daisy-chained TMC2130/TMC5160 (chain_length >= 2): klippy
+    # looks it up with share_type="tmc_spi_cs" (tmc2130.py:190-194), so
+    # pins.py permits several such drivers on one pin.
+    tmc_spi_chain_cs: bool = False
 
     @property
     def label(self) -> str:
@@ -728,6 +732,16 @@ def validate_config(config: ConfigFile) -> ValidationResult:
     section_counts: dict[str, int] = {}
     used_pins: dict[str, list[PinUse]] = {}
     defined_sections: set[str] = set()
+    # User-defined [thermistor NAME] sections are registered as sensor
+    # factories by heaters.py at load, so they are valid sensor_type values
+    # alongside the builtin enum (heaters.py add_factory, exact-name
+    # lookup — configparser section names are case-sensitive).
+    user_thermistor_names = {
+        section.section_name.strip()
+        for section in config.sections
+        if section.section_type == "thermistor" and not section.is_commented_out
+        and section.section_name.strip()
+    }
     # A TMC driver's diag pin is allocated only while sensorless homing is
     # active for that driver (tmc.py TMCVirtualPinHelper.setup_pin); compute
     # the set of '<chip>:virtual_endstop' references once per file so dead
@@ -900,8 +914,17 @@ def validate_config(config: ConfigFile) -> ValidationResult:
                 ))
                 continue
 
-            # Type validation
-            _validate_param_value(param, param_def, section, result)
+            # sensor_type is validated against the BUILTIN Klipper sensor
+            # list, but heaters.py add_factory also registers every user
+            # [thermistor NAME] section in the config (Config_Reference:
+            # "if one defines a [thermistor my_thermistor] section then one
+            # may use sensor_type: my_thermistor"). Skip the enum check for
+            # those names; unknown names still error.
+            if not (
+                param.key == "sensor_type"
+                and param.value.strip() in user_thermistor_names
+            ):
+                _validate_param_value(param, param_def, section, result)
 
             # Relational validation (param A vs param B, same section)
             _check_relational_param(param, param_def, section, result)
@@ -938,6 +961,11 @@ def validate_config(config: ConfigFile) -> ValidationResult:
         ),
     )
 
+    # TMC SPI daisy-chain consistency (same length / unique positions).
+    _check_tmc_spi_chain_conflicts(
+        {config.filename: config}, {config.filename: result}, {config.filename},
+    )
+
     # Bulk-ack suppression (Phase 4 save gate): drop warnings whose stable
     # identity is in the identity store. Warnings ONLY — errors are never
     # acknowledged (the save-gate override is per-save by design), and info
@@ -967,6 +995,31 @@ def validate_project_configs(configs: dict[str, ConfigFile]) -> dict[str, Valida
     # regardless of file count (tmc.py), so this runs for single-file
     # projects too (unlike the cross-file passes below it).
     _check_tmc_stepper_references(configs, results, _get_active_project_files(configs))
+
+    # A [thermistor NAME] in ANY active file registers a sensor factory for
+    # the whole project (Klipper loads includes into one namespace), so a
+    # sensor_type error raised file-locally is a false positive when the
+    # name is defined elsewhere in the project.
+    if len(configs) > 1:
+        project_thermistor_names = {
+            section.section_name.strip()
+            for filename, config in configs.items()
+            if filename in _get_active_project_files(configs)
+            for section in config.sections
+            if section.section_type == "thermistor" and not section.is_commented_out
+            and section.section_name.strip()
+        }
+        if project_thermistor_names:
+            for filename, result in results.items():
+                result.errors = [
+                    e for e in result.errors
+                    if not (
+                        e.severity == "error"
+                        and e.param == "sensor_type"
+                        and e.message.startswith("Invalid value '")
+                        and e.message.split("'")[1] in project_thermistor_names
+                    )
+                ]
 
     if len(configs) <= 1:
         return results
@@ -1178,6 +1231,10 @@ def validate_project_configs(configs: dict[str, ConfigFile]) -> dict[str, Valida
         _collect_duplicate_pin_override_pins(configs, active_files),
     )
 
+    # TMC SPI daisy chains can span files (drivers in an included file);
+    # the per-file pass only sees one file's drivers.
+    _check_tmc_spi_chain_conflicts(configs, results, active_files)
+
     # Pin-chip membership (F8): a pin's chip prefix must name a chip the
     # project registers ([mcu NAME], probe, TMC virtual-endstop chips, ...),
     # mirroring klippy/pins.py parse_pin's 'Unknown pin chip name' hard-fail.
@@ -1238,6 +1295,10 @@ def _check_tmc_stepper_references(
     file), mirroring how Klipper loads all includes into one namespace.
     """
     # Map referenced section name (lowercased) -> first active ConfigSection.
+    # Keyed by FULL HEADER: klippy joins every word after the driver type
+    # (" ".join(config.get_name().split()[1:])) and calls has_section on the
+    # result, so [tmc2208 manual_stepper gear_stepper] resolves to the FULL
+    # header [manual_stepper gear_stepper], not the bare type 'manual_stepper'.
     referenced_sections: dict[str, tuple[str, ConfigSection]] = {}
     for filename, config in configs.items():
         if filename not in active_files:
@@ -1245,7 +1306,7 @@ def _check_tmc_stepper_references(
         for section in config.sections:
             if section.section_type == "include" or section.is_commented_out:
                 continue
-            key = section.section_type.lower()
+            key = section.full_header.lower()
             if key not in referenced_sections:
                 referenced_sections[key] = (filename, section)
 
@@ -1855,6 +1916,7 @@ def _find_param_def(sec_def, key: str):
 
 def _track_pin_usage(param, section, used_pins: dict, filename: str = "") -> None:
     """Record every normalized pin value of a PIN param into used_pins."""
+    chain_cs = _is_tmc_spi_chain_cs(param, section)
     for clean_pin in _normalize_pin_values(param.value):
         if clean_pin not in used_pins:
             used_pins[clean_pin] = []
@@ -1865,7 +1927,37 @@ def _track_pin_usage(param, section, used_pins: dict, filename: str = "") -> Non
             param=param.key,
             line_number=param.line_number,
             filename=filename,
+            tmc_spi_chain_cs=chain_cs,
         ))
+
+
+# TMC drivers whose SPI path shares cs_pin via share_type="tmc_spi_cs"
+# when daisy-chained: tmc2130 and tmc5160 route through
+# tmc2130.MCU_TMC_SPI (tmc5160.py:328), and SPI-mode tmc2240 does too
+# (tmc2240.py:358, only when uart_pin is absent). tmc2660 uses its OWN
+# MCU_SPI_from_config WITHOUT share_type (tmc2660.py:196) — chaining there
+# is meaningless and cs_pin stays exclusive.
+TMC_SPI_CHAINABLE_TYPES = frozenset({"tmc2130", "tmc2240", "tmc5160"})
+
+
+def _is_tmc_spi_chain_cs(param, section) -> bool:
+    """True when this cs_pin use belongs to a daisy-chained SPI TMC driver.
+
+    Ground truth (tmc2130.py lookup_tmc_spi_chain + MCU_TMC_SPI_chain):
+    with chain_length >= 2 the cs_pin is looked up with
+    share_type='tmc_spi_cs', so pins.py permits it on several chained
+    drivers; without chain_length the lookup is unshared and a second user
+    hard-fails 'pin ... used multiple times'.
+    """
+    if param.key != "cs_pin" or section.section_type not in TMC_SPI_CHAINABLE_TYPES:
+        return False
+    if section.section_type == "tmc2240" and section.get_value("uart_pin").strip():
+        return False  # UART-mode 2240 never touches the SPI chain path
+    chain_len = section.get_value("chain_length").strip()
+    try:
+        return int(chain_len) >= 2
+    except ValueError:
+        return False
 
 
 def _check_pin_conflicts(
@@ -2118,7 +2210,118 @@ def _is_allowed_shared_pin(users: list[PinUse]) -> bool:
         or _is_allowed_shared_enable_pin(users)
         or _is_allowed_shared_communication_pin(users)
         or _is_allowed_shared_display_button_pin(users)
+        or _is_allowed_shared_tmc_spi_chain_cs_pin(users)
     )
+
+
+def _is_allowed_shared_tmc_spi_chain_cs_pin(users: list[PinUse]) -> bool:
+    """Daisy-chained TMC2130/2240/5160 drivers may share one cs_pin.
+
+    Only the cs_pin itself is shareable (share_type='tmc_spi_cs'); any
+    other param on the pin keeps the conflict. Chain-internal errors
+    (mismatched chain_length, duplicate chain_position) are separate
+    Klipper hard-fails reported by _check_tmc_spi_chain_conflicts, so this
+    exemption never hides them.
+    """
+    if not users:
+        return False
+    return all(u.param == "cs_pin" and u.tmc_spi_chain_cs for u in users)
+
+
+def _check_tmc_spi_chain_conflicts(
+    configs: dict,
+    results: dict,
+    active_files: set,
+) -> None:
+    """Mirror lookup_tmc_spi_chain's two chain hard-fails (tmc2130.py:244-257).
+
+    Drivers sharing one daisy-chain cs_pin must declare the same
+    chain_length ("TMC SPI chain must have same length") and distinct
+    chain_positions ("TMC SPI chain can not have duplicate position").
+    Grouped by normalized cs_pin across the active project.
+    """
+    groups: dict[str, list[tuple[str, "ConfigSection", int]]] = {}
+    for filename in sorted(active_files):
+        for section in configs[filename].sections:
+            if section.is_commented_out or section.section_type == "include":
+                continue
+            if section.section_type not in TMC_SPI_CHAINABLE_TYPES:
+                continue
+            if section.section_type == "tmc2240" and section.get_value("uart_pin").strip():
+                continue
+            try:
+                chain_len = int(section.get_value("chain_length").strip())
+            except ValueError:
+                continue
+            if chain_len < 2:
+                continue
+            for pin in _normalize_pin_values(section.get_value("cs_pin")):
+                groups.setdefault(pin, []).append((filename, section, chain_len))
+
+    for _pin, entries in groups.items():
+        lengths = {e[2] for e in entries}
+        seen_pos: dict[str, int] = {}
+
+        def _already(result, param, message):
+            return any(
+                e.severity == "error" and e.param == param and e.message == message
+                for e in result.errors
+            )
+
+        for filename, section, chain_len in entries:
+            result = results.get(filename)
+            if result is None:
+                continue
+            if len(lengths) > 1 and chain_len != sorted(lengths)[0]:
+                message = (
+                    f"TMC SPI chain must have same length — this section "
+                    f"declares chain_length {chain_len}, another driver on "
+                    f"the same cs_pin declares {sorted(lengths)[0]}. Klipper "
+                    "fails to start."
+                )
+                if not _already(result, "chain_length", message):
+                    result.errors.append(ValidationError(
+                        severity="error",
+                        section=section.full_header,
+                        param="chain_length",
+                        message=message,
+                        line_number=section.line_number,
+                    ))
+            pos = section.get_value("chain_position").strip()
+            if pos:
+                try:
+                    pos_int = int(pos)
+                except ValueError:
+                    pos_int = 0
+                if not 1 <= pos_int <= chain_len:
+                    message = (
+                        f"chain_position '{pos}' is outside 1..chain_length "
+                        f"{chain_len} — Klipper rejects it at startup."
+                    )
+                    if not _already(result, "chain_position", message):
+                        result.errors.append(ValidationError(
+                            severity="error",
+                            section=section.full_header,
+                            param="chain_position",
+                            message=message,
+                            line_number=section.line_number,
+                        ))
+                if pos in seen_pos:
+                    message = (
+                        f"TMC SPI chain can not have duplicate position "
+                        f"'{pos}' — another driver on the same cs_pin uses "
+                        "it. Klipper fails to start."
+                    )
+                    if not _already(result, "chain_position", message):
+                        result.errors.append(ValidationError(
+                            severity="error",
+                            section=section.full_header,
+                            param="chain_position",
+                            message=message,
+                            line_number=section.line_number,
+                        ))
+                else:
+                    seen_pos[pos] = chain_len
 
 
 def _is_allowed_shared_tmc_uart_pin(users: list[PinUse]) -> bool:

--- a/backend/parser/validator.py
+++ b/backend/parser/validator.py
@@ -188,6 +188,162 @@ def _normalize_pin_values(value: str) -> list[str]:
     return pins
 
 
+# klippy/extras/tmc.py: TMCVirtualPinHelper allocates its diag pin ONLY
+# inside setup_pin — i.e. only when a stepper's endstop_pin references
+# <driver_type>_<driver_name>:virtual_endstop. With sensorless homing off
+# (the common "diag wired but unused" layout — MPMDV2 cross-wires diag to
+# the other axis' physical endstops), the diag pin is never claimed, so it
+# legally collides with any other section's pin.
+TMC_DIAG_PARAM_NAMES = frozenset({"diag_pin", "diag0_pin", "diag1_pin"})
+
+
+def _collect_active_virtual_endstop_chips(sections) -> set[str]:
+    """Chip names referenced as '<chip>:virtual_endstop' by ANY param value.
+
+    A TMC driver's diag pin is live only when its registered chip name
+    (tmc.py:583 `register_chip(f'{type}_{name}')`) appears here. Case-folded
+    to match the chip registry's normalization.
+    """
+    chips: set[str] = set()
+    for section in sections:
+        if section.is_commented_out:
+            continue
+        for param in section.params:
+            if param.is_commented_out or not param.value:
+                continue
+            for clean in _normalize_pin_values(param.value):
+                head, sep, tail = clean.partition(":")
+                if sep and tail.strip().lower() == "virtual_endstop":
+                    chips.add(head.strip().lower())
+    return chips
+
+
+def _is_dead_tmc_diag_use(param, section, active_virtual_chips: set[str]) -> bool:
+    """True when a TMC diag param will never be allocated by klippy."""
+    if param.key.strip().lower() not in TMC_DIAG_PARAM_NAMES:
+        return False
+    driver_chip = f"{section.section_type}_{section.section_name}".strip().lower()
+    return driver_chip not in active_virtual_chips
+
+
+def _project_file_order(configs: dict[str, ConfigFile], main_file: str) -> list[str]:
+    """Files in effective-merge order: deepest includes first, main LAST.
+
+    Approximation of Klipper's linear parse (configfile.py _parse_config
+    processes an [include] at its line position). KWC's parser does not keep
+    include line numbers, so we assume the conventional layout — include
+    directives at the top, own definitions below — which makes the including
+    file's own content win over anything its includes define. The live
+    Trident/voron configs all follow this layout (printer.cfg's
+    [idle_timeout] overriding Hotkey.cfg's is exactly this precedence).
+    Worst case (an [include] placed BELOW a duplicated section) the shadow
+    is attributed to the wrong side; conventional layout makes that rare.
+    """
+    basename_map = {_basename(filename): filename for filename in configs}
+    ordered: list[str] = []
+    seen: set[str] = set()
+
+    def visit(filename: str) -> None:
+        if filename in seen:
+            return
+        seen.add(filename)
+        config = configs.get(filename)
+        if config is not None:
+            for include_path in config.includes:
+                target = include_path if include_path in configs else basename_map.get(_basename(include_path))
+                if target is not None:
+                    visit(target)
+        ordered.append(filename)
+
+    visit(main_file)
+    return ordered
+
+
+def _collect_live_pin_values(configs: dict[str, ConfigFile], active_files: set[str]) -> dict[tuple[str, str], set[str]]:
+    """Winning pin values per (section-header, param) under Klipper's merge.
+
+    RawConfigParser(strict=False) merges duplicate sections as a per-option
+    union where the LAST definition of an option wins. A pin value from an
+    earlier definition of the same (header, param) that the winner doesn't
+    contain is never allocated — ground-truthed with real klippy (dup
+    [fan] pin shadowing a [heater_fan] pin loads clean). Only keys defined
+    more than once appear in the map.
+    """
+    main_file = _find_main_project_file(configs)
+    if main_file is None:
+        return {}
+
+    values_by_key: dict[tuple[str, str], list[set[str]]] = {}
+    for filename in _project_file_order(configs, main_file):
+        if filename not in active_files:
+            continue
+        for section in configs[filename].sections:
+            if section.is_commented_out or section.section_type == "include":
+                continue
+            sec_def = get_section_def(section.section_type)
+            for param in section.params:
+                if param.is_commented_out or param.key == "_comment_" or not param.value:
+                    continue
+                param_def = _find_param_def(sec_def, param.key)
+                if param_def is None or param_def.param_type != ParamType.PIN:
+                    continue
+                key = (section.full_header.lower(), param.key.lower())
+                values_by_key.setdefault(key, []).append(set(_normalize_pin_values(param.value)))
+
+    return {
+        key: occs[-1]
+        for key, occs in values_by_key.items()
+        if len(occs) > 1
+    }
+
+
+def _collect_live_pin_values_single_file(config: ConfigFile) -> dict[tuple[str, str], set[str]]:
+    """Same merge semantics as _collect_live_pin_values, scoped to one file:
+    duplicate sections inside a file merge in definition order, last wins."""
+    values_by_key: dict[tuple[str, str], list[set[str]]] = {}
+    for section in config.sections:
+        if section.is_commented_out or section.section_type == "include":
+            continue
+        sec_def = get_section_def(section.section_type)
+        for param in section.params:
+            if param.is_commented_out or param.key == "_comment_" or not param.value:
+                continue
+            param_def = _find_param_def(sec_def, param.key)
+            if param_def is None or param_def.param_type != ParamType.PIN:
+                continue
+            key = (section.full_header.lower(), param.key.lower())
+            values_by_key.setdefault(key, []).append(set(_normalize_pin_values(param.value)))
+
+    return {
+        key: occs[-1]
+        for key, occs in values_by_key.items()
+        if len(occs) > 1
+    }
+
+
+def _drop_shadowed_pin_uses(used_pins: dict[str, list[PinUse]], live_pin_values: dict[tuple[str, str], set[str]]) -> None:
+    """Remove pin uses that Klipper's section merge never allocates."""
+    if not live_pin_values:
+        return
+    for pin in list(used_pins):
+        kept = [u for u in used_pins[pin] if not _is_shadowed_pin_use(u, live_pin_values)]
+        if kept:
+            used_pins[pin] = kept
+        else:
+            del used_pins[pin]
+
+
+def _is_shadowed_pin_use(use: PinUse, live_pin_values: dict[tuple[str, str], set[str]]) -> bool:
+    """True when this pin's value was overridden by a later definition."""
+    if not live_pin_values:
+        return False
+    key = (use.section.lower(), use.param.lower())
+    winners = live_pin_values.get(key)
+    if winners is None:
+        return False
+    return use.pin not in winners
+
+
 def _find_main_project_file(configs: dict[str, ConfigFile]) -> str | None:
     if not configs:
         return None
@@ -572,6 +728,11 @@ def validate_config(config: ConfigFile) -> ValidationResult:
     section_counts: dict[str, int] = {}
     used_pins: dict[str, list[PinUse]] = {}
     defined_sections: set[str] = set()
+    # A TMC driver's diag pin is allocated only while sensorless homing is
+    # active for that driver (tmc.py TMCVirtualPinHelper.setup_pin); compute
+    # the set of '<chip>:virtual_endstop' references once per file so dead
+    # diag pins never enter the conflict ledger.
+    active_virtual_chips = _collect_active_virtual_endstop_chips(config.sections)
     save_config_params_by_header: dict[str, set[str]] = {}
     save_config_section_types: set[str] = set()
     save_config_component_groups: set[str] = set()
@@ -660,6 +821,11 @@ def validate_config(config: ConfigFile) -> ValidationResult:
         for param_def in sec_def.params:
             if not param_def.required or param_def.name in active_params:
                 continue
+            if param_def.name == "rotation_distance" and "gear_ratio" in active_params:
+                # klippy/stepper.py parse_step_distance (297-309):
+                # rotation_distance is read only when gear_ratio is absent
+                # (the units_in_radians path fixes one rotation at 2*pi).
+                continue
             if _skip_missing_required_param(section, param_def.name, active_params):
                 continue
             result.errors.append(ValidationError(
@@ -742,6 +908,8 @@ def validate_config(config: ConfigFile) -> ValidationResult:
 
             # Track pin usage
             if param_def.param_type == ParamType.PIN and param.value:
+                if _is_dead_tmc_diag_use(param, section, active_virtual_chips):
+                    continue
                 _track_pin_usage(param, section, used_pins)
 
     # Check for required sections
@@ -758,7 +926,10 @@ def validate_config(config: ConfigFile) -> ValidationResult:
         result,
     )
 
-    # Check for pin conflicts
+    # Check for pin conflicts (drop uses shadowed by duplicate-section merge —
+    # a pin value overridden by a later definition of the same section is
+    # never allocated by Klipper)
+    _drop_shadowed_pin_uses(used_pins, _collect_live_pin_values_single_file(config))
     _check_pin_conflicts(
         used_pins,
         result,
@@ -1754,6 +1925,9 @@ def _check_cross_file_pin_conflicts(
     """
     used_pins: dict[str, list[PinUse]] = {}
     active_files = _get_active_project_files(configs)
+    active_virtual_chips: set[str] = set()
+    for filename in sorted(active_files):
+        active_virtual_chips |= _collect_active_virtual_endstop_chips(configs[filename].sections)
     for filename in sorted(active_files):
         config = configs[filename]
         for section in config.sections:
@@ -1765,7 +1939,13 @@ def _check_cross_file_pin_conflicts(
                     continue
                 param_def = _find_param_def(sec_def, param.key)
                 if param_def is not None and param_def.param_type == ParamType.PIN and param.value:
+                    if _is_dead_tmc_diag_use(param, section, active_virtual_chips):
+                        continue
                     _track_pin_usage(param, section, used_pins, filename=filename)
+
+    # Uses shadowed by the duplicate-section merge (later definition wins)
+    # are never allocated by Klipper — drop them before conflict detection.
+    _drop_shadowed_pin_uses(used_pins, _collect_live_pin_values(configs, active_files))
 
     # Pins already reported by a per-file check (both users in the same file)
     # are deduped by (pin, sorted user labels).
@@ -1783,7 +1963,13 @@ def _check_cross_file_pin_conflicts(
             continue  # [duplicate_pin_override] registered it — legal multi-use
         files_involved = {u.filename for u in users}
         if len(files_involved) < 2:
-            continue  # same-file conflict already reported per-file
+            # Same-file pair: normally the per-file pass already reported it
+            # (deduped by `already` below), but that pass may have SUPPRESSED
+            # the pair while the pin looked dead locally — e.g. both TMC diag
+            # pins in drivers.cfg while the <chip>:virtual_endstop reference
+            # lives in printer.cfg. The project-wide ledger sees them live,
+            # so let the finding through when no per-file one exists.
+            pass
         anchor = next((u for u in users if u.section), users[0])
         already = any(
             (u.section, u.param, u.line_number) in reported
@@ -1866,6 +2052,17 @@ def _collect_known_pin_chips(configs: dict[str, ConfigFile], active_files: set[s
                 chips.add((name or "mcu").lower())
             elif sec_type in ("probe", "multi_pin", "replicape"):
                 chips.add(sec_type.lower())
+            elif _is_probe_like_section_type(sec_type):
+                # klippy/extras/probe.py:215 — HomingViaProbeHelper.__init__
+                # registers the 'probe' chip, and it is constructed by
+                # [bltouch] (bltouch.py:292), [smart_effector]
+                # (smart_effector.py:169), [load_cell_probe] (698),
+                # [probe_eddy_current] (729) in addition to [probe] itself
+                # (probe.py:619). A probe-family section therefore makes
+                # probe:z_virtual_endstop resolvable (klipper_backup audit
+                # 2026-09-04: bltouch-only configs hard-failed the old check
+                # despite loading clean).
+                chips.add("probe")
             elif sec_type in ("tmc2130", "tmc2209", "tmc5160", "tmc2240") and name:
                 name_parts = name.split()
                 chips.add(f"{sec_type}_{name_parts[-1]}".lower())

--- a/backend/parser/validator.py
+++ b/backend/parser/validator.py
@@ -327,12 +327,26 @@ def _collect_live_pin_values_single_file(config: ConfigFile) -> dict[tuple[str, 
 
 def _drop_shadowed_pin_uses(used_pins: dict[str, list[PinUse]], live_pin_values: dict[tuple[str, str], set[str]]) -> None:
     """Remove pin uses that Klipper's section merge never allocates."""
-    if not live_pin_values:
-        return
     for pin in list(used_pins):
         kept = [u for u in used_pins[pin] if not _is_shadowed_pin_use(u, live_pin_values)]
-        if kept:
-            used_pins[pin] = kept
+        # Duplicate section definitions merge per-option (last wins), so a
+        # given (section, param) key allocates the pin at most ONCE even when
+        # several definitions repeat the identical value — the mirrored
+        # toolhead-board pattern where [extruder] appears verbatim in
+        # printer.cfg and an include. Collapse same-key uses to the LAST
+        # occurrence (the winner). Real report 2026-09-05; ground-truthed:
+        # identical dup [extruder] reaches 'Starting serial connect' clean.
+        seen_keys: set[tuple[str, str, str]] = set()
+        collapsed: list[PinUse] = []
+        for use in reversed(kept):
+            key = (use.section.lower(), use.param.lower(), use.pin)
+            if key in seen_keys:
+                continue
+            seen_keys.add(key)
+            collapsed.append(use)
+        collapsed.reverse()
+        if collapsed:
+            used_pins[pin] = collapsed
         else:
             del used_pins[pin]
 

--- a/backend/parser/validator.py
+++ b/backend/parser/validator.py
@@ -1753,6 +1753,15 @@ def _skip_missing_required_param(section: ConfigSection, param_name: str, active
     if section.section_type == "dual_carriage" and "primary_carriage" in active_params:
         return param_name in {"axis", "step_pin", "dir_pin", "microsteps", "rotation_distance"}
 
+    if (
+        section.section_type == "tmc2240"
+        and param_name == "cs_pin"
+        and "uart_pin" in active_params
+    ):
+        # tmc2240.py:352 — uart_pin present selects the UART path; cs_pin
+        # is never read (SPI-mode-only requirement).
+        return True
+
     return False
 
 
@@ -2274,7 +2283,7 @@ def _check_tmc_spi_chain_conflicts(
 
     for _pin, entries in groups.items():
         lengths = {e[2] for e in entries}
-        seen_pos: dict[str, int] = {}
+        seen_pos: dict[int, int] = {}
 
         def _already(result, param, message):
             return any(
@@ -2320,22 +2329,28 @@ def _check_tmc_spi_chain_conflicts(
                             message=message,
                             line_number=section.line_number,
                         ))
-                if pos in seen_pos:
-                    message = (
-                        f"TMC SPI chain can not have duplicate position "
-                        f"'{pos}' — another driver on the same cs_pin uses "
-                        "it. Klipper fails to start."
-                    )
-                    if not _already(result, "chain_position", message):
-                        result.errors.append(ValidationError(
-                            severity="error",
-                            section=section.full_header,
-                            param="chain_position",
-                            message=message,
-                            line_number=section.line_number,
-                        ))
-                else:
-                    seen_pos[pos] = chain_len
+                # klippy reads the position with config.getint (tmc2130.py:254),
+                # so '1' and '01' are the SAME position — dedupe on the int,
+                # not the string. Unparseable values raise in getint before
+                # klipper ever reaches its duplicate check, so they stay out
+                # of the ledger (the range error above already covers them).
+                if pos_int >= 1:
+                    if pos_int in seen_pos:
+                        message = (
+                            f"TMC SPI chain can not have duplicate position "
+                            f"'{pos}' — another driver on the same cs_pin uses "
+                            f"{pos_int}. Klipper fails to start."
+                        )
+                        if not _already(result, "chain_position", message):
+                            result.errors.append(ValidationError(
+                                severity="error",
+                                section=section.full_header,
+                                param="chain_position",
+                                message=message,
+                                line_number=section.line_number,
+                            ))
+                    else:
+                        seen_pos[pos_int] = chain_len
 
 
 def _is_allowed_shared_tmc_uart_pin(users: list[PinUse]) -> bool:
@@ -2343,7 +2358,11 @@ def _is_allowed_shared_tmc_uart_pin(users: list[PinUse]) -> bool:
         return False
 
     shared_params = {"uart_pin", "tx_pin"}
-    shared_driver_types = {"tmc2208", "tmc2209"}
+    # tmc_uart.py:196-202 looks rx/tx up with share_type tmc_uart_rx/tx, so
+    # any bit-banged-UART driver may share the line: 2208/2209 (UART-only)
+    # and 2240 in UART mode (tmc2240.py:352). A 2240 in SPI mode never
+    # registers its uart_pin — such a config errors elsewhere anyway.
+    shared_driver_types = {"tmc2208", "tmc2209", "tmc2240"}
     return all(user.section_type in shared_driver_types and user.param in shared_params for user in users)
 
 

--- a/backend/services/mainsail_sidebar.py
+++ b/backend/services/mainsail_sidebar.py
@@ -14,15 +14,19 @@ entry at every service start — and every update_manager update restarts the
 service via managed_services.
 
 All operations are best-effort: any failure is swallowed to a status string
-so app startup can never break on this.
+so app startup can never break on this. Failures are still logged (warning
+level or above) so silent permission/IO problems are diagnosable.
 """
 from __future__ import annotations
 
 import json
+import logging
 import os
 import shutil
 import socket
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 # KWC favicon mark (frontend/public/favicon.svg) converted to a single filled
 # SVG path — identical to the icon strings/install.sh writes. Coordinates
@@ -122,7 +126,10 @@ def ensure_sidebar_entry(theme_dir: Path, url: str) -> str:
             try:
                 shutil.copy2(navi_path, str(navi_path) + ".bak")
             except OSError:
-                pass
+                logger.warning(
+                    "Could not back up corrupt navi.json at %s", navi_path,
+                    exc_info=True,
+                )
         entries = []
 
     before = len(entries)
@@ -142,6 +149,10 @@ def ensure_sidebar_entry(theme_dir: Path, url: str) -> str:
         theme_dir.mkdir(parents=True, exist_ok=True)
         _write_navi(navi_path, entries)
     except OSError:
+        logger.warning(
+            "Failed to write Mainsail sidebar entry to %s "
+            "(permission or IO error)", navi_path, exc_info=True,
+        )
         return "failed"
     return "updated" if was_present else "added"
 
@@ -179,4 +190,5 @@ def self_heal_sidebar(port: int | None = None, ip_addr: str | None = None) -> st
             pass
         return ensure_sidebar_entry(theme_dir, url)
     except Exception:
+        logger.exception("Unexpected error while self-healing Mainsail sidebar entry")
         return "failed"

--- a/backend/services/mainsail_sidebar.py
+++ b/backend/services/mainsail_sidebar.py
@@ -1,0 +1,182 @@
+"""Self-healing Mainsail sidebar entry for KWC.
+
+Context (V2.6.0 user report 2026-09-03): updating KWC through Moonraker's
+update_manager does NOT re-run install.sh — Moonraker's git_repo type only
+does git pull + pip requirements + managed_services restart (its
+`install_script:` option is merely *parsed* for apt package names, never
+executed). The Mainsail sidebar link lives outside the repo (navi.json in
+the Klipper config dir's .theme folder), so after an update the entry was
+only restored by re-running scripts/install.sh by hand.
+
+This module mirrors scripts/install.sh's sidebar logic (mainsail detection,
+theme-dir resolution, navi.json merge semantics) so the backend can heal the
+entry at every service start — and every update_manager update restarts the
+service via managed_services.
+
+All operations are best-effort: any failure is swallowed to a status string
+so app startup can never break on this.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import socket
+from pathlib import Path
+
+# KWC favicon mark (frontend/public/favicon.svg) converted to a single filled
+# SVG path — identical to the icon strings/install.sh writes. Coordinates
+# shifted (-2,-4) from the favicon so the whole mark sits inside the 24x24
+# viewBox; nav icons render monochrome with the sidebar text color.
+KWC_NAV_ICON = (
+    "M6 13L22 13A1 1 0 0 1 22 11L6 11A1 1 0 0 1 6 13Z"
+    "M13 4L13 20A1 1 0 0 1 15 20L15 4A1 1 0 0 1 13 4Z"
+    "M7.293 6.707L19.293 18.707A1 1 0 0 1 20.707 17.293L8.707 5.293A1 1 0 0 1 7.293 6.707Z"
+    "M19.293 5.293L7.293 17.293A1 1 0 0 1 8.707 18.707L20.707 6.707A1 1 0 0 1 19.293 5.293Z"
+    "M4 12a2 2 0 1 0 4 0a2 2 0 1 0 -4 0Z"
+    "M20 12a2 2 0 1 0 4 0a2 2 0 1 0 -4 0Z"
+    "M12 4a2 2 0 1 0 4 0a2 2 0 1 0 -4 0Z"
+    "M12 20a2 2 0 1 0 4 0a2 2 0 1 0 -4 0Z"
+)
+
+
+def _home() -> Path:
+    return Path(os.path.expanduser("~"))
+
+
+def resolve_moonraker_config_dir() -> Path | None:
+    """Locate the Klipper/Moonraker config dir (kiauh layouts, installer parity)."""
+    home = _home()
+    for candidate in (home / "printer_data" / "config", home / "klipper_config"):
+        if candidate.is_dir():
+            return candidate
+    return None
+
+
+def resolve_mainsail_theme_dir() -> Path | None:
+    """Locate (or nominate) Mainsail's .theme folder, installer parity."""
+    config_dir = resolve_moonraker_config_dir()
+    if config_dir is None:
+        return None
+    theme = config_dir / ".theme"
+    return theme
+
+
+def mainsail_installed() -> bool:
+    """Detect Mainsail: the checkout dir or an update_manager entry in moonraker.conf."""
+    home = _home()
+    if (home / "mainsail").is_dir():
+        return True
+    for config_dir in (home / "printer_data" / "config", home / "klipper_config"):
+        moonraker_conf = config_dir / "moonraker.conf"
+        try:
+            if moonraker_conf.is_file() and "[update_manager mainsail]" in moonraker_conf.read_text():
+                return True
+        except OSError:
+            continue
+    return False
+
+
+def detect_ip() -> str:
+    """Best-effort primary LAN IP (installer uses `hostname -I | awk '{print $1}'`)."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        # No packets are sent for UDP connect; this just selects the route's source IP.
+        sock.connect(("8.8.8.8", 80))
+        return str(sock.getsockname()[0])
+    except OSError:
+        return ""
+    finally:
+        sock.close()
+
+
+def _write_navi(path: Path, entries: list) -> None:
+    path.write_text(json.dumps(entries, indent=2) + "\n", encoding="utf-8")
+
+
+def ensure_sidebar_entry(theme_dir: Path, url: str) -> str:
+    """Merge the KWC entry into theme_dir/navi.json. Returns added|updated|failed.
+
+    Merge semantics match install.sh edit_mainsail_navi: replace the KWC
+    entry in place, preserve every other custom entry, and back up a
+    corrupt/non-array file before replacing it.
+    """
+    navi_path = theme_dir / "navi.json"
+    entries: list = []
+    parseable = True
+    existing_raw: str | None = None
+    try:
+        existing_raw = navi_path.read_text(encoding="utf-8")
+        parsed = json.loads(existing_raw)
+        if isinstance(parsed, list):
+            entries = parsed
+        else:
+            parseable = False
+    except FileNotFoundError:
+        pass
+    except (OSError, ValueError):
+        parseable = False
+
+    if not parseable:
+        if existing_raw is not None:
+            try:
+                shutil.copy2(navi_path, str(navi_path) + ".bak")
+            except OSError:
+                pass
+        entries = []
+
+    before = len(entries)
+    entries = [
+        e for e in entries
+        if not (isinstance(e, dict) and e.get("title") == "KWC")
+    ]
+    was_present = len(entries) != before
+    entries.append({
+        "title": "KWC",
+        "href": url,
+        "target": "_blank",
+        "position": 95,
+        "icon": KWC_NAV_ICON,
+    })
+    try:
+        theme_dir.mkdir(parents=True, exist_ok=True)
+        _write_navi(navi_path, entries)
+    except OSError:
+        return "failed"
+    return "updated" if was_present else "added"
+
+
+def self_heal_sidebar(port: int | None = None, ip_addr: str | None = None) -> str:
+    """Heal the Mainsail sidebar entry at startup. Returns a status string.
+
+    Statuses: added | updated | skipped | failed. Never raises.
+    """
+    try:
+        if port is None:
+            port = int(os.environ.get("KWC_PORT", "8099"))
+        if not mainsail_installed():
+            return "skipped"
+        theme_dir = resolve_mainsail_theme_dir()
+        if theme_dir is None:
+            return "skipped"
+        if ip_addr is None:
+            ip_addr = detect_ip()
+        if not ip_addr:
+            # Installer parity: never write a placeholder/localhost entry —
+            # a sidebar link pointing nowhere is worse than no link.
+            return "skipped"
+        # If the entry is already current, do not rewrite the file.
+        navi_path = theme_dir / "navi.json"
+        url = f"http://{ip_addr}:{port}"
+        try:
+            parsed = json.loads(navi_path.read_text(encoding="utf-8"))
+            if isinstance(parsed, list) and any(
+                isinstance(e, dict) and e.get("title") == "KWC" and e.get("href") == url
+                for e in parsed
+            ):
+                return "skipped"
+        except (OSError, ValueError):
+            pass
+        return ensure_sidebar_entry(theme_dir, url)
+    except Exception:
+        return "failed"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "klipper-wire-configurator",
   "private": true,
-  "version": "2.6.0",
+  "version": "2.6.1",
   "type": "module",
   "scripts": {
     "prepare:reference": "node scripts/generate-examples.js",

--- a/reference/schema.json
+++ b/reference/schema.json
@@ -219,6 +219,15 @@
           "description": "Square corner velocity",
           "enum_values": [],
           "unit": "mm/s"
+        },
+        {
+          "name": "max_angular_velocity",
+          "type": "float",
+          "required": false,
+          "default": "0",
+          "description": "Maximum angular velocity",
+          "enum_values": [],
+          "unit": ""
         }
       ]
     },
@@ -13805,10 +13814,10 @@
       "params": [
         {
           "name": "endstop_accuracy",
-          "type": "int",
+          "type": "float",
           "required": false,
           "default": null,
-          "description": "Endstop accuracy",
+          "description": "Endstop accuracy (mm)",
           "enum_values": [],
           "unit": ""
         },
@@ -15164,6 +15173,83 @@
           "default": null,
           "description": "Software SPI MISO",
           "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "i2c_mcu",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "I2C MCU name (defaults to the main mcu)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "i2c_bus",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "I2C bus name (hardware I2C)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "i2c_address",
+          "type": "int",
+          "required": false,
+          "default": null,
+          "description": "I2C device address (0-127)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "i2c_speed",
+          "type": "int",
+          "required": false,
+          "default": null,
+          "description": "I2C clock speed in Hz",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "i2c_software_scl_pin",
+          "type": "pin",
+          "required": false,
+          "default": null,
+          "description": "Software I2C SCL pin",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "i2c_software_sda_pin",
+          "type": "pin",
+          "required": false,
+          "default": null,
+          "description": "Software I2C SDA pin",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "htu21d_hold_master",
+          "type": "bool",
+          "required": false,
+          "default": null,
+          "description": "HTU21D clock-stretch hold during read",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "htu21d_resolution",
+          "type": "enum",
+          "required": false,
+          "default": "TEMP12_HUM08",
+          "description": "HTU21D measurement resolution",
+          "enum_values": [
+            "TEMP14_HUM12",
+            "TEMP13_HUM10",
+            "TEMP12_HUM08",
+            "TEMP11_HUM11"
+          ],
           "unit": ""
         },
         {
@@ -19340,6 +19426,126 @@
           "required": false,
           "default": "0.1",
           "description": "Auto cancel variation",
+          "enum_values": [],
+          "unit": ""
+        }
+      ]
+    },
+    "dac084S085": {
+      "section_type": "dac084S085",
+      "display_name": "DAC084S085",
+      "category": "sub_component",
+      "component_group": "stepper_driver",
+      "is_named": true,
+      "description": "DAC084S085 SPI digipot (stepper current reference), e.g. Alligator r2/r3",
+      "max_instances": 0,
+      "requires": [],
+      "params": [
+        {
+          "name": "enable_pin",
+          "type": "pin",
+          "required": false,
+          "default": null,
+          "description": "CS/enable pin (SPI chip select role)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "cs_pin",
+          "type": "pin",
+          "required": false,
+          "default": null,
+          "description": "SPI chip select pin",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "spi_bus",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "SPI bus name (hardware SPI)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "spi_speed",
+          "type": "int",
+          "required": false,
+          "default": null,
+          "description": "SPI clock speed in Hz",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "spi_software_sclk_pin",
+          "type": "pin",
+          "required": false,
+          "default": null,
+          "description": "Software SPI clock pin",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "spi_software_mosi_pin",
+          "type": "pin",
+          "required": false,
+          "default": null,
+          "description": "Software SPI MOSI pin",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "spi_software_miso_pin",
+          "type": "pin",
+          "required": false,
+          "default": null,
+          "description": "Software SPI MISO pin",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "scale",
+          "type": "float",
+          "required": false,
+          "default": "1.0",
+          "description": "Channel value scale (amps)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "channel_A",
+          "type": "float",
+          "required": false,
+          "default": null,
+          "description": "Channel A value (0..scale)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "channel_B",
+          "type": "float",
+          "required": false,
+          "default": null,
+          "description": "Channel B value (0..scale)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "channel_C",
+          "type": "float",
+          "required": false,
+          "default": null,
+          "description": "Channel C value (0..scale)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "channel_D",
+          "type": "float",
+          "required": false,
+          "default": null,
+          "description": "Channel D value (0..scale)",
           "enum_values": [],
           "unit": ""
         }

--- a/reference/schema.json
+++ b/reference/schema.json
@@ -7181,6 +7181,15 @@
           "unit": ""
         },
         {
+          "name": "spi_speed",
+          "type": "int",
+          "required": false,
+          "default": null,
+          "description": "SPI bus clock speed",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
           "name": "spi_software_sclk_pin",
           "type": "pin",
           "required": false,
@@ -7401,11 +7410,20 @@
         },
         {
           "name": "tc_type",
-          "type": "string",
+          "type": "enum",
           "required": false,
-          "default": null,
-          "description": "Thermocouple type (K/J/T/E/N/R/S/B)",
-          "enum_values": [],
+          "default": "K",
+          "description": "Thermocouple type",
+          "enum_values": [
+            "B",
+            "E",
+            "J",
+            "K",
+            "N",
+            "R",
+            "S",
+            "T"
+          ],
           "unit": ""
         },
         {
@@ -7419,11 +7437,17 @@
         },
         {
           "name": "tc_averaging_count",
-          "type": "int",
+          "type": "enum",
           "required": false,
-          "default": null,
+          "default": "1",
           "description": "TC sample averaging count",
-          "enum_values": [],
+          "enum_values": [
+            "1",
+            "2",
+            "4",
+            "8",
+            "16"
+          ],
           "unit": ""
         }
       ]
@@ -7649,6 +7673,15 @@
           "unit": ""
         },
         {
+          "name": "spi_speed",
+          "type": "int",
+          "required": false,
+          "default": null,
+          "description": "SPI bus clock speed",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
           "name": "spi_software_sclk_pin",
           "type": "pin",
           "required": false,
@@ -7869,11 +7902,20 @@
         },
         {
           "name": "tc_type",
-          "type": "string",
+          "type": "enum",
           "required": false,
-          "default": null,
-          "description": "Thermocouple type (K/J/T/E/N/R/S/B)",
-          "enum_values": [],
+          "default": "K",
+          "description": "Thermocouple type",
+          "enum_values": [
+            "B",
+            "E",
+            "J",
+            "K",
+            "N",
+            "R",
+            "S",
+            "T"
+          ],
           "unit": ""
         },
         {
@@ -7887,11 +7929,17 @@
         },
         {
           "name": "tc_averaging_count",
-          "type": "int",
+          "type": "enum",
           "required": false,
-          "default": null,
+          "default": "1",
           "description": "TC sample averaging count",
-          "enum_values": [],
+          "enum_values": [
+            "1",
+            "2",
+            "4",
+            "8",
+            "16"
+          ],
           "unit": ""
         }
       ]
@@ -8117,6 +8165,15 @@
           "unit": ""
         },
         {
+          "name": "spi_speed",
+          "type": "int",
+          "required": false,
+          "default": null,
+          "description": "SPI bus clock speed",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
           "name": "spi_software_sclk_pin",
           "type": "pin",
           "required": false,
@@ -8337,11 +8394,20 @@
         },
         {
           "name": "tc_type",
-          "type": "string",
+          "type": "enum",
           "required": false,
-          "default": null,
-          "description": "Thermocouple type (K/J/T/E/N/R/S/B)",
-          "enum_values": [],
+          "default": "K",
+          "description": "Thermocouple type",
+          "enum_values": [
+            "B",
+            "E",
+            "J",
+            "K",
+            "N",
+            "R",
+            "S",
+            "T"
+          ],
           "unit": ""
         },
         {
@@ -8355,11 +8421,17 @@
         },
         {
           "name": "tc_averaging_count",
-          "type": "int",
+          "type": "enum",
           "required": false,
-          "default": null,
+          "default": "1",
           "description": "TC sample averaging count",
-          "enum_values": [],
+          "enum_values": [
+            "1",
+            "2",
+            "4",
+            "8",
+            "16"
+          ],
           "unit": ""
         }
       ]
@@ -8585,6 +8657,15 @@
           "unit": ""
         },
         {
+          "name": "spi_speed",
+          "type": "int",
+          "required": false,
+          "default": null,
+          "description": "SPI bus clock speed",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
           "name": "spi_software_sclk_pin",
           "type": "pin",
           "required": false,
@@ -8805,11 +8886,20 @@
         },
         {
           "name": "tc_type",
-          "type": "string",
+          "type": "enum",
           "required": false,
-          "default": null,
-          "description": "Thermocouple type (K/J/T/E/N/R/S/B)",
-          "enum_values": [],
+          "default": "K",
+          "description": "Thermocouple type",
+          "enum_values": [
+            "B",
+            "E",
+            "J",
+            "K",
+            "N",
+            "R",
+            "S",
+            "T"
+          ],
           "unit": ""
         },
         {
@@ -8823,11 +8913,17 @@
         },
         {
           "name": "tc_averaging_count",
-          "type": "int",
+          "type": "enum",
           "required": false,
-          "default": null,
+          "default": "1",
           "description": "TC sample averaging count",
-          "enum_values": [],
+          "enum_values": [
+            "1",
+            "2",
+            "4",
+            "8",
+            "16"
+          ],
           "unit": ""
         }
       ]
@@ -9053,6 +9149,15 @@
           "unit": ""
         },
         {
+          "name": "spi_speed",
+          "type": "int",
+          "required": false,
+          "default": null,
+          "description": "SPI bus clock speed",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
           "name": "spi_software_sclk_pin",
           "type": "pin",
           "required": false,
@@ -9273,11 +9378,20 @@
         },
         {
           "name": "tc_type",
-          "type": "string",
+          "type": "enum",
           "required": false,
-          "default": null,
-          "description": "Thermocouple type (K/J/T/E/N/R/S/B)",
-          "enum_values": [],
+          "default": "K",
+          "description": "Thermocouple type",
+          "enum_values": [
+            "B",
+            "E",
+            "J",
+            "K",
+            "N",
+            "R",
+            "S",
+            "T"
+          ],
           "unit": ""
         },
         {
@@ -9291,11 +9405,17 @@
         },
         {
           "name": "tc_averaging_count",
-          "type": "int",
+          "type": "enum",
           "required": false,
-          "default": null,
+          "default": "1",
           "description": "TC sample averaging count",
-          "enum_values": [],
+          "enum_values": [
+            "1",
+            "2",
+            "4",
+            "8",
+            "16"
+          ],
           "unit": ""
         }
       ]
@@ -9521,6 +9641,15 @@
           "unit": ""
         },
         {
+          "name": "spi_speed",
+          "type": "int",
+          "required": false,
+          "default": null,
+          "description": "SPI bus clock speed",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
           "name": "spi_software_sclk_pin",
           "type": "pin",
           "required": false,
@@ -9741,11 +9870,20 @@
         },
         {
           "name": "tc_type",
-          "type": "string",
+          "type": "enum",
           "required": false,
-          "default": null,
-          "description": "Thermocouple type (K/J/T/E/N/R/S/B)",
-          "enum_values": [],
+          "default": "K",
+          "description": "Thermocouple type",
+          "enum_values": [
+            "B",
+            "E",
+            "J",
+            "K",
+            "N",
+            "R",
+            "S",
+            "T"
+          ],
           "unit": ""
         },
         {
@@ -9759,11 +9897,17 @@
         },
         {
           "name": "tc_averaging_count",
-          "type": "int",
+          "type": "enum",
           "required": false,
-          "default": null,
+          "default": "1",
           "description": "TC sample averaging count",
-          "enum_values": [],
+          "enum_values": [
+            "1",
+            "2",
+            "4",
+            "8",
+            "16"
+          ],
           "unit": ""
         }
       ]
@@ -9989,6 +10133,15 @@
           "unit": ""
         },
         {
+          "name": "spi_speed",
+          "type": "int",
+          "required": false,
+          "default": null,
+          "description": "SPI bus clock speed",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
           "name": "spi_software_sclk_pin",
           "type": "pin",
           "required": false,
@@ -10209,11 +10362,20 @@
         },
         {
           "name": "tc_type",
-          "type": "string",
+          "type": "enum",
           "required": false,
-          "default": null,
-          "description": "Thermocouple type (K/J/T/E/N/R/S/B)",
-          "enum_values": [],
+          "default": "K",
+          "description": "Thermocouple type",
+          "enum_values": [
+            "B",
+            "E",
+            "J",
+            "K",
+            "N",
+            "R",
+            "S",
+            "T"
+          ],
           "unit": ""
         },
         {
@@ -10227,11 +10389,17 @@
         },
         {
           "name": "tc_averaging_count",
-          "type": "int",
+          "type": "enum",
           "required": false,
-          "default": null,
+          "default": "1",
           "description": "TC sample averaging count",
-          "enum_values": [],
+          "enum_values": [
+            "1",
+            "2",
+            "4",
+            "8",
+            "16"
+          ],
           "unit": ""
         }
       ]
@@ -10457,6 +10625,15 @@
           "unit": ""
         },
         {
+          "name": "spi_speed",
+          "type": "int",
+          "required": false,
+          "default": null,
+          "description": "SPI bus clock speed",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
           "name": "spi_software_sclk_pin",
           "type": "pin",
           "required": false,
@@ -10677,11 +10854,20 @@
         },
         {
           "name": "tc_type",
-          "type": "string",
+          "type": "enum",
           "required": false,
-          "default": null,
-          "description": "Thermocouple type (K/J/T/E/N/R/S/B)",
-          "enum_values": [],
+          "default": "K",
+          "description": "Thermocouple type",
+          "enum_values": [
+            "B",
+            "E",
+            "J",
+            "K",
+            "N",
+            "R",
+            "S",
+            "T"
+          ],
           "unit": ""
         },
         {
@@ -10695,11 +10881,17 @@
         },
         {
           "name": "tc_averaging_count",
-          "type": "int",
+          "type": "enum",
           "required": false,
-          "default": null,
+          "default": "1",
           "description": "TC sample averaging count",
-          "enum_values": [],
+          "enum_values": [
+            "1",
+            "2",
+            "4",
+            "8",
+            "16"
+          ],
           "unit": ""
         }
       ]
@@ -10992,11 +11184,20 @@
         },
         {
           "name": "tc_type",
-          "type": "string",
+          "type": "enum",
           "required": false,
-          "default": null,
-          "description": "Thermocouple type (K/J/T/E/N/R/S/B)",
-          "enum_values": [],
+          "default": "K",
+          "description": "Thermocouple type",
+          "enum_values": [
+            "B",
+            "E",
+            "J",
+            "K",
+            "N",
+            "R",
+            "S",
+            "T"
+          ],
           "unit": ""
         },
         {
@@ -11010,11 +11211,17 @@
         },
         {
           "name": "tc_averaging_count",
-          "type": "int",
+          "type": "enum",
           "required": false,
-          "default": null,
+          "default": "1",
           "description": "TC sample averaging count",
-          "enum_values": [],
+          "enum_values": [
+            "1",
+            "2",
+            "4",
+            "8",
+            "16"
+          ],
           "unit": ""
         }
       ]
@@ -11289,11 +11496,20 @@
         },
         {
           "name": "tc_type",
-          "type": "string",
+          "type": "enum",
           "required": false,
-          "default": null,
-          "description": "Thermocouple type (K/J/T/E/N/R/S/B)",
-          "enum_values": [],
+          "default": "K",
+          "description": "Thermocouple type",
+          "enum_values": [
+            "B",
+            "E",
+            "J",
+            "K",
+            "N",
+            "R",
+            "S",
+            "T"
+          ],
           "unit": ""
         },
         {
@@ -11307,11 +11523,17 @@
         },
         {
           "name": "tc_averaging_count",
-          "type": "int",
+          "type": "enum",
           "required": false,
-          "default": null,
+          "default": "1",
           "description": "TC sample averaging count",
-          "enum_values": [],
+          "enum_values": [
+            "1",
+            "2",
+            "4",
+            "8",
+            "16"
+          ],
           "unit": ""
         }
       ]
@@ -13422,11 +13644,20 @@
         },
         {
           "name": "tc_type",
-          "type": "string",
+          "type": "enum",
           "required": false,
-          "default": null,
-          "description": "Thermocouple type (K/J/T/E/N/R/S/B)",
-          "enum_values": [],
+          "default": "K",
+          "description": "Thermocouple type",
+          "enum_values": [
+            "B",
+            "E",
+            "J",
+            "K",
+            "N",
+            "R",
+            "S",
+            "T"
+          ],
           "unit": ""
         },
         {
@@ -13440,11 +13671,17 @@
         },
         {
           "name": "tc_averaging_count",
-          "type": "int",
+          "type": "enum",
           "required": false,
-          "default": null,
+          "default": "1",
           "description": "TC sample averaging count",
-          "enum_values": [],
+          "enum_values": [
+            "1",
+            "2",
+            "4",
+            "8",
+            "16"
+          ],
           "unit": ""
         }
       ]
@@ -16040,6 +16277,15 @@
           "unit": ""
         },
         {
+          "name": "spi_speed",
+          "type": "int",
+          "required": false,
+          "default": null,
+          "description": "SPI bus clock speed",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
           "name": "spi_software_sclk_pin",
           "type": "pin",
           "required": false,
@@ -16208,11 +16454,20 @@
         },
         {
           "name": "tc_type",
-          "type": "string",
+          "type": "enum",
           "required": false,
-          "default": null,
-          "description": "Thermocouple type (K/J/T/E/N/R/S/B)",
-          "enum_values": [],
+          "default": "K",
+          "description": "Thermocouple type",
+          "enum_values": [
+            "B",
+            "E",
+            "J",
+            "K",
+            "N",
+            "R",
+            "S",
+            "T"
+          ],
           "unit": ""
         },
         {
@@ -16226,11 +16481,17 @@
         },
         {
           "name": "tc_averaging_count",
-          "type": "int",
+          "type": "enum",
           "required": false,
-          "default": null,
+          "default": "1",
           "description": "TC sample averaging count",
-          "enum_values": [],
+          "enum_values": [
+            "1",
+            "2",
+            "4",
+            "8",
+            "16"
+          ],
           "unit": ""
         }
       ]
@@ -19751,11 +20012,20 @@
         },
         {
           "name": "tc_type",
-          "type": "string",
+          "type": "enum",
           "required": false,
-          "default": null,
-          "description": "Thermocouple type (K/J/T/E/N/R/S/B)",
-          "enum_values": [],
+          "default": "K",
+          "description": "Thermocouple type",
+          "enum_values": [
+            "B",
+            "E",
+            "J",
+            "K",
+            "N",
+            "R",
+            "S",
+            "T"
+          ],
           "unit": ""
         },
         {
@@ -19769,11 +20039,17 @@
         },
         {
           "name": "tc_averaging_count",
-          "type": "int",
+          "type": "enum",
           "required": false,
-          "default": null,
+          "default": "1",
           "description": "TC sample averaging count",
-          "enum_values": [],
+          "enum_values": [
+            "1",
+            "2",
+            "4",
+            "8",
+            "16"
+          ],
           "unit": ""
         }
       ]
@@ -21959,11 +22235,20 @@
         },
         {
           "name": "tc_type",
-          "type": "string",
+          "type": "enum",
           "required": false,
-          "default": null,
-          "description": "Thermocouple type (K/J/T/E/N/R/S/B)",
-          "enum_values": [],
+          "default": "K",
+          "description": "Thermocouple type",
+          "enum_values": [
+            "B",
+            "E",
+            "J",
+            "K",
+            "N",
+            "R",
+            "S",
+            "T"
+          ],
           "unit": ""
         },
         {
@@ -21977,11 +22262,17 @@
         },
         {
           "name": "tc_averaging_count",
-          "type": "int",
+          "type": "enum",
           "required": false,
-          "default": null,
+          "default": "1",
           "description": "TC sample averaging count",
-          "enum_values": [],
+          "enum_values": [
+            "1",
+            "2",
+            "4",
+            "8",
+            "16"
+          ],
           "unit": ""
         },
         {

--- a/reference/schema.json
+++ b/reference/schema.json
@@ -11385,7 +11385,7 @@
       "category": "sub_component",
       "component_group": "stepper_driver",
       "is_named": true,
-      "description": "TMC2240 stepper driver (SPI)",
+      "description": "TMC2240 stepper driver (SPI, or UART when uart_pin is set)",
       "max_instances": 0,
       "requires": [],
       "params": [
@@ -11557,6 +11557,42 @@
           "required": false,
           "default": null,
           "description": "TMC driver register override",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "uart_pin",
+          "type": "pin",
+          "required": false,
+          "default": null,
+          "description": "UART RX pin (switches the driver to UART mode)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "tx_pin",
+          "type": "pin",
+          "required": false,
+          "default": null,
+          "description": "UART TX pin (if separate)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "select_pins",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Select pins for UART mux",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "uart_address",
+          "type": "int",
+          "required": false,
+          "default": "0",
+          "description": "UART address (0-7)",
           "enum_values": [],
           "unit": ""
         }

--- a/reference/schema.json
+++ b/reference/schema.json
@@ -7362,6 +7362,69 @@
           "description": "Pressure advance smooth time",
           "enum_values": [],
           "unit": "s"
+        },
+        {
+          "name": "rtd_nominal_r",
+          "type": "float",
+          "required": false,
+          "default": null,
+          "description": "RTD nominal resistance at 0\u00b0C (ohms)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_num_of_wires",
+          "type": "int",
+          "required": false,
+          "default": null,
+          "description": "RTD wire count (2/3/4)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_reference_r",
+          "type": "float",
+          "required": false,
+          "default": null,
+          "description": "RTD reference wire resistance (ohms)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_use_50Hz_filter",
+          "type": "bool",
+          "required": false,
+          "default": null,
+          "description": "Enable RTD 50 Hz noise filter",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "tc_type",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Thermocouple type (K/J/T/E/N/R/S/B)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "tc_use_50Hz_filter",
+          "type": "bool",
+          "required": false,
+          "default": null,
+          "description": "Enable TC 50 Hz noise filter",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "tc_averaging_count",
+          "type": "int",
+          "required": false,
+          "default": null,
+          "description": "TC sample averaging count",
+          "enum_values": [],
+          "unit": ""
         }
       ]
     },
@@ -7767,6 +7830,69 @@
           "description": "Pressure advance smooth time",
           "enum_values": [],
           "unit": "s"
+        },
+        {
+          "name": "rtd_nominal_r",
+          "type": "float",
+          "required": false,
+          "default": null,
+          "description": "RTD nominal resistance at 0\u00b0C (ohms)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_num_of_wires",
+          "type": "int",
+          "required": false,
+          "default": null,
+          "description": "RTD wire count (2/3/4)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_reference_r",
+          "type": "float",
+          "required": false,
+          "default": null,
+          "description": "RTD reference wire resistance (ohms)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_use_50Hz_filter",
+          "type": "bool",
+          "required": false,
+          "default": null,
+          "description": "Enable RTD 50 Hz noise filter",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "tc_type",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Thermocouple type (K/J/T/E/N/R/S/B)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "tc_use_50Hz_filter",
+          "type": "bool",
+          "required": false,
+          "default": null,
+          "description": "Enable TC 50 Hz noise filter",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "tc_averaging_count",
+          "type": "int",
+          "required": false,
+          "default": null,
+          "description": "TC sample averaging count",
+          "enum_values": [],
+          "unit": ""
         }
       ]
     },
@@ -8172,6 +8298,69 @@
           "description": "Pressure advance smooth time",
           "enum_values": [],
           "unit": "s"
+        },
+        {
+          "name": "rtd_nominal_r",
+          "type": "float",
+          "required": false,
+          "default": null,
+          "description": "RTD nominal resistance at 0\u00b0C (ohms)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_num_of_wires",
+          "type": "int",
+          "required": false,
+          "default": null,
+          "description": "RTD wire count (2/3/4)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_reference_r",
+          "type": "float",
+          "required": false,
+          "default": null,
+          "description": "RTD reference wire resistance (ohms)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_use_50Hz_filter",
+          "type": "bool",
+          "required": false,
+          "default": null,
+          "description": "Enable RTD 50 Hz noise filter",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "tc_type",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Thermocouple type (K/J/T/E/N/R/S/B)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "tc_use_50Hz_filter",
+          "type": "bool",
+          "required": false,
+          "default": null,
+          "description": "Enable TC 50 Hz noise filter",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "tc_averaging_count",
+          "type": "int",
+          "required": false,
+          "default": null,
+          "description": "TC sample averaging count",
+          "enum_values": [],
+          "unit": ""
         }
       ]
     },
@@ -8577,6 +8766,69 @@
           "description": "Pressure advance smooth time",
           "enum_values": [],
           "unit": "s"
+        },
+        {
+          "name": "rtd_nominal_r",
+          "type": "float",
+          "required": false,
+          "default": null,
+          "description": "RTD nominal resistance at 0\u00b0C (ohms)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_num_of_wires",
+          "type": "int",
+          "required": false,
+          "default": null,
+          "description": "RTD wire count (2/3/4)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_reference_r",
+          "type": "float",
+          "required": false,
+          "default": null,
+          "description": "RTD reference wire resistance (ohms)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_use_50Hz_filter",
+          "type": "bool",
+          "required": false,
+          "default": null,
+          "description": "Enable RTD 50 Hz noise filter",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "tc_type",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Thermocouple type (K/J/T/E/N/R/S/B)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "tc_use_50Hz_filter",
+          "type": "bool",
+          "required": false,
+          "default": null,
+          "description": "Enable TC 50 Hz noise filter",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "tc_averaging_count",
+          "type": "int",
+          "required": false,
+          "default": null,
+          "description": "TC sample averaging count",
+          "enum_values": [],
+          "unit": ""
         }
       ]
     },
@@ -8982,6 +9234,69 @@
           "description": "Pressure advance smooth time",
           "enum_values": [],
           "unit": "s"
+        },
+        {
+          "name": "rtd_nominal_r",
+          "type": "float",
+          "required": false,
+          "default": null,
+          "description": "RTD nominal resistance at 0\u00b0C (ohms)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_num_of_wires",
+          "type": "int",
+          "required": false,
+          "default": null,
+          "description": "RTD wire count (2/3/4)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_reference_r",
+          "type": "float",
+          "required": false,
+          "default": null,
+          "description": "RTD reference wire resistance (ohms)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_use_50Hz_filter",
+          "type": "bool",
+          "required": false,
+          "default": null,
+          "description": "Enable RTD 50 Hz noise filter",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "tc_type",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Thermocouple type (K/J/T/E/N/R/S/B)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "tc_use_50Hz_filter",
+          "type": "bool",
+          "required": false,
+          "default": null,
+          "description": "Enable TC 50 Hz noise filter",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "tc_averaging_count",
+          "type": "int",
+          "required": false,
+          "default": null,
+          "description": "TC sample averaging count",
+          "enum_values": [],
+          "unit": ""
         }
       ]
     },
@@ -9387,6 +9702,69 @@
           "description": "Pressure advance smooth time",
           "enum_values": [],
           "unit": "s"
+        },
+        {
+          "name": "rtd_nominal_r",
+          "type": "float",
+          "required": false,
+          "default": null,
+          "description": "RTD nominal resistance at 0\u00b0C (ohms)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_num_of_wires",
+          "type": "int",
+          "required": false,
+          "default": null,
+          "description": "RTD wire count (2/3/4)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_reference_r",
+          "type": "float",
+          "required": false,
+          "default": null,
+          "description": "RTD reference wire resistance (ohms)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_use_50Hz_filter",
+          "type": "bool",
+          "required": false,
+          "default": null,
+          "description": "Enable RTD 50 Hz noise filter",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "tc_type",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Thermocouple type (K/J/T/E/N/R/S/B)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "tc_use_50Hz_filter",
+          "type": "bool",
+          "required": false,
+          "default": null,
+          "description": "Enable TC 50 Hz noise filter",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "tc_averaging_count",
+          "type": "int",
+          "required": false,
+          "default": null,
+          "description": "TC sample averaging count",
+          "enum_values": [],
+          "unit": ""
         }
       ]
     },
@@ -9792,6 +10170,69 @@
           "description": "Pressure advance smooth time",
           "enum_values": [],
           "unit": "s"
+        },
+        {
+          "name": "rtd_nominal_r",
+          "type": "float",
+          "required": false,
+          "default": null,
+          "description": "RTD nominal resistance at 0\u00b0C (ohms)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_num_of_wires",
+          "type": "int",
+          "required": false,
+          "default": null,
+          "description": "RTD wire count (2/3/4)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_reference_r",
+          "type": "float",
+          "required": false,
+          "default": null,
+          "description": "RTD reference wire resistance (ohms)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_use_50Hz_filter",
+          "type": "bool",
+          "required": false,
+          "default": null,
+          "description": "Enable RTD 50 Hz noise filter",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "tc_type",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Thermocouple type (K/J/T/E/N/R/S/B)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "tc_use_50Hz_filter",
+          "type": "bool",
+          "required": false,
+          "default": null,
+          "description": "Enable TC 50 Hz noise filter",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "tc_averaging_count",
+          "type": "int",
+          "required": false,
+          "default": null,
+          "description": "TC sample averaging count",
+          "enum_values": [],
+          "unit": ""
         }
       ]
     },
@@ -10197,6 +10638,69 @@
           "description": "Pressure advance smooth time",
           "enum_values": [],
           "unit": "s"
+        },
+        {
+          "name": "rtd_nominal_r",
+          "type": "float",
+          "required": false,
+          "default": null,
+          "description": "RTD nominal resistance at 0\u00b0C (ohms)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_num_of_wires",
+          "type": "int",
+          "required": false,
+          "default": null,
+          "description": "RTD wire count (2/3/4)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_reference_r",
+          "type": "float",
+          "required": false,
+          "default": null,
+          "description": "RTD reference wire resistance (ohms)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_use_50Hz_filter",
+          "type": "bool",
+          "required": false,
+          "default": null,
+          "description": "Enable RTD 50 Hz noise filter",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "tc_type",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Thermocouple type (K/J/T/E/N/R/S/B)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "tc_use_50Hz_filter",
+          "type": "bool",
+          "required": false,
+          "default": null,
+          "description": "Enable TC 50 Hz noise filter",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "tc_averaging_count",
+          "type": "int",
+          "required": false,
+          "default": null,
+          "description": "TC sample averaging count",
+          "enum_values": [],
+          "unit": ""
         }
       ]
     },
@@ -10395,6 +10899,123 @@
           "description": "Pullup resistor",
           "enum_values": [],
           "unit": ""
+        },
+        {
+          "name": "cs_pin",
+          "type": "pin",
+          "required": false,
+          "default": null,
+          "description": "SPI chip select pin",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "spi_bus",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "SPI bus name (hardware SPI)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "spi_speed",
+          "type": "int",
+          "required": false,
+          "default": null,
+          "description": "SPI clock speed in Hz",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "spi_software_sclk_pin",
+          "type": "pin",
+          "required": false,
+          "default": null,
+          "description": "Software SPI clock pin",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "spi_software_mosi_pin",
+          "type": "pin",
+          "required": false,
+          "default": null,
+          "description": "Software SPI MOSI pin",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "spi_software_miso_pin",
+          "type": "pin",
+          "required": false,
+          "default": null,
+          "description": "Software SPI MISO pin",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_nominal_r",
+          "type": "float",
+          "required": false,
+          "default": null,
+          "description": "RTD nominal resistance at 0\u00b0C (ohms)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_num_of_wires",
+          "type": "int",
+          "required": false,
+          "default": null,
+          "description": "RTD wire count (2/3/4)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_reference_r",
+          "type": "float",
+          "required": false,
+          "default": null,
+          "description": "RTD reference wire resistance (ohms)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_use_50Hz_filter",
+          "type": "bool",
+          "required": false,
+          "default": null,
+          "description": "Enable RTD 50 Hz noise filter",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "tc_type",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Thermocouple type (K/J/T/E/N/R/S/B)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "tc_use_50Hz_filter",
+          "type": "bool",
+          "required": false,
+          "default": null,
+          "description": "Enable TC 50 Hz noise filter",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "tc_averaging_count",
+          "type": "int",
+          "required": false,
+          "default": null,
+          "description": "TC sample averaging count",
+          "enum_values": [],
+          "unit": ""
         }
       ]
     },
@@ -10575,6 +11196,123 @@
           "description": "PWM cycle time",
           "enum_values": [],
           "unit": "s"
+        },
+        {
+          "name": "cs_pin",
+          "type": "pin",
+          "required": false,
+          "default": null,
+          "description": "SPI chip select pin",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "spi_bus",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "SPI bus name (hardware SPI)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "spi_speed",
+          "type": "int",
+          "required": false,
+          "default": null,
+          "description": "SPI clock speed in Hz",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "spi_software_sclk_pin",
+          "type": "pin",
+          "required": false,
+          "default": null,
+          "description": "Software SPI clock pin",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "spi_software_mosi_pin",
+          "type": "pin",
+          "required": false,
+          "default": null,
+          "description": "Software SPI MOSI pin",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "spi_software_miso_pin",
+          "type": "pin",
+          "required": false,
+          "default": null,
+          "description": "Software SPI MISO pin",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_nominal_r",
+          "type": "float",
+          "required": false,
+          "default": null,
+          "description": "RTD nominal resistance at 0\u00b0C (ohms)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_num_of_wires",
+          "type": "int",
+          "required": false,
+          "default": null,
+          "description": "RTD wire count (2/3/4)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_reference_r",
+          "type": "float",
+          "required": false,
+          "default": null,
+          "description": "RTD reference wire resistance (ohms)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_use_50Hz_filter",
+          "type": "bool",
+          "required": false,
+          "default": null,
+          "description": "Enable RTD 50 Hz noise filter",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "tc_type",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Thermocouple type (K/J/T/E/N/R/S/B)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "tc_use_50Hz_filter",
+          "type": "bool",
+          "required": false,
+          "default": null,
+          "description": "Enable TC 50 Hz noise filter",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "tc_averaging_count",
+          "type": "int",
+          "required": false,
+          "default": null,
+          "description": "TC sample averaging count",
+          "enum_values": [],
+          "unit": ""
         }
       ]
     },
@@ -12589,6 +13327,123 @@
           "required": false,
           "default": null,
           "description": "G-code temperature report ID",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "cs_pin",
+          "type": "pin",
+          "required": false,
+          "default": null,
+          "description": "SPI chip select pin",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "spi_bus",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "SPI bus name (hardware SPI)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "spi_speed",
+          "type": "int",
+          "required": false,
+          "default": null,
+          "description": "SPI clock speed in Hz",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "spi_software_sclk_pin",
+          "type": "pin",
+          "required": false,
+          "default": null,
+          "description": "Software SPI clock pin",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "spi_software_mosi_pin",
+          "type": "pin",
+          "required": false,
+          "default": null,
+          "description": "Software SPI MOSI pin",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "spi_software_miso_pin",
+          "type": "pin",
+          "required": false,
+          "default": null,
+          "description": "Software SPI MISO pin",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_nominal_r",
+          "type": "float",
+          "required": false,
+          "default": null,
+          "description": "RTD nominal resistance at 0\u00b0C (ohms)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_num_of_wires",
+          "type": "int",
+          "required": false,
+          "default": null,
+          "description": "RTD wire count (2/3/4)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_reference_r",
+          "type": "float",
+          "required": false,
+          "default": null,
+          "description": "RTD reference wire resistance (ohms)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_use_50Hz_filter",
+          "type": "bool",
+          "required": false,
+          "default": null,
+          "description": "Enable RTD 50 Hz noise filter",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "tc_type",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Thermocouple type (K/J/T/E/N/R/S/B)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "tc_use_50Hz_filter",
+          "type": "bool",
+          "required": false,
+          "default": null,
+          "description": "Enable TC 50 Hz noise filter",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "tc_averaging_count",
+          "type": "int",
+          "required": false,
+          "default": null,
+          "description": "TC sample averaging count",
           "enum_values": [],
           "unit": ""
         }
@@ -15312,6 +16167,69 @@
           "required": false,
           "default": null,
           "description": "G-code ID for temperature reporting",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_nominal_r",
+          "type": "float",
+          "required": false,
+          "default": null,
+          "description": "RTD nominal resistance at 0\u00b0C (ohms)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_num_of_wires",
+          "type": "int",
+          "required": false,
+          "default": null,
+          "description": "RTD wire count (2/3/4)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_reference_r",
+          "type": "float",
+          "required": false,
+          "default": null,
+          "description": "RTD reference wire resistance (ohms)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_use_50Hz_filter",
+          "type": "bool",
+          "required": false,
+          "default": null,
+          "description": "Enable RTD 50 Hz noise filter",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "tc_type",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Thermocouple type (K/J/T/E/N/R/S/B)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "tc_use_50Hz_filter",
+          "type": "bool",
+          "required": false,
+          "default": null,
+          "description": "Enable TC 50 Hz noise filter",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "tc_averaging_count",
+          "type": "int",
+          "required": false,
+          "default": null,
+          "description": "TC sample averaging count",
           "enum_values": [],
           "unit": ""
         }
@@ -18738,6 +19656,123 @@
           "required": false,
           "default": "100",
           "description": "Max temp",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "cs_pin",
+          "type": "pin",
+          "required": false,
+          "default": null,
+          "description": "SPI chip select pin",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "spi_bus",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "SPI bus name (hardware SPI)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "spi_speed",
+          "type": "int",
+          "required": false,
+          "default": null,
+          "description": "SPI clock speed in Hz",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "spi_software_sclk_pin",
+          "type": "pin",
+          "required": false,
+          "default": null,
+          "description": "Software SPI clock pin",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "spi_software_mosi_pin",
+          "type": "pin",
+          "required": false,
+          "default": null,
+          "description": "Software SPI MOSI pin",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "spi_software_miso_pin",
+          "type": "pin",
+          "required": false,
+          "default": null,
+          "description": "Software SPI MISO pin",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_nominal_r",
+          "type": "float",
+          "required": false,
+          "default": null,
+          "description": "RTD nominal resistance at 0\u00b0C (ohms)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_num_of_wires",
+          "type": "int",
+          "required": false,
+          "default": null,
+          "description": "RTD wire count (2/3/4)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_reference_r",
+          "type": "float",
+          "required": false,
+          "default": null,
+          "description": "RTD reference wire resistance (ohms)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "rtd_use_50Hz_filter",
+          "type": "bool",
+          "required": false,
+          "default": null,
+          "description": "Enable RTD 50 Hz noise filter",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "tc_type",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Thermocouple type (K/J/T/E/N/R/S/B)",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "tc_use_50Hz_filter",
+          "type": "bool",
+          "required": false,
+          "default": null,
+          "description": "Enable TC 50 Hz noise filter",
+          "enum_values": [],
+          "unit": ""
+        },
+        {
+          "name": "tc_averaging_count",
+          "type": "int",
+          "required": false,
+          "default": null,
+          "description": "TC sample averaging count",
           "enum_values": [],
           "unit": ""
         }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -29,7 +29,9 @@ KWC_GIT_REF="${KWC_GIT_REF:-}"
 PYTHON_MIN_VERSION="3.10"
 NODE_MIN_VERSION="18"
 LOG_DIR="${TMPDIR:-/tmp}"
-LOG_FILE="${LOG_DIR}/klipper-wire-configurator-install-$(date +%Y%m%d-%H%M%S).log"
+# LOG_FILE is honoured from the environment so the sudo-guard re-exec can
+# hand the same log path to the child (one continuous install log).
+LOG_FILE="${LOG_FILE:-${LOG_DIR}/klipper-wire-configurator-install-$(date +%Y%m%d-%H%M%S).log}"
 SYSTEM_SERVICE_FILE="/etc/systemd/system/${SERVICE_NAME}.service"
 LEGACY_USER_SERVICE_FILE="$HOME/.config/systemd/user/${SERVICE_NAME}.service"
 
@@ -56,17 +58,27 @@ error() { echo -e "${RED}[ERROR]${NC} $*"; exit 1; }
 if [ "$(id -u)" -eq 0 ] && [ -n "${SUDO_USER:-}" ] && [ "${SUDO_USER}" != "root" ] && [ -f "${BASH_SOURCE[0]}" ]; then
     real_home="$(getent passwd "$SUDO_USER" | cut -d: -f6)"
     warn "Running under sudo; re-executing as '$SUDO_USER' (the installer must run as your user)."
+    # The main log tee isn't installed yet (it lives below the function
+    # definitions), so seed the log file with this notice ourselves; the
+    # re-exec'd child inherits LOG_FILE and continues the same log.
+    # The seed file is created root-owned here (the exec below skips the
+    # tee-site chmod), so loosen it or the user child can't append.
+    mkdir -p "$LOG_DIR" 2>/dev/null || true
+    echo "[sudo-guard] re-executing installer as '$SUDO_USER'" >> "$LOG_FILE" 2>/dev/null || true
+    chmod 666 "$LOG_FILE" 2>/dev/null || true
     # Unset SUDO_USER for the re-exec so the guard can't loop even if the
     # child still somehow sees EUID 0. Supported KWC_* env vars are passed
     # explicitly because sudo's -E preservation needs sudoers `setenv` and
     # fails open otherwise.
-    kwc_env=("KWC_PORT=${KWC_PORT:-8099}" "KWC_GIT_REF=${KWC_GIT_REF:-}")
+    kwc_env=("KWC_PORT=${KWC_PORT:-8099}" "KWC_GIT_REF=${KWC_GIT_REF:-}" "LOG_FILE=$LOG_FILE")
     [ -n "${KWC_PROJECTS_DIR:-}" ] && kwc_env+=("KWC_PROJECTS_DIR=$KWC_PROJECTS_DIR")
     exec env -u SUDO_USER sudo -u "$SUDO_USER" \
         env "HOME=$real_home" "USER=$SUDO_USER" "${kwc_env[@]}" \
         bash "${BASH_SOURCE[0]}" "$@"
 fi
 if [ "$(id -u)" -eq 0 ]; then
+    mkdir -p "$LOG_DIR" 2>/dev/null || true
+    echo "[sudo-guard] refused: installer run as root without SUDO_USER" >> "$LOG_FILE" 2>/dev/null || true
     error "Do not run this installer as root. Run it as your normal user WITHOUT sudo (it escalates internally where needed): bash scripts/install.sh"
 fi
 
@@ -388,6 +400,14 @@ on_error() {
 }
 
 mkdir -p "$LOG_DIR"
+# Pre-create the log BEFORE the tee opens it. Under `sudo bash install.sh`
+# this runs as root just before the guard re-execs the install as the
+# invoking user; a file created lazily by tee would be root-owned 644 and
+# the user child could not append. Creating it here and loosening it keeps
+# one continuous install log across the re-exec. (Same tradeoff /tmp temp
+# files already make: any local user may append to a timestamped log.)
+touch "$LOG_FILE"
+chmod 666 "$LOG_FILE" 2>/dev/null || true
 exec > >(tee -a "$LOG_FILE") 2>&1
 trap 'on_error "$LINENO" "$?"' ERR
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -12,7 +12,8 @@
 # config dir). Running `sudo bash scripts/install.sh` resets $HOME to /root,
 # so the Moonraker config directory is not found and the update_manager /
 # Mainsail sidebar setup is silently skipped (and the app installs into
-# /root instead of your user's home).
+# /root instead of your user's home). If sudo is used anyway, the guard
+# below re-execs the script as the invoking user automatically.
 #
 # Uninstall:
 #   bash scripts/install.sh --uninstall
@@ -43,6 +44,31 @@ info()  { echo -e "${BLUE}[INFO]${NC} $*"; }
 ok()    { echo -e "${GREEN}[OK]${NC} $*"; }
 warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
 error() { echo -e "${RED}[ERROR]${NC} $*"; exit 1; }
+
+# --- Sudo guard ---
+# The installer must run as the invoking (non-root) user: INSTALL_DIR, the
+# Moonraker config-dir lookup, and Mainsail detection all hang off $HOME,
+# which `sudo` rewrites to /root. If someone runs the script under sudo
+# anyway, re-exec it as the original user (SUDO_USER) with that user's
+# HOME restored and the supported KWC_* vars passed through explicitly.
+# Running as root without sudo (direct root login, or curl | sudo bash)
+# is unrecoverable, so fail loudly.
+if [ "$(id -u)" -eq 0 ] && [ -n "${SUDO_USER:-}" ] && [ "${SUDO_USER}" != "root" ] && [ -f "${BASH_SOURCE[0]}" ]; then
+    real_home="$(getent passwd "$SUDO_USER" | cut -d: -f6)"
+    warn "Running under sudo; re-executing as '$SUDO_USER' (the installer must run as your user)."
+    # Unset SUDO_USER for the re-exec so the guard can't loop even if the
+    # child still somehow sees EUID 0. Supported KWC_* env vars are passed
+    # explicitly because sudo's -E preservation needs sudoers `setenv` and
+    # fails open otherwise.
+    kwc_env=("KWC_PORT=${KWC_PORT:-8099}" "KWC_GIT_REF=${KWC_GIT_REF:-}")
+    [ -n "${KWC_PROJECTS_DIR:-}" ] && kwc_env+=("KWC_PROJECTS_DIR=$KWC_PROJECTS_DIR")
+    exec env -u SUDO_USER sudo -u "$SUDO_USER" \
+        env "HOME=$real_home" "USER=$SUDO_USER" "${kwc_env[@]}" \
+        bash "${BASH_SOURCE[0]}" "$@"
+fi
+if [ "$(id -u)" -eq 0 ]; then
+    error "Do not run this installer as root. Run it as your normal user WITHOUT sudo (it escalates internally where needed): bash scripts/install.sh"
+fi
 
 is_legacy_user_service_active() {
     systemctl --user is-active --quiet "$SERVICE_NAME" 2>/dev/null

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -676,6 +676,21 @@ ok "Python dependencies installed."
 deactivate
 
 # --- Build frontend ---
+# Low-memory guard: Node's default V8 old-space is tiny on 32-bit ARM
+# (~128 MB) and the process ABORTS at that ceiling long before the
+# system's swap is used (swap is invisible to a self-imposed heap limit).
+# On devices with < 2 GB combined RAM+swap, size the heap to ~half of
+# that total so npm/Vite page into swap instead of aborting. Verified on
+# a Pi Zero 2 W (424 MB RAM + 1 GB swap): npm ci died at ~130 MB with
+# "Reached heap limit" until this was set (2026-09-06).
+total_mem_mb=$(awk '/MemTotal/ {m=$2} /SwapTotal/ {s=$2} END {printf "%d", (m+s)/1024}' /proc/meminfo 2>/dev/null || echo 0)
+if [ "${total_mem_mb:-0}" -lt 2048 ]; then
+    node_heap_mb=$(( total_mem_mb / 2 ))
+    [ "$node_heap_mb" -lt 384 ] && node_heap_mb=384
+    export NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--max-old-space-size=$node_heap_mb"
+    info "Low-memory device (${total_mem_mb} MB RAM+swap): Node heap raised to ${node_heap_mb} MB."
+fi
+
 info "Installing frontend dependencies..."
 cd "$INSTALL_DIR/frontend"
 if ! npm ci; then

--- a/tests/test_examples_sweep_fixes_2026_09.py
+++ b/tests/test_examples_sweep_fixes_2026_09.py
@@ -1,0 +1,531 @@
+"""Seven false-positive fixes from the klipper/config examples sweep (2026-09-04).
+
+Ground truth for each is klipper master (f0892d82) source + headless klippy
+fixtures (recipes in kwc-validation skill, references/klipper-examples-audit-2026-09-04.md):
+
+1. sensor_type enum — user-defined [thermistor NAME] sections are valid
+   sensor_type values (Config_Reference: "if one defines a
+   [thermistor my_thermistor] section then one may use sensor_type:
+   my_thermistor"). Fixture fx2/a_therm.cfg reaches 'Starting serial
+   connect'; an undefined name is a Config error.
+2. TMC driver for [manual_stepper <name>] — klippy joins ALL header words
+   after the driver type (tmc.py TMCMicrostepHelper: " ".join(...)), so
+   [tmc2208 manual_stepper gear_stepper] resolves to the FULL header
+   [manual_stepper gear_stepper]. Fixture fx2/b_mmu.cfg loads clean.
+3. SPI cs_pin daisy chain — tmc2130.MCU_TMC_SPI_chain looks up cs_pin with
+   share_type="tmc_spi_cs" when chain_length >= 2 (tmc2130.py:190-194), so
+   chained TMC2130/TMC5160 drivers legally share one cs_pin (fixture
+   c2_chain2130 loads clean); without chain_length the same config fails
+   "pin PF5 used multiple times" (fixture c_chain_ctl). tmc5160 routes
+   through tmc2130.MCU_TMC_SPI (tmc5160.py:328).
+4. [printer] max_angular_velocity — valid, polar kinematics
+   (kinematics/polar.py:52 config.getfloat, default 0).
+5. [endstop_phase] endstop_accuracy — float in klippy
+   (endstop_phase.py:78 config.getfloat); stock makergear-m2 '.200' loads.
+6. [temperature_sensor] I2C sensor params — the sensor chip's bus params
+   apply under [temperature_sensor]: i2c family + htu21d_hold_master +
+   htu21d_resolution (Config_Reference HTU21D section).
+7. Multi-word section types whose first word is a load_config_prefix module
+   (dac084S085 stepper_digipot, ds18b20 sensor_name, hx711 <name>,
+   lis2dw <name>): known, params not flagged. Unknown multi-word types
+   (stepper_1) remain unknown_section warnings.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'backend'))
+
+from parser.config_parser import parse_config  # noqa: E402
+from parser.validator import validate_config, validate_project_configs  # noqa: E402
+
+
+def _validate(text: str):
+    return validate_config(parse_config(text, 'printer.cfg'))
+
+
+def _errors(result, code: str | None = None):
+    return [
+        e for e in result.errors
+        if e.severity == "error" and (code is None or e.code == code)
+    ]
+
+
+# ── 1. Custom [thermistor NAME] satisfies sensor_type ──────────────────
+
+_THERM_BASE = """
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 15
+max_z_accel: 100
+
+[stepper_x]
+step_pin: PF0
+dir_pin: PF1
+enable_pin: !PD7
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PE5
+position_endstop: 0
+position_max: 200
+
+[stepper_y]
+step_pin: PF6
+dir_pin: !PF7
+enable_pin: !PF2
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PJ1
+position_endstop: 0
+position_max: 200
+
+[stepper_z]
+step_pin: PL3
+dir_pin: PL1
+enable_pin: !PK0
+microsteps: 16
+rotation_distance: 8
+endstop_pin: ^PD3
+position_endstop: 0
+position_max: 200
+
+[extruder]
+step_pin: PA4
+dir_pin: PA6
+enable_pin: !PA2
+microsteps: 16
+rotation_distance: 33.5
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PB4
+sensor_type: {sensor}
+sensor_pin: PK5
+control: pid
+pid_kp: 22.2
+pid_ki: 1.08
+pid_kd: 114
+min_temp: 0
+max_temp: 250
+
+[fan]
+pin: PH6
+"""
+
+_THERM_DEF = """
+[thermistor G2]
+temperature1: 20
+resistance1: 1000000
+beta: 3700
+"""
+
+
+def test_custom_thermistor_satisfies_sensor_type():
+    # fx2/a_therm.cfg: klippy 'Starting serial connect'
+    result = _validate(_THERM_DEF + _THERM_BASE.format(sensor="G2"))
+    assert not [e for e in _errors(result) if "sensor_type" in (e.param or "")]
+
+
+def test_undefined_sensor_type_still_errors():
+    # fixture a_therm_ctl.cfg: klippy Config error for an undefined name
+    result = _validate(_THERM_BASE.format(sensor="G2_NOT_DEFINED"))
+    hits = [e for e in _errors(result) if e.param == "sensor_type"]
+    assert hits and "Invalid value" in hits[0].message
+
+
+def test_cross_file_thermistor_satisfies_sensor_type():
+    # Klipper loads includes into one namespace — a [thermistor] in any
+    # project file is valid for a heater in another.
+    results = validate_project_configs({
+        "printer.cfg": parse_config(
+            "[include sensors.cfg]\n" + _THERM_BASE.format(sensor="G2"), "printer.cfg"),
+        "sensors.cfg": parse_config(_THERM_DEF, "sensors.cfg"),
+    })
+    assert not [e for e in _errors(results["printer.cfg"]) if e.param == "sensor_type"]
+
+
+# ── 2. TMC driver header referencing [manual_stepper <name>] ───────────
+
+_MANUAL_TMC = """
+[mcu]
+serial: /dev/ttyUSB0
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 15
+max_z_accel: 100
+
+[stepper_x]
+step_pin: PF0
+dir_pin: PF1
+enable_pin: !PD7
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PE5
+position_endstop: 0
+position_max: 200
+
+[stepper_y]
+step_pin: PF6
+dir_pin: !PF7
+enable_pin: !PF2
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PJ1
+position_endstop: 0
+position_max: 200
+
+[stepper_z]
+step_pin: PL3
+dir_pin: PL1
+enable_pin: !PK0
+microsteps: 16
+rotation_distance: 8
+endstop_pin: ^PD3
+position_endstop: 0
+position_max: 200
+
+[manual_stepper gear_stepper]
+step_pin: PC4
+dir_pin: PC5
+enable_pin: !PH2
+microsteps: 16
+rotation_distance: 8
+
+[tmc2208 manual_stepper gear_stepper]
+uart_pin: PK6
+run_current: 0.350
+sense_resistor: 0.110
+stealthchop_threshold: 999999
+"""
+
+
+def test_tmc_for_manual_stepper_resolves_full_header():
+    # fixture fx2/b_mmu.cfg: klippy 'Starting serial connect'
+    results = validate_project_configs({"printer.cfg": parse_config(_MANUAL_TMC, "printer.cfg")})
+    assert not [e for e in _errors(results["printer.cfg"]) if "required by tmc driver" in e.message]
+
+
+def test_tmc_for_nonexistent_manual_stepper_still_errors():
+    results = validate_project_configs({"printer.cfg": parse_config(_MANUAL_TMC.replace(
+        "[manual_stepper gear_stepper]", "[manual_stepper other_stepper]"), "printer.cfg")})
+    assert any(
+        "required by tmc driver" in e.message
+        and "manual_stepper gear_stepper" in e.message
+        for e in _errors(results["printer.cfg"])
+    )
+
+
+def test_tmc_microsteps_check_still_applies_via_full_header():
+    # microsteps on the referenced manual_stepper must still be a TMC mres
+    results = validate_project_configs({"printer.cfg": parse_config(_MANUAL_TMC.replace(
+        "[manual_stepper gear_stepper]\nstep_pin: PC4\ndir_pin: PC5\nenable_pin: !PH2\nmicrosteps: 16",
+        "[manual_stepper gear_stepper]\nstep_pin: PC4\ndir_pin: PC5\nenable_pin: !PH2\nmicrosteps: 5"), "printer.cfg")})
+    assert any(
+        e.param == "microsteps" and "not a valid TMC value" in e.message
+        for e in _errors(results["printer.cfg"])
+    )
+
+
+# ── 3. SPI daisy-chain cs_pin sharing (tmc2130/tmc5160) ────────────────
+
+_CHAIN_BASE = """
+[mcu]
+serial: /dev/ttyUSB0
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 15
+max_z_accel: 100
+
+[stepper_x]
+step_pin: PF0
+dir_pin: PF1
+enable_pin: !PD7
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PE5
+position_endstop: 0
+position_max: 200
+
+[stepper_y]
+step_pin: PF6
+dir_pin: !PF7
+enable_pin: !PF2
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PJ1
+position_endstop: 0
+position_max: 200
+
+[stepper_z]
+step_pin: PL3
+dir_pin: PL1
+enable_pin: !PK0
+microsteps: 16
+rotation_distance: 8
+endstop_pin: ^PD3
+position_endstop: 0
+position_max: 200
+"""
+
+
+def test_chained_tmc2130_shared_cs_pin_allowed():
+    # fixture c2_chain2130.cfg: klippy 'Starting serial connect'
+    result = _validate(_CHAIN_BASE + """
+[tmc2130 stepper_x]
+cs_pin: PF5
+run_current: 0.800
+sense_resistor: 0.075
+chain_position: 1
+chain_length: 2
+
+[tmc2130 stepper_y]
+cs_pin: PF5
+run_current: 0.800
+sense_resistor: 0.075
+chain_position: 2
+chain_length: 2
+""")
+    assert not _errors(result, "shared_pin")
+
+
+def test_shared_cs_pin_without_chain_still_errors():
+    # fixture c_chain_ctl.cfg: klippy 'pin PF5 used multiple times in config'
+    result = _validate(_CHAIN_BASE + """
+[tmc2130 stepper_x]
+cs_pin: PF5
+run_current: 0.800
+sense_resistor: 0.075
+
+[tmc2130 stepper_y]
+cs_pin: PF5
+run_current: 0.800
+sense_resistor: 0.075
+""")
+    hits = [e for e in _errors(result, "shared_pin") if "PF5" in e.message]
+    assert hits
+
+
+def test_mixed_chain_lengths_flagged():
+    # klippy: "TMC SPI chain must have same length" — same share_type
+    # passes pins.py, then the chain helper hard-fails on the mismatch.
+    result = _validate(_CHAIN_BASE + """
+[tmc2130 stepper_x]
+cs_pin: PF5
+run_current: 0.800
+sense_resistor: 0.075
+chain_position: 1
+chain_length: 2
+
+[tmc2130 stepper_y]
+cs_pin: PF5
+run_current: 0.800
+sense_resistor: 0.075
+chain_position: 1
+chain_length: 3
+""")
+    hits = [e for e in _errors(result) if "same length" in e.message]
+    assert hits
+
+
+def test_duplicate_chain_position_flagged():
+    result = _validate(_CHAIN_BASE + """
+[tmc2130 stepper_x]
+cs_pin: PF5
+run_current: 0.800
+sense_resistor: 0.075
+chain_position: 1
+chain_length: 2
+
+[tmc2130 stepper_y]
+cs_pin: PF5
+run_current: 0.800
+sense_resistor: 0.075
+chain_position: 1
+chain_length: 2
+""")
+    hits = [e for e in _errors(result) if "duplicate position" in e.message]
+    assert hits
+
+
+def test_chain_position_beyond_length_flagged():
+    # tmc2130.py:254 getint('chain_position', minval=1, maxval=chain_len)
+    result = _validate(_CHAIN_BASE + """
+[tmc2130 stepper_x]
+cs_pin: PF5
+run_current: 0.800
+sense_resistor: 0.075
+chain_position: 1
+chain_length: 2
+
+[tmc2130 stepper_y]
+cs_pin: PG0
+run_current: 0.800
+sense_resistor: 0.075
+chain_position: 5
+chain_length: 2
+""")
+    hits = [e for e in _errors(result) if e.param == "chain_position" and "chain_length" in e.message]
+    assert hits
+
+
+def test_cross_file_chained_cs_pin_allowed():
+    results = validate_project_configs({
+        "printer.cfg": parse_config("[include drivers.cfg]\n" + _CHAIN_BASE, "printer.cfg"),
+        "drivers.cfg": parse_config("""
+[tmc5160 stepper_x]
+cs_pin: PF5
+spi_bus: spi
+run_current: 0.800
+sense_resistor: 0.075
+chain_position: 1
+chain_length: 6
+
+[tmc5160 stepper_y]
+cs_pin: PF5
+spi_bus: spi
+run_current: 0.800
+sense_resistor: 0.075
+chain_position: 2
+chain_length: 6
+""", "drivers.cfg"),
+    })
+    assert not [
+        e for r in results.values() for e in _errors(r, "shared_pin") if "PF5" in e.message
+    ]
+
+
+def test_non_chainable_spi_driver_shared_cs_still_errors():
+    # tmc2660 is SPI but routes through its own MCU_TMC_SPI with NO
+    # share_type (tmc2660.py:196) — chain params are meaningless there.
+    result = _validate(_CHAIN_BASE + """
+[tmc2660 stepper_x]
+cs_pin: PF5
+run_current: 0.800
+sense_resistor: 0.075
+chain_position: 1
+chain_length: 2
+
+[tmc2660 stepper_y]
+cs_pin: PF5
+run_current: 0.800
+sense_resistor: 0.075
+chain_position: 2
+chain_length: 2
+""")
+    assert _errors(result, "shared_pin")
+
+
+# ── 4/5/6. Schema param gaps ────────────────────────────────────────────
+
+def test_printer_max_angular_velocity_known():
+    result = _validate("""
+[printer]
+kinematics: polar
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 15
+max_z_accel: 100
+max_angular_velocity: 10
+""")
+    assert not [e for e in result.errors
+                if e.param == "max_angular_velocity" and e.severity == "error"]
+
+
+def test_endstop_accuracy_accepts_fraction():
+    # stock printer-makergear-m2-2012.cfg uses 'endstop_accuracy: .200'
+    result = _validate("""
+[endstop_phase stepper_x]
+endstop_accuracy: .200
+""")
+    assert not _errors(result)
+
+
+def test_temperature_sensor_htu21d_i2c_params_known():
+    # stock sample-raspberry-pi.cfg enclosure_temp
+    result = _validate("""
+[temperature_sensor enclosure_temp]
+sensor_type: HTU21D
+i2c_mcu: rpi
+i2c_bus: i2c1
+htu21d_hold_master: False
+""")
+    assert not [e for e in result.errors if e.code == "unknown_param" and e.severity == "error"]
+
+
+def test_temperature_sensor_i2c_pins_tracked():
+    # i2c_software_* pins are real pin claims — a collision with an output
+    # must still surface as shared_pin.
+    result = _validate("""
+[temperature_sensor env]
+sensor_type: LM75
+i2c_software_scl_pin: PB6
+
+[output_pin laser]
+pin: PB6
+value: 0
+""")
+    assert _errors(result, "shared_pin")
+
+
+# ── 7. load_config_prefix multi-word section types ─────────────────────
+
+def test_dac084s085_named_section_known():
+    # stock generic-alligator-r2/r3.cfg — dac084S085.py is a
+    # load_config_prefix module (named instances).
+    result = _validate("""
+[dac084S085 stepper_digipot]
+enable_pin: PB14
+spi_bus: spi0
+scale: 2.50
+channel_A: 0.7882
+channel_B: 0.7882
+channel_C: 0.6814
+""")
+    assert not [e for e in result.errors
+                if e.code in ("unknown_section", "unknown_param") and e.severity in ("error", "warning")]
+    # the enable_pin is a real pin claim: colliding it must still conflict
+    result2 = _validate("""
+[dac084S085 stepper_digipot]
+enable_pin: PB14
+scale: 2.50
+
+[output_pin laser]
+pin: PB14
+value: 0
+""")
+    assert _errors(result2, "shared_pin")
+
+
+def test_ds18b20_hx711_are_sensor_types_not_sections():
+    # ds18b20/hx711 are sensor_type values under [temperature_sensor], not
+    # section prefixes (no load_config_prefix in klippy) — must NOT be
+    # blessed as section types.
+    result = _validate("""
+[ds18b20 my_temp]
+sensor_pin: PA1
+
+[hx711 load_cell]
+dout_pin: PG6
+""")
+    codes = [e.code for e in result.errors if e.code == "unknown_section"]
+    assert len(codes) == 2
+
+
+def test_unknown_multiword_section_still_warns():
+    # stepper_1 is NOT a load_config_prefix module — first-word fallback
+    # must not silently bless it.
+    result = _validate("""
+[stepper_1]
+step_pin: EXP2_6
+dir_pin: EXP2_5
+microsteps: 16
+rotation_distance: 40
+""")
+    hits = [e for e in result.errors if e.code == "unknown_section"]
+    assert hits and "stepper_1" in hits[0].message

--- a/tests/test_examples_sweep_fixes_2026_09.py
+++ b/tests/test_examples_sweep_fixes_2026_09.py
@@ -353,6 +353,52 @@ chain_length: 2
     assert hits
 
 
+def test_duplicate_chain_position_numeric_forms_flagged():
+    # klippy reads chain_position with config.getint (tmc2130.py:254), so
+    # '1' and '01' are the SAME position — hard-fail. String comparison
+    # missed it (PR #29 review 2026-09-07).
+    result = _validate(_CHAIN_BASE + """
+[tmc2130 stepper_x]
+cs_pin: PF5
+run_current: 0.800
+sense_resistor: 0.075
+chain_position: 1
+chain_length: 2
+
+[tmc2130 stepper_y]
+cs_pin: PF5
+run_current: 0.800
+sense_resistor: 0.075
+chain_position: 01
+chain_length: 2
+""")
+    hits = [e for e in _errors(result) if "duplicate position" in e.message]
+    assert hits
+
+
+def test_unparseable_chain_positions_not_duplicate_flagged():
+    # klippy getint raises on 'abc' before any duplicate-position check —
+    # unparseable values get the range error only, never each other's
+    # 'duplicate' (both would coerce to 0 under a naive int fallback).
+    result = _validate(_CHAIN_BASE + """
+[tmc2130 stepper_x]
+cs_pin: PF5
+run_current: 0.800
+sense_resistor: 0.075
+chain_position: abc
+chain_length: 2
+
+[tmc2130 stepper_y]
+cs_pin: PF5
+run_current: 0.800
+sense_resistor: 0.075
+chain_position: xyz
+chain_length: 2
+""")
+    dups = [e for e in _errors(result) if "duplicate position" in e.message]
+    assert not dups
+
+
 def test_chain_position_beyond_length_flagged():
     # tmc2130.py:254 getint('chain_position', minval=1, maxval=chain_len)
     result = _validate(_CHAIN_BASE + """
@@ -529,3 +575,56 @@ rotation_distance: 40
 """)
     hits = [e for e in result.errors if e.code == "unknown_section"]
     assert hits and "stepper_1" in hits[0].message
+
+
+# ── 8. [tmc2240] UART mode (PR #29 review 2026-09-07) ──────────────────
+
+def test_tmc2240_uart_mode_valid():
+    # tmc2240.py:352 — config.get("uart_pin") present => UART comm
+    # (tmc_uart.MCU_TMC_uart, max_addr=7), cs_pin not read at all.
+    # uart_address goes 0..7 for the 2240 (tmc2240.py:355 passes 7).
+    result = _validate("""
+[tmc2240 stepper_x]
+uart_pin: PB0
+run_current: 0.800
+sense_resistor: 0.110
+uart_address: 3
+""")
+    hits = [e for e in result.errors
+            if e.code in ("unknown_param",) and e.param in ("uart_pin", "uart_address")]
+    assert not hits, hits
+    # cs_pin must NOT be demanded in UART mode
+    missing = [e for e in result.errors if "cs_pin" in e.message]
+    assert not missing, missing
+
+
+def test_tmc2240_spi_mode_still_requires_cs_pin():
+    result = _validate("""
+[tmc2240 stepper_x]
+run_current: 0.800
+sense_resistor: 0.110
+""")
+    hits = [e for e in result.errors
+            if e.severity == "error" and "cs_pin" in e.message]
+    assert hits
+
+
+def test_tmc2240_uart_pin_shareable_on_one_uart_line():
+    # tmc_uart.py:196-202 — rx/tx looked up with share_type
+    # tmc_uart_rx/tx, so multiple UART-mode drivers legally share one
+    # line (same as the existing 2208/2209 exemption).
+    result = _validate("""
+[tmc2240 stepper_x]
+uart_pin: PB0
+uart_address: 0
+run_current: 0.800
+sense_resistor: 0.110
+
+[tmc2240 stepper_y]
+uart_pin: PB0
+uart_address: 1
+run_current: 0.800
+sense_resistor: 0.110
+""")
+    hits = [e for e in _errors(result, "shared_pin") if "PB0" in e.message]
+    assert not hits, hits

--- a/tests/test_mainsail_sidebar.py
+++ b/tests/test_mainsail_sidebar.py
@@ -1,0 +1,175 @@
+"""V2.6.0 user report 2026-09-03: updating KWC via Moonraker's update_manager
+did not add the Mainsail sidebar entry (navi.json) — only re-running
+install.sh did.
+
+Root cause: Moonraker's git_repo update type NEVER executes the extension's
+installer. Its `install_script:` option is only parsed for apt package names
+(deprecated), not run. Updates are git pull + pip + managed_services
+restart. So anything install.sh does outside the repo tree (navi.json lives
+in the Moonraker config dir) must ALSO be self-healed by the app itself.
+
+Fix: the backend heals the sidebar entry at service startup — which every
+update_manager update triggers via managed_services restart.
+
+The merge semantics mirror scripts/install.sh edit_mainsail_navi exactly:
+- navi.json is a JSON array of {title, href, target, position, icon}
+- the KWC entry is replaced in place (single entry, current URL)
+- other custom entries are preserved verbatim
+- a corrupt/non-array navi.json is backed up (.bak) before replacement
+"""
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'backend'))
+
+import pytest  # noqa: E402
+
+from services.mainsail_sidebar import (  # noqa: E402
+    ensure_sidebar_entry,
+    resolve_mainsail_theme_dir,
+    resolve_moonraker_config_dir,
+    self_heal_sidebar,
+)
+
+
+@pytest.fixture()
+def fake_home(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    (home / "printer_data" / "config").mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+    return home
+
+
+def _kwc_entries(navi_path: Path):
+    entries = json.loads(navi_path.read_text())
+    return [e for e in entries if isinstance(e, dict) and e.get("title") == "KWC"]
+
+
+def test_no_mainsail_no_write(fake_home):
+    # No ~/mainsail dir and no [update_manager mainsail] in moonraker.conf:
+    # nothing must be created.
+    self_heal_sidebar()
+    assert not (fake_home / "printer_data" / "config" / ".theme").exists()
+
+
+def test_mainsail_dir_creates_entry(fake_home):
+    (fake_home / "mainsail").mkdir()
+    result = self_heal_sidebar(port=8099, ip_addr="192.168.1.50")
+    assert result == "added"
+    navi = fake_home / "printer_data" / "config" / ".theme" / "navi.json"
+    entries = _kwc_entries(navi)
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["href"] == "http://192.168.1.50:8099"
+    assert entry["target"] == "_blank"
+    assert entry["position"] == 95
+    assert entry["icon"].startswith("M")
+
+
+def test_mainsail_via_moonraker_conf_detection(fake_home):
+    (fake_home / "printer_data" / "config" / "moonraker.conf").write_text(
+        "[update_manager mainsail]\ntype: git_repo\n"
+    )
+    result = self_heal_sidebar(port=8099, ip_addr="192.168.1.50")
+    assert result == "added"
+
+
+def test_idempotent_and_single_entry(fake_home):
+    (fake_home / "mainsail").mkdir()
+    self_heal_sidebar(port=8099, ip_addr="192.168.1.50")
+    self_heal_sidebar(port=8099, ip_addr="192.168.1.50")
+    navi = fake_home / "printer_data" / "config" / ".theme" / "navi.json"
+    assert len(json.loads(navi.read_text())) == 1
+
+
+def test_stale_href_is_repaired(fake_home):
+    (fake_home / "mainsail").mkdir()
+    theme = fake_home / "printer_data" / "config" / ".theme"
+    theme.mkdir()
+    (theme / "navi.json").write_text(json.dumps([
+        {"title": "KWC", "href": "http://10.0.0.9:8099", "target": "_blank",
+         "position": 95, "icon": "M0 0h1v1z"},
+    ]))
+    result = self_heal_sidebar(port=8099, ip_addr="192.168.1.50")
+    assert result == "updated"
+    entries = _kwc_entries(theme / "navi.json")
+    assert len(entries) == 1
+    assert entries[0]["href"] == "http://192.168.1.50:8099"
+
+
+def test_other_custom_entries_preserved(fake_home):
+    (fake_home / "mainsail").mkdir()
+    theme = fake_home / "printer_data" / "config" / ".theme"
+    theme.mkdir()
+    other = {"title": "GCode History", "href": "http://x/gcode-history",
+             "target": "_blank", "position": 10, "icon": "M1 1"}
+    (theme / "navi.json").write_text(json.dumps([other]))
+    self_heal_sidebar(port=8099, ip_addr="192.168.1.50")
+    entries = json.loads((theme / "navi.json").read_text())
+    assert other in entries
+    assert len([e for e in entries if e.get("title") == "KWC"]) == 1
+
+
+def test_corrupt_navi_backed_up_not_destroyed(fake_home):
+    (fake_home / "mainsail").mkdir()
+    theme = fake_home / "printer_data" / "config" / ".theme"
+    theme.mkdir()
+    (theme / "navi.json").write_text("{not json")
+    self_heal_sidebar(port=8099, ip_addr="192.168.1.50")
+    assert (theme / "navi.json.bak").read_text() == "{not json"
+    assert len(_kwc_entries(theme / "navi.json")) == 1
+
+
+def test_no_ip_skips(fake_home):
+    # Same guard as the installer: never write a placeholder/localhost entry.
+    (fake_home / "mainsail").mkdir()
+    assert self_heal_sidebar(port=8099, ip_addr="") == "skipped"
+    assert not (fake_home / "printer_data" / "config" / ".theme" / "navi.json").exists()
+
+
+def test_no_config_dir_skips(tmp_path, monkeypatch):
+    home = tmp_path / "lonely"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    (home / "mainsail").mkdir()
+    assert self_heal_sidebar(port=8099, ip_addr="192.168.1.50") == "skipped"
+
+
+def test_kiauh_layout_resolved(fake_home):
+    # Legacy kiauh layout: ~/klipper_config instead of ~/printer_data/config.
+    (fake_home / "printer_data" / "config").rmdir()
+    (fake_home / "klipper_config").mkdir()
+    (fake_home / "mainsail").mkdir()
+    assert resolve_moonraker_config_dir() == fake_home / "klipper_config"
+    assert resolve_mainsail_theme_dir() == fake_home / "klipper_config" / ".theme"
+    assert self_heal_sidebar(port=8099, ip_addr="192.168.1.50") == "added"
+    assert (fake_home / "klipper_config" / ".theme" / "navi.json").exists()
+
+
+def test_ensure_sidebar_entry_unwritable_dir_is_noop(fake_home, monkeypatch):
+    # Permission errors must never crash startup: return "failed", no raise.
+    (fake_home / "mainsail").mkdir()
+    theme = fake_home / "printer_data" / "config" / ".theme"
+    theme.mkdir()
+    monkeypatch.setattr(
+        "services.mainsail_sidebar._write_navi",
+        lambda *a, **k: (_ for _ in ()).throw(PermissionError("ro")),
+    )
+    assert ensure_sidebar_entry(theme, "http://1.2.3.4:8099") == "failed"
+
+
+def test_startup_hook_runs_heal(fake_home, monkeypatch):
+    # Functional: booting the app must write the sidebar entry — that is
+    # what makes update_manager updates self-repairing (managed_services
+    # restarts the service). End-to-end through the real ASGI lifespan.
+    (fake_home / "mainsail").mkdir()
+    monkeypatch.setenv("KWC_PORT", "8099")
+    from fastapi.testclient import TestClient
+    from main import app
+
+    with TestClient(app):  # entering runs the lifespan startup
+        pass
+    navi = fake_home / "printer_data" / "config" / ".theme" / "navi.json"
+    assert navi.is_file(), "app startup did not write the Mainsail sidebar entry"
+    assert len(_kwc_entries(navi)) == 1

--- a/tests/test_mainsail_sidebar.py
+++ b/tests/test_mainsail_sidebar.py
@@ -159,6 +159,45 @@ def test_ensure_sidebar_entry_unwritable_dir_is_noop(fake_home, monkeypatch):
     assert ensure_sidebar_entry(theme, "http://1.2.3.4:8099") == "failed"
 
 
+def test_ensure_sidebar_entry_write_failure_is_logged(fake_home, monkeypatch, caplog):
+    # The noop above proves startup survives; this proves the failure is not
+    # silent — a warning with the navi.json path must be logged so
+    # permission/IO problems are diagnosable from service logs.
+    (fake_home / "mainsail").mkdir()
+    theme = fake_home / "printer_data" / "config" / ".theme"
+    theme.mkdir()
+    monkeypatch.setattr(
+        "services.mainsail_sidebar._write_navi",
+        lambda *a, **k: (_ for _ in ()).throw(PermissionError("ro")),
+    )
+    navi = theme / "navi.json"
+    with caplog.at_level("WARNING", logger="services.mainsail_sidebar"):
+        assert ensure_sidebar_entry(theme, "http://1.2.3.4:8099") == "failed"
+    assert any(
+        "Failed to write Mainsail sidebar entry" in r.message
+        and str(navi) in r.message
+        and r.exc_info is not None
+        for r in caplog.records
+    )
+
+
+def test_self_heal_unexpected_error_is_logged(fake_home, monkeypatch, caplog):
+    # The catch-all in self_heal_sidebar must log a traceback rather than
+    # swallowing the exception to a bare "failed".
+    (fake_home / "mainsail").mkdir()
+    monkeypatch.setattr(
+        "services.mainsail_sidebar.ensure_sidebar_entry",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    with caplog.at_level("ERROR", logger="services.mainsail_sidebar"):
+        assert self_heal_sidebar(port=8099, ip_addr="192.168.1.50") == "failed"
+    assert any(
+        "Unexpected error while self-healing" in r.message
+        and r.exc_info is not None
+        for r in caplog.records
+    )
+
+
 def test_startup_hook_runs_heal(fake_home, monkeypatch):
     # Functional: booting the app must write the sidebar entry — that is
     # what makes update_manager updates self-repairing (managed_services

--- a/tests/test_pin_false_positives_2026_09.py
+++ b/tests/test_pin_false_positives_2026_09.py
@@ -441,3 +441,201 @@ def test_rotation_distance_still_required_without_gear_ratio():
     assert not [e for e in result.errors if 'rotation_distance' in e.message]
     result2 = _validate(_stepper_x("#rotation_distance: 40"))
     assert [e for e in result2.errors if 'rotation_distance' in e.message]
+
+
+# ── 3b. Identical duplicate definitions (mirror files) ──────────────────────
+# Real report 2026-09-05 (V0 live config): [extruder] defined VERBATIM in
+# printer.cfg and in an included toolhead_board.cfg. The 4892884 shadow-drop
+# only removed pin values OVERRIDDEN by the later definition; with identical
+# values both uses survive and the conflict pass sees a double claim.
+# Ground truth: real klippy merges the definitions into ONE section and
+# allocates each option exactly once — fixture reaches 'Starting serial
+# connect' with no pins.error (/tmp/dup-extruder-fp, verified 2026-09-05).
+
+_MIRROR_EXTRUDER = """
+step_pin: EBBCan: PD0
+dir_pin: !EBBCan: PD1
+enable_pin: !EBBCan: PD2
+microsteps: 16
+rotation_distance: 53.494165
+gear_ratio: 44:10, 37:17
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: EBBCan: PB13
+sensor_type: ATC Semitec 104GT-2
+sensor_pin: EBBCan: PA3
+control: pid
+pid_Kp: 21.527
+pid_Ki: 1.063
+pid_Kd: 108.982
+min_temp: 0
+max_temp: 300
+"""
+
+
+def test_identical_duplicate_section_across_files_is_not_a_conflict():
+    """V0 pattern: [extruder] mirrored verbatim in printer.cfg + include."""
+    printer = f"""
+[mcu]
+serial: /tmp/klippy.sock
+[mcu EBBCan]
+canbus_uuid: aabbccddee11
+
+[printer]
+kinematics: corexy
+max_velocity: 300
+max_accel: 5000
+max_z_velocity: 15
+max_z_accel: 100
+
+[stepper_x]
+step_pin: PE2
+dir_pin: !PE1
+enable_pin: !PE3
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PG0
+position_endstop: 0
+position_max: 350
+
+[stepper_y]
+step_pin: PD3
+dir_pin: !PD6
+enable_pin: !PD5
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PL0
+position_endstop: 0
+position_max: 350
+
+[stepper_z]
+step_pin: PD1
+dir_pin: PA0
+enable_pin: !PA2
+microsteps: 16
+rotation_distance: 8
+endstop_pin: ^PC4
+position_endstop: 0
+position_max: 330
+
+[extruder]
+{_MIRROR_EXTRUDER}
+
+[include toolhead_board.cfg]
+"""
+    results = _project({'printer.cfg': printer, 'toolhead_board.cfg': f"[extruder]\n{_MIRROR_EXTRUDER}"})
+    assert _shared_pin_errors(results) == []
+
+
+def test_identical_duplicate_section_in_one_file_is_not_a_conflict():
+    """Same mirror pattern inside a single file."""
+    text = f"""
+[mcu]
+canbus_uuid: aabbccddee11
+
+[printer]
+kinematics: corexy
+max_velocity: 300
+max_accel: 5000
+max_z_velocity: 15
+max_z_accel: 100
+
+[stepper_x]
+step_pin: PE2
+dir_pin: !PE1
+enable_pin: !PE3
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PG0
+position_endstop: 0
+position_max: 350
+
+[stepper_y]
+step_pin: PD3
+dir_pin: !PD6
+enable_pin: !PD5
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PL0
+position_endstop: 0
+position_max: 350
+
+[stepper_z]
+step_pin: PD1
+dir_pin: PA0
+enable_pin: !PA2
+microsteps: 16
+rotation_distance: 8
+endstop_pin: ^PC4
+position_endstop: 0
+position_max: 330
+
+[extruder]
+{_MIRROR_EXTRUDER}
+
+[extruder]
+{_MIRROR_EXTRUDER}
+"""
+    result = _validate(text)
+    assert _shared_pin_errors(result) == []
+
+
+def test_genuine_conflict_survives_identical_duplicate_of_other_section():
+    """The dedup must not swallow real conflicts: the merged [extruder]
+    value still collides with a DIFFERENT section claiming the same pin."""
+    printer = f"""
+[mcu]
+serial: /tmp/klippy.sock
+[mcu EBBCan]
+canbus_uuid: aabbccddee11
+
+[printer]
+kinematics: corexy
+max_velocity: 300
+max_accel: 5000
+max_z_velocity: 15
+max_z_accel: 100
+
+[stepper_x]
+step_pin: PE2
+dir_pin: !PE1
+enable_pin: !PE3
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PG0
+position_endstop: 0
+position_max: 350
+
+[stepper_y]
+step_pin: PD3
+dir_pin: !PD6
+enable_pin: !PD5
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PL0
+position_endstop: 0
+position_max: 350
+
+[stepper_z]
+step_pin: PD1
+dir_pin: PA0
+enable_pin: !PA2
+microsteps: 16
+rotation_distance: 8
+endstop_pin: ^PC4
+position_endstop: 0
+position_max: 330
+
+[extruder]
+{_MIRROR_EXTRUDER}
+
+[heater_fan hotend_fan]
+pin: EBBCan: PB13
+heater: extruder
+heater_temp: 50.0
+
+[include toolhead_board.cfg]
+"""
+    results = _project({'printer.cfg': printer, 'toolhead_board.cfg': f"[extruder]\n{_MIRROR_EXTRUDER}"})
+    errs = _shared_pin_errors(results)
+    assert any('PB13' in e.message for e in errs), errs

--- a/tests/test_pin_false_positives_2026_09.py
+++ b/tests/test_pin_false_positives_2026_09.py
@@ -1,0 +1,443 @@
+"""Four shared-pin / pin-chip false-positive fixes (klipper_backup audit, 2026-09-04).
+
+Ground truth verified by running real klippy on minimal fixtures (same method
+as plan 3.5):
+
+1. probe chip — klippy/extras/probe.py:215 registers the 'probe' chip inside
+   HomingViaProbeHelper.__init__, which is constructed by [probe] (probe.py:619),
+   [bltouch] (bltouch.py:292), [smart_effector] (smart_effector.py:169),
+   [load_cell_probe] (load_cell_probe.py:698) and [probe_eddy_current]
+   (probe_eddy_current.py:729). A bltouch-only config with
+   endstop_pin: probe:z_virtual_endstop reaches 'Starting serial connect';
+   removing [bltouch] fails with "Unknown pin chip name 'probe'".
+
+2. TMC diag_pin — klippy/extras/tmc.py:598 allocates diag_pin ONLY inside
+   TMCVirtualPinHelper.setup_pin, i.e. only when a stepper's endstop_pin
+   references <driver>:virtual_endstop. With sensorless commented out, the
+   diag pin is dead: stepper endstop + unused diag on the same GPIO loads
+   clean; the same config with the virtual endstop ACTIVE fails
+   "pin gpio3 used multiple times in config".
+
+3. Duplicate-section merge — RawConfigParser(strict=False) is a per-option
+   union, later definition wins. A pin claimed by an EARLIER [fan] definition
+   that a later [fan] definition overrides is never allocated (fixture loads
+   clean). Same-file and cross-file (include order = recursive walk,
+   configfile.py _parse_config buffers includes and parses linearly).
+
+4. rotation_distance optional with gear_ratio — klippy/stepper.py
+   parse_step_distance (297-309): rotation_distance is read only when
+   gear_ratio is absent (the units_in_radians path uses 2*pi).
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'backend'))
+
+from parser.config_parser import parse_config  # noqa: E402
+from parser.validator import validate_config, validate_project_configs  # noqa: E402
+
+
+def _validate(text: str):
+    return validate_config(parse_config(text, 'printer.cfg'))
+
+
+def _project(files: dict[str, str]) -> dict:
+    return validate_project_configs({
+        name: parse_config(text, name) for name, text in files.items()
+    })
+
+
+def _shared_pin_errors(results) -> list:
+    if not isinstance(results, dict):
+        results = {'printer.cfg': results}
+    return [
+        e
+        for res in results.values()
+        for e in res.errors
+        if getattr(e, 'code', '') == 'shared_pin'
+    ]
+
+
+def _unknown_chip_errors(results) -> list:
+    if not isinstance(results, dict):
+        results = {'printer.cfg': results}
+    return [
+        e
+        for res in results.values()
+        for e in res.errors
+        if 'Unknown pin chip name' in e.message
+    ]
+
+
+# ── 1. probe chip registered by the probe family, not only [probe] ─────────
+
+
+BLTOUCH_PRINTER = """
+[mcu]
+serial: /tmp/klippy.sock
+
+[printer]
+kinematics: cartesian
+max_velocity: 200
+max_accel: 5000
+max_z_velocity: 25
+max_z_accel: 100
+
+[stepper_x]
+step_pin: PB0
+dir_pin: PB1
+enable_pin: !PB2
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PB3
+position_endstop: 0
+position_max: 235
+
+[stepper_y]
+step_pin: PB4
+dir_pin: !PB5
+enable_pin: !PB6
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PB7
+position_endstop: 0
+position_max: 235
+
+[stepper_z]
+step_pin: PB8
+dir_pin: !PB9
+enable_pin: !PB10
+microsteps: 16
+rotation_distance: 8
+endstop_pin: probe:z_virtual_endstop
+position_min: -5
+position_max: 250
+
+[bltouch]
+sensor_pin: ^PC13
+control_pin: PA1
+z_offset: -2.0
+"""
+
+
+OTHER_CFG = "[force_move]\nenable_force_move: true\n"
+
+
+def test_bltouch_registers_probe_chip():
+    """bltouch (component_group probe) must satisfy probe:z_virtual_endstop.
+    Chip membership is a project-pass check, so run a 2-file project."""
+    results = _project({
+        'printer.cfg': "[include other.cfg]\n" + BLTOUCH_PRINTER,
+        'other.cfg': OTHER_CFG,
+    })
+    assert _unknown_chip_errors(results) == []
+
+
+def test_probe_chip_still_unknown_without_any_probe_section():
+    """Negative control: no probe family section → error stays."""
+    text = BLTOUCH_PRINTER.replace(
+        "\n[bltouch]\nsensor_pin: ^PC13\ncontrol_pin: PA1\nz_offset: -2.0\n", ""
+    )
+    results = _project({
+        'printer.cfg': "[include other.cfg]\n" + text,
+        'other.cfg': OTHER_CFG,
+    })
+    errs = _unknown_chip_errors(results)
+    assert any("'probe'" in e.message for e in errs), errs
+
+
+def test_probe_chip_registered_cross_file():
+    """The defining [bltouch] may live in an included file."""
+    results = _project({
+        'printer.cfg': "[include probe.cfg]\n" + BLTOUCH_PRINTER,
+        'probe.cfg': "[bltouch]\nsensor_pin: ^PC13\ncontrol_pin: PA1\nz_offset: -2.0\n",
+    })
+    assert _unknown_chip_errors(results) == []
+
+
+# ── 2. TMC diag_pin is only claimed when sensorless is active ───────────────
+
+
+MPMD_STYLE = """
+[mcu]
+serial: /tmp/klippy.sock
+
+[printer]
+kinematics: cartesian
+max_velocity: 200
+max_accel: 5000
+max_z_velocity: 25
+max_z_accel: 100
+
+[stepper_x]
+step_pin: PB0
+dir_pin: PB1
+enable_pin: !PB2
+microsteps: 16
+rotation_distance: 40
+endstop_pin: !PB3
+position_endstop: 0
+position_max: 235
+
+[tmc2209 stepper_x]
+uart_pin: PB4
+run_current: 0.400
+diag_pin: ^PB5
+driver_SGTHRS: 52
+
+[stepper_y]
+step_pin: PB6
+dir_pin: !PB7
+enable_pin: !PB8
+microsteps: 16
+rotation_distance: 40
+endstop_pin: !PB5
+position_endstop: 0
+position_max: 235
+
+[tmc2209 stepper_y]
+uart_pin: PB9
+run_current: 0.400
+diag_pin: ^PB3
+driver_SGTHRS: 52
+"""
+
+
+def test_unused_diag_pin_does_not_conflict_with_physical_endstop():
+    """MPMDV2 pattern: diag pins cross-wired to the OTHER axis' physical
+    endstops with sensorless commented out — klippy loads (fixture:
+    'Starting serial connect'); diag_pin is never allocated."""
+    result = _validate(MPMD_STYLE)
+    assert _shared_pin_errors(result) == []
+
+
+def test_active_sensorless_diag_conflict_still_fires():
+    """Positive control: endstop_pin: tmc2209_stepper_x:virtual_endstop makes
+    the diag pin live — klippy fixture fails 'pin used multiple times'."""
+    text = MPMD_STYLE.replace(
+        "endstop_pin: !PB3\nposition_endstop: 0",
+        "endstop_pin: tmc2209_stepper_x:virtual_endstop\nposition_endstop: 0",
+    )
+    result = _validate(text)
+    errs = _shared_pin_errors(result)
+    assert errs, "expected a shared_pin error once stepper_x homes sensorless"
+    assert any('PB5' in e.message for e in errs)
+
+
+def test_diag_pin_conflict_caught_cross_file():
+    """Virtual endstop in printer.cfg, diag pin claimed in an included file —
+    the project pass must still see the conflict (no false negative)."""
+    printer = """
+[mcu]
+serial: /tmp/klippy.sock
+
+[printer]
+kinematics: cartesian
+max_velocity: 200
+max_accel: 5000
+max_z_velocity: 25
+max_z_accel: 100
+
+[stepper_x]
+step_pin: PB0
+dir_pin: PB1
+enable_pin: !PB2
+microsteps: 16
+rotation_distance: 40
+endstop_pin: tmc2209_stepper_x:virtual_endstop
+position_endstop: 0
+position_max: 235
+homing_retract_dist: 0
+
+[stepper_y]
+step_pin: PB6
+dir_pin: !PB7
+enable_pin: !PB8
+microsteps: 16
+rotation_distance: 40
+endstop_pin: tmc2209_stepper_y:virtual_endstop
+position_endstop: 0
+position_max: 235
+homing_retract_dist: 0
+
+[include drivers.cfg]
+"""
+    drivers = """
+[tmc2209 stepper_x]
+uart_pin: PB4
+run_current: 0.400
+diag_pin: ^PB13
+
+[tmc2209 stepper_y]
+uart_pin: PB9
+run_current: 0.400
+diag_pin: ^PB13
+"""
+    results = _project({'printer.cfg': printer, 'drivers.cfg': drivers})
+    errs = _shared_pin_errors(results)
+    assert any('PB13' in e.message for e in errs), (
+        "two ACTIVE diag pins on PB13 must remain an error"
+    )
+
+
+# ── 3. Shadowed pin values in duplicate sections ────────────────────────────
+
+
+def _fan_cfg(first_pin: str, heater_pin: str, last_pin: str) -> str:
+    return f"""
+[mcu]
+serial: /tmp/klippy.sock
+
+[printer]
+kinematics: cartesian
+max_velocity: 200
+max_accel: 5000
+max_z_velocity: 25
+max_z_accel: 100
+
+[stepper_x]
+step_pin: PB0
+dir_pin: PB1
+enable_pin: !PB2
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PB3
+position_endstop: 0
+position_max: 235
+
+[fan]
+pin: {first_pin}
+
+[heater_fan hotend_fan]
+pin: {heater_pin}
+heater: extruder
+heater_temp: 50.0
+
+[fan]
+pin: {last_pin}
+"""
+
+
+def test_shadowed_duplicate_pin_in_same_file_is_not_a_conflict():
+    """Later [fan] definition wins the merge; the earlier pin value is dead.
+    Klipper fixture: loads clean."""
+    result = _validate(_fan_cfg('PA0', 'PA0', 'PA1'))
+    assert _shared_pin_errors(result) == []
+
+
+def test_genuine_conflict_survives_unrelated_duplicate_section():
+    """The shadow pass must not swallow real conflicts: the surviving [fan]
+    definition (last wins) still collides with [heater_fan]."""
+    result = _validate(_fan_cfg('PA9', 'PA0', 'PA0'))
+    errs = _shared_pin_errors(result)
+    assert any('PA0' in e.message for e in errs), errs
+
+
+def test_shadowed_duplicate_pin_across_files_is_not_a_conflict():
+    """voron_01 pattern: sample-EBB [fan] pin PA0 (earlier in include order)
+    is overridden by printer.cfg's later [fan] pin PA1 → no conflict with
+    printer.cfg's [heater_fan hotend_fan] pin PA0."""
+    sample = """
+[fan]
+pin: EBBCan: PA0
+"""
+    printer = """
+[mcu EBBCan]
+canbus_uuid: aabbccddee11
+
+[printer]
+kinematics: corexy
+max_velocity: 300
+max_accel: 5000
+max_z_velocity: 15
+max_z_accel: 100
+
+[include sample-ebb.cfg]
+
+[fan]
+pin: EBBCan: PA1
+
+[heater_fan hotend_fan]
+pin: EBBCan: PA0
+heater: extruder
+heater_temp: 50.0
+"""
+    results = _project({'printer.cfg': printer, 'sample-ebb.cfg': sample})
+    assert _shared_pin_errors(results) == []
+
+
+def test_cross_file_conflict_survives_when_later_def_clamps_to_taken_pin():
+    """If the LAST definition of the duplicated section pins onto the
+    contested pin, the conflict is real and must still fire."""
+    sample = """
+[fan]
+pin: EBBCan: PA9
+"""
+    printer = """
+[mcu EBBCan]
+canbus_uuid: aabbccddee11
+
+[printer]
+kinematics: corexy
+max_velocity: 300
+max_accel: 5000
+max_z_velocity: 15
+max_z_accel: 100
+
+[include sample-ebb.cfg]
+
+[fan]
+pin: EBBCan: PA0
+
+[heater_fan hotend_fan]
+pin: EBBCan: PA0
+heater: extruder
+heater_temp: 50.0
+"""
+    results = _project({'printer.cfg': printer, 'sample-ebb.cfg': sample})
+    errs = _shared_pin_errors(results)
+    assert any('PA0' in e.message for e in errs), errs
+
+
+# ── 4. rotation_distance optional when gear_ratio present ───────────────────
+
+
+def _stepper_x(extra: str) -> str:
+    return f"""
+[mcu]
+serial: /tmp/klippy.sock
+
+[printer]
+kinematics: cartesian
+max_velocity: 200
+max_accel: 5000
+max_z_velocity: 25
+max_z_accel: 100
+
+[stepper_x]
+step_pin: PB0
+dir_pin: PB1
+enable_pin: !PB2
+microsteps: 16
+{extra}
+endstop_pin: ^PB3
+position_endstop: 0
+position_max: 235
+"""
+
+
+def test_gear_ratio_satisfies_rotation_distance_requirement():
+    """parse_step_distance: gear_ratio alone is legal (units_in_radians path).
+    Pico.cfg Afterburner-style configs ship gear_ratio: 50:10 with no
+    rotation_distance and load fine."""
+    result = _validate(_stepper_x("gear_ratio: 50:10"))
+    assert not [e for e in result.errors if 'rotation_distance' in e.message], (
+        "gear_ratio must satisfy the rotation_distance requirement"
+    )
+
+
+def test_rotation_distance_still_required_without_gear_ratio():
+    result = _validate(_stepper_x("rotation_distance: 40"))
+    assert not [e for e in result.errors if 'rotation_distance' in e.message]
+    result2 = _validate(_stepper_x("#rotation_distance: 40"))
+    assert [e for e in result2.errors if 'rotation_distance' in e.message]

--- a/tests/test_pin_mcu_membership.py
+++ b/tests/test_pin_mcu_membership.py
@@ -162,6 +162,48 @@ def test_chip_name_case_insensitive():
     assert not _unknown_chip_errors(results), "chip matching must be case-insensitive"
 
 
+def test_pullup_prefixed_chip_resolves():
+    # V2.6.0 user report 2026-09-03: encoder_pins: ^menu:PA0, ^menu:PA1 with
+    # [mcu menu] defined threw "Unknown pin chip name '^menu'".
+    # Ground truth (klippy/pins.py parse_pin): pullup/invert prefixes are
+    # stripped BEFORE the chip split, so '^menu:PA0' resolves against chip
+    # 'menu'. The comma-separated list form also puts a leading space on the
+    # second pin — normalization must strip whitespace before the prefix.
+    # Two-file project: the membership check is a cross-file pass that
+    # early-returns for single-file projects.
+    results = _project({
+        "printer.cfg": "[mcu]\n[include menu.cfg]\n",
+        "menu.cfg": (
+            "[mcu menu]\n"
+            "serial: /dev/serial/by-id/usb-Klipper_stm32f042x6_x-if00\n"
+            "[display]\n"
+            "lcd_type: uc1701\n"
+            "encoder_pins: ^menu:PA0, ^menu:PA1\n"
+            "click_pin: ^!menu:PB1\n"
+        ),
+    })
+    assert not _unknown_chip_errors(results), "pullup-prefixed chip-pinned values in a comma list must resolve"
+
+
+def test_pullup_prefixed_chip_still_flags_unknown_chip():
+    # The fix must not weaken the check: an unknown chip stays an error even
+    # when wrapped in polarity prefixes inside a comma list.
+    results = _project({
+        "printer.cfg": "[mcu]\n[include menu.cfg]\n",
+        "menu.cfg": (
+            "[display]\n"
+            "lcd_type: uc1701\n"
+            "encoder_pins: ^ghost:PA0, ^ghost:PA1\n"
+        ),
+    })
+    errors = _unknown_chip_errors(results)
+    assert errors, "pullup-prefixed pins of an undefined chip must still error"
+    assert "^" not in errors[0].message.split("Unknown pin chip name ")[1].split("'")[0], (
+        "error must name the chip without its polarity prefix"
+    )
+    assert "ghost" in errors[0].message
+
+
 def test_single_file_mode_does_not_check_membership():
     # validate_config has no project context — the chip may live in another
     # file. Membership is a project-pass check only.

--- a/tests/test_rtd_sensor_params_2026_09.py
+++ b/tests/test_rtd_sensor_params_2026_09.py
@@ -1,0 +1,173 @@
+"""RTD/TC sensor-family params are valid on EVERY sensor_type section (2026-09-07).
+
+Ground truth: heaters.py Heater.__init__ -> setup_sensor(config) (heaters.py:280-300)
+instantiates the sensor factory with the SAME section config, so an SPI sensor
+class reads its own params directly from [extruder]/[heater_bed]/etc.
+spi_temperature.py MAX31865 reads rtd_nominal_r / rtd_reference_r (:285-286),
+rtd_use_50Hz_filter (:334) and rtd_num_of_wires (:336); MAX31856 reads tc_type,
+tc_use_50Hz_filter and tc_averaging_count. The stock sample
+printer-modix-big60-2020.cfg uses all four rtd_* params under [extruder] and
+[extruder1] with sensor_type: MAX31865 — KWC false-errored 8 unknown_param
+findings on it.
+
+Scope note: only sections whose sensor_type accepts the generic SENSOR_TYPE_ENUM
+(and therefore MAX31865/MAX31856) gain the family. Sections with fixed sensor
+enums ([angle], [load_cell], [probe_eddy_current], [load_cell_probe]) cannot
+host an RTD chip and must NOT accept these params.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'backend'))
+
+from parser.config_parser import parse_config  # noqa: E402
+from parser.config_schema import SECTION_DEFS, SENSOR_TYPE_ENUM  # noqa: E402
+from parser.validator import validate_config  # noqa: E402
+
+
+RTD_TC_PARAMS = [
+    "rtd_nominal_r",
+    "rtd_reference_r",
+    "rtd_num_of_wires",
+    "rtd_use_50Hz_filter",
+    "tc_type",
+    "tc_use_50Hz_filter",
+    "tc_averaging_count",
+]
+
+
+def _validate(text: str):
+    return validate_config(parse_config(text, 'printer.cfg'))
+
+
+def _unknown_params(result):
+    return [e for e in result.errors if e.code == "unknown_param"]
+
+
+# ── 1. [extruder] with MAX31865 (modix-big60 shape) validates clean ────
+
+def test_extruder_max31865_rtd_params_accepted():
+    text = """
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 15
+max_z_accel: 100
+
+[extruder]
+step_pin: PD5
+dir_pin: PA1
+enable_pin: !PC6
+microsteps: 256
+rotation_distance: 22.9344
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: !PA20
+sensor_type: MAX31865
+spi_bus: usart0
+sensor_pin: PB2
+rtd_nominal_r: 100
+rtd_reference_r: 400
+rtd_num_of_wires: 3
+rtd_use_50Hz_filter: True
+min_temp: 0
+max_temp: 350
+"""
+    result = _validate(text)
+    assert _unknown_params(result) == [], (
+        f"MAX31865 RTD params under [extruder] must be known: {_unknown_params(result)}"
+    )
+
+
+# ── 2.heater-family + other generic-sensor sections carry the family ───
+
+def test_sensor_sections_carry_rtd_tc_params():
+    generic_sections = [
+        "extruder",
+        "extruder1",
+        "heater_bed",
+        "heater_generic",
+        "temperature_fan",
+        "temperature_sensor",
+        "z_thermal_adjust",
+    ]
+    for sec in generic_sections:
+        names = {p.name for p in SECTION_DEFS[sec].params}
+        for param in RTD_TC_PARAMS:
+            assert param in names, f"{sec} is missing sensor-family param '{param}'"
+
+
+def test_max31856_tc_params_accepted_on_heater_generic():
+    text = """
+[heater_generic heater_chamber]
+heater_pin: PF6
+sensor_type: MAX31856
+spi_bus: spi1
+sensor_pin: PB2
+tc_type: K
+tc_use_50Hz_filter: True
+tc_averaging_count: 4
+max_power: 1.0
+min_temp: 0
+max_temp: 90
+control: pid
+pid_Kp: 50
+pid_Ki: 1
+pid_Kd: 10
+"""
+    result = _validate(text)
+    assert _unknown_params(result) == [], (
+        f"MAX31856 TC params under [heater_generic] must be known: {_unknown_params(result)}"
+    )
+
+
+# ── 3. Positive controls: genuinely unknown params still flagged ───────
+
+def test_bogus_param_on_extruder_still_flagged():
+    text = """
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 15
+max_z_accel: 100
+
+[extruder]
+step_pin: PD5
+dir_pin: PA1
+microsteps: 16
+rotation_distance: 22.9344
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: !PA20
+sensor_type: MAX31865
+spi_bus: usart0
+sensor_pin: PB2
+rtd_nominal_r: 100
+rtd_bogus_r: 400
+min_temp: 0
+max_temp: 350
+"""
+    result = _validate(text)
+    flagged = [e for e in _unknown_params(result) if "rtd_bogus_r" in e.message]
+    assert len(flagged) == 1, "a param outside the sensor family must still be unknown_param"
+
+
+def test_fixed_enum_sections_do_not_carry_rtd_params():
+    # [angle] (a1333/as5047d/tle5012b) and [load_cell] (HX711/...) cannot host
+    # an RTD chip — accepting rtd_* there would be a false NEGATIVE.
+    for sec in ("angle", "load_cell", "probe_eddy_current"):
+        names = {p.name for p in SECTION_DEFS[sec].params}
+        assert "rtd_nominal_r" not in names, (
+            f"{sec} has a fixed sensor_type enum and must NOT accept RTD params"
+        )
+
+
+# ── 4. Bounds carried with the family (spi_temperature.py getfloat above=0) ──
+
+def test_rtd_bounds_match_klipper():
+    params = {p.name: p for p in SECTION_DEFS["extruder"].params}
+    assert params["rtd_nominal_r"].strict_above == "0" or float(params["rtd_nominal_r"].strict_above) == 0.0
+    assert params["rtd_reference_r"].strict_above is not None
+    assert params["rtd_num_of_wires"].min_val is None or int(params["rtd_num_of_wires"].min_val) <= 0

--- a/tests/test_rtd_sensor_params_2026_09.py
+++ b/tests/test_rtd_sensor_params_2026_09.py
@@ -171,3 +171,73 @@ def test_rtd_bounds_match_klipper():
     assert params["rtd_nominal_r"].strict_above == "0" or float(params["rtd_nominal_r"].strict_above) == 0.0
     assert params["rtd_reference_r"].strict_above is not None
     assert params["rtd_num_of_wires"].min_val is None or int(params["rtd_num_of_wires"].min_val) <= 0
+
+
+# ── 5. tc_type / tc_averaging_count are getchoice-read: invalid values are
+#       config-load hard-fails (spi_temperature.py:165-184, configfile.py:84) ──
+
+def test_invalid_tc_type_is_error():
+    text = """
+[heater_generic chamber]
+heater_pin: PF6
+sensor_type: MAX31856
+spi_bus: spi1
+sensor_pin: PB2
+tc_type: Z
+max_power: 1.0
+min_temp: 0
+max_temp: 90
+"""
+    result = _validate(text)
+    errs = [e for e in result.errors
+            if e.severity == "error" and e.param == "tc_type"]
+    assert len(errs) == 1, f"tc_type Z is not a getchoice value — must error: {result.errors}"
+
+
+def test_invalid_tc_averaging_count_is_error():
+    text = """
+[heater_generic chamber]
+heater_pin: PF6
+sensor_type: MAX31856
+spi_bus: spi1
+sensor_pin: PB2
+tc_type: K
+tc_averaging_count: 3
+max_power: 1.0
+min_temp: 0
+max_temp: 90
+"""
+    result = _validate(text)
+    errs = [e for e in result.errors
+            if e.severity == "error" and e.param == "tc_averaging_count"]
+    assert len(errs) == 1, f"tc_averaging_count 3 is not a getchoice value — must error: {result.errors}"
+
+
+def test_temperature_probe_tc_params_are_enums():
+    # temperature_probe carries its own copy of the RTD/TC family.
+    params = {p.name: p for p in SECTION_DEFS["temperature_probe"].params}
+    assert params["tc_type"].enum_values == ["B", "E", "J", "K", "N", "R", "S", "T"]
+    assert params["tc_averaging_count"].enum_values == ["1", "2", "4", "8", "16"]
+
+
+# ── 6. spi_speed is read unconditionally by bus.py MCU_SPI_from_config ──
+
+def test_spi_speed_accepted_on_extruder_and_temperature_sensor():
+    for sec in ("extruder", "temperature_sensor"):
+        names = {p.name for p in SECTION_DEFS[sec].params}
+        assert "spi_speed" in names, f"{sec} must accept spi_speed (bus.py:137)"
+    text = """
+[temperature_sensor rtd_probe]
+sensor_type: MAX31865
+spi_bus: spi1
+spi_speed: 500000
+sensor_pin: PB2
+rtd_nominal_r: 100
+rtd_reference_r: 400
+min_temp: 0
+max_temp: 300
+"""
+    result = _validate(text)
+    assert _unknown_params(result) == [], (
+        f"spi_speed under [temperature_sensor] must be known: {_unknown_params(result)}"
+    )

--- a/tests/test_save_config_api_reconstruction.py
+++ b/tests/test_save_config_api_reconstruction.py
@@ -152,3 +152,121 @@ def test_missing_required_still_errors_when_no_tail():
     assert res.status_code == 200
     missing = _tail_missing_errors(res.json()["errors"])
     assert {e["param"] for e in missing} == TAIL_REQUIRED, missing
+
+
+# ── Param line numbers across the reconstruction boundary ──────────────
+# ParamUpdate carries no line_number, so every reconstructed param is 0.
+# Section-anchored findings survive, but macro Jinja findings are computed
+# as param.line + body offset: with param.line=0 they collapse to the bare
+# offset (e.g. line 3) — a CONFIDENT wrong number the frontend treats as
+# fresh and authoritative (the same class as the historical "dot on the
+# wrong line" reports). The reconstructor now re-derives param lines from
+# raw_text; a finding emitted for the rebuilt file must carry the same line
+# as the same finding emitted from the fresh parse.
+
+_FILLER = "\n".join(f"# filler line {i}" for i in range(1, 200))
+
+JINJA_TEXT = _FILLER + """
+[gcode_macro START_PRINT]
+gcode:
+  {% set foo = 1 %}
+  {% if foo %}
+    M117 hi
+"""
+
+
+def test_macro_jinja_line_matches_fresh_parse():
+    fresh = client.post("/api/validate", json=_config_dict(JINJA_TEXT)).json()
+    fresh_lines = [
+        e["line_number"] for e in fresh["errors"]
+        if e.get("code") == "macro_jinja_unterminated"
+    ]
+    assert len(fresh_lines) == 1, fresh["errors"]
+    assert fresh_lines[0] > 200, "control: body offset must be file-absolute on parse"
+
+    # Same payload shape the editor sends (to_dict + raw_text): the finding
+    # must keep the authoritative line, not collapse to the body offset.
+    res = client.post("/api/validate", json=_config_dict(JINJA_TEXT))
+    rebuilt = [
+        e for e in res.json()["errors"]
+        if e.get("code") == "macro_jinja_unterminated"
+    ]
+    assert rebuilt and rebuilt[0]["line_number"] == fresh_lines[0], rebuilt
+
+
+def test_param_value_error_line_restored_via_reconstruction():
+    """A value error deep in the file keeps its param line (0 → heuristic
+    fallback was the old behavior; the gutter dot for e.g. 'microsteps: abc'
+    should anchor on the param line authoritatively)."""
+    text = _FILLER + """
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+
+[stepper_x]
+step_pin: PF0
+dir_pin: PF1
+enable_pin: !PD7
+microsteps: abc
+rotation_distance: 40
+endstop_pin: ^PE5
+position_endstop: 0
+position_max: 200
+
+[stepper_y]
+step_pin: PF6
+dir_pin: !PF7
+enable_pin: !PF2
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PJ1
+position_endstop: 0
+position_max: 200
+
+[stepper_z]
+step_pin: PL3
+dir_pin: PL1
+enable_pin: !PK0
+microsteps: 16
+rotation_distance: 8
+endstop_pin: ^PD3
+position_endstop: 0
+position_max: 200
+
+[mcu]
+serial: /dev/ttyFAKE
+"""
+    d = _config_dict(text)
+    microsteps_line = next(
+        i for i, l in enumerate(text.splitlines(), start=1)
+        if l.startswith("microsteps: abc")
+    )
+    res = client.post("/api/validate", json=d)
+    errs = [e for e in res.json()["errors"] if e["param"] == "microsteps"]
+    assert errs, res.json()["errors"]
+    assert errs[0]["line_number"] == microsteps_line, errs
+
+
+def test_renamed_param_line_stays_zero():
+    """Params that don't exist in raw_text (graph-editor additions) must stay
+    line 0 so the frontend heuristic resolves them — the matcher must not
+    misattribute a neighboring param's line."""
+    d = _config_dict("[printer]\nkinematics: cartesian\nmax_velocity: 300\nmax_accel: 3000\n")
+    # Inject a brand-new section with a bad value that raw_text doesn't have.
+    d["sections"].append({
+        "full_header": "fan", "section_type": "fan", "section_name": "",
+        "line_number": 0,
+        "params": [
+            {"key": "pin", "value": "PB0", "is_commented_out": False, "comment": "", "separator": ":"},
+            {"key": "cycle_time", "value": "hello", "is_commented_out": False, "comment": "", "separator": ":"},
+        ],
+        "header_comments": [], "trailing_comments": [], "is_commented_out": False,
+    })
+    res = client.post("/api/validate", json=d)
+    errs = [e for e in res.json()["errors"] if e["param"] == "cycle_time"]
+    assert errs, res.json()["errors"]
+    assert errs[0]["line_number"] == 0, (
+        "invented params must not borrow a line from raw_text", errs)
+

--- a/tests/test_save_config_api_reconstruction.py
+++ b/tests/test_save_config_api_reconstruction.py
@@ -1,0 +1,154 @@
+"""
+Regression: #*# SAVE_CONFIG tail values must survive the VALIDATION API path.
+
+The frontend's live-edit path sends serialized model dicts (to_dict() shape +
+raw_text) to /validate and /validate-project, which reconstruct ConfigFile
+objects server-side. to_dict() does not serialize save_config_sections, so the
+reconstruction produced a file with NO saved-config tail. The validator's
+required-param checks merge saved-config params into active_params (a SAVE_CONFIG
+block satisfies e.g. position_endstop/arm_length/delta_radius — Klipper appends
+the autosave data into the same RawConfigParser), so the empty reconstruction
+made valid configs report false "Required parameter ... is missing" errors.
+
+Reported shape: a Monoprice Mini Delta (MPMDV2) config whose position_endstop,
+arm_length and delta_radius live only in the #*# tail — Klipper loads it clean,
+KWC flagged three errors. Same class as the unclosed_headers API-path gap.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'backend'))
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from main import app  # noqa: E402
+from parser.config_parser import parse_config  # noqa: E402
+
+client = TestClient(app)
+
+# Delta config whose required params exist ONLY in the SAVE_CONFIG tail
+# (the post-DELTA_CALIBRATE / DELTA_TUNE state of a real MPMDV2 printer.cfg).
+MPMD_TEXT = """[printer]
+kinematics: delta
+max_velocity: 300
+max_accel: 3000
+
+[stepper_a]
+homing_speed: 50
+step_pin: PB12
+dir_pin: PB11
+enable_pin: !PB10
+microsteps: 16
+rotation_distance: 56
+endstop_pin: ^PC14
+#position_endstop: 125.00
+#arm_length: 120.8
+
+[stepper_b]
+step_pin: PB2
+dir_pin: PB1
+enable_pin: !PB10
+microsteps: 16
+rotation_distance: 56
+endstop_pin: ^PC13
+
+[stepper_c]
+step_pin: PB0
+dir_pin: PC5
+enable_pin: !PB10
+microsteps: 16
+rotation_distance: 56
+endstop_pin: ^PC4
+
+[mcu]
+serial: /dev/ttyFAKE
+
+#*# <---------------------- SAVE_CONFIG ---------------------->
+#*# DO NOT EDIT THIS BLOCK OR BELOW. The contents are auto-generated.
+#*#
+#*# [stepper_a]
+#*# position_endstop = 125.00
+#*# arm_length = 120.8
+#*#
+#*# [printer]
+#*# delta_radius = 87.062
+"""
+
+TAIL_REQUIRED = {"delta_radius", "position_endstop", "arm_length"}
+
+
+def _config_dict(text: str, filename: str = "printer.cfg") -> dict:
+    """Exactly what the frontend store sends: to_dict() + raw_text."""
+    d = parse_config(text, filename).to_dict()
+    d["raw_text"] = text
+    return d
+
+
+def _tail_missing_errors(errors: list[dict]) -> list[dict]:
+    return [
+        e for e in errors
+        if e.get("param") in TAIL_REQUIRED
+        and "is missing" in e.get("message", "")
+    ]
+
+
+def test_direct_parse_has_no_false_required_errors():
+    """Control: the parse path already merges the tail into required checks."""
+    cfg = parse_config(MPMD_TEXT, "printer.cfg")
+    assert [s.full_header for s in cfg.save_config_sections] == ["stepper_a", "printer"]
+    res = client.post("/api/validate", json=_config_dict(MPMD_TEXT))
+    assert res.status_code == 200
+    assert not _tail_missing_errors(res.json()["errors"]), res.json()["errors"]
+
+
+def test_validate_single_file_survives_reconstruction():
+    """/validate rebuilds the ConfigFile from the model dict — the tail must be
+    re-derived from raw_text, not silently dropped."""
+    # Sanity: the model dict carries no ACTIVE save_config params (the tail
+    # values appear at most as comments — that is the reconstruction gap; the
+    # validator only counts non-commented params).
+    d = _config_dict(MPMD_TEXT)
+    active = {
+        p["key"]
+        for s in d["sections"]
+        for p in s["params"]
+        if not p["is_commented_out"]
+    }
+    assert TAIL_REQUIRED.isdisjoint(active)
+
+    res = client.post("/api/validate", json=d)
+    assert res.status_code == 200
+    missing = _tail_missing_errors(res.json()["errors"])
+    assert not missing, f"tail values must satisfy required params via API path: {missing}"
+
+
+def test_validate_project_survives_reconstruction():
+    """The multi-file path the live editor renders from."""
+    body = {"config_files": [
+        _config_dict("[include stepper_b_c.cfg]\n" + MPMD_TEXT.replace(
+            "[stepper_b]", "#[stepper_b]", 1).replace("[stepper_c]", "#[stepper_c]", 1
+        ), "printer.cfg"),
+        _config_dict(
+            "[stepper_b]\nstep_pin: PB2\ndir_pin: PB1\nenable_pin: !PB10\n"
+            "microsteps: 16\nrotation_distance: 56\nendstop_pin: ^PC13\n\n"
+            "[stepper_c]\nstep_pin: PB0\ndir_pin: PC5\nenable_pin: !PB10\n"
+            "microsteps: 16\nrotation_distance: 56\nendstop_pin: ^PC4\n",
+            "stepper_b_c.cfg",
+        ),
+    ]}
+    res = client.post("/api/validate-project", json=body)
+    assert res.status_code == 200
+    files = res.json()["files"]
+    for fname, validation in files.items():
+        missing = _tail_missing_errors(validation["errors"])
+        assert not missing, f"{fname}: tail values lost in project reconstruction: {missing}"
+
+
+def test_missing_required_still_errors_when_no_tail():
+    """Positive control: without a tail the same config MUST still error —
+    the fix must not blind the required-param checks."""
+    text = MPMD_TEXT.split("#*#")[0]
+    res = client.post("/api/validate", json=_config_dict(text))
+    assert res.status_code == 200
+    missing = _tail_missing_errors(res.json()["errors"])
+    assert {e["param"] for e in missing} == TAIL_REQUIRED, missing


### PR DESCRIPTION
## Summary
Four commits vs `main`:

- **fix(validation): strip whitespace before polarity prefix in pin normalization** — 247a18d
- **fix(installer): self-heal Mainsail sidebar entry at service startup** — ba156d0
- **fix(validation): four shared-pin/pin-chip false positives from klipper_backup audit** — 4892884
- **fix(validation): seven false-positive classes from the klipper/config examples sweep** — e3768c3

## Validation FP fixes (4892884, e3768c3)
Driven by two audit sweeps against real-world configs:

- `klipper_backup` audit → fixed probe-chip family, shadowed duplicate-section pins, dead TMC `diag_pin`, `gear_ratio` FPs.
- `klipper/config` examples sweep (228 stock configs) → fixed custom `[thermistor]` sensor_type, TMC→manual_stepper full-header, chained TMC2130/2240/5160 shared `cs_pin` + chain hard-fail checks, `max_angular_velocity`, `endstop_accuracy` float, temperature_sensor I2C, dac084S085 FPs.

Re-sweep harness reports **zero FPs** across the 228 stock configs (remaining items are known upstream stock bugs / deferred).

## Mainsail sidebar (ba156d0)
Self-heals the Mainsail sidebar entry at service startup instead of requiring manual re-add.

## Tests
New coverage: `tests/test_examples_sweep_fixes_2026_09.py`, `tests/test_pin_false_positives_2026_09.py`, `tests/test_mainsail_sidebar.py`, `tests/test_pin_mcu_membership.py`.

**Not merged yet — review in progress.**