### PR TITLE
feat(ai-chat): live-context MCP tools + server-side merged-result validation, repair, audit

### DIFF
--- a/backend/api/ai_routes.py
+++ b/backend/api/ai_routes.py
@@ -585,9 +585,12 @@ _MCP_TOOL_SNIPPETS: dict[str, str] = {
     "search_example_configs": "Search example configs by board or printer (query='voron', limit=N)",
     "read_example_config": "Read a full example config file (filename='generic-....cfg')",
     "validate_klipper_config": (
-        "Validate a config draft YOU wrote (config_text='...' required) — "
-        "for a section/snippet in your reply, not the user's saved files; "
-        "use validate_config_project to check what's actually on disk"
+        "VERIFY config TEXT for errors (config_text='...' required) — "
+        "'check this for errors' / 'is this section correct' about ANY "
+        "config text you can see, pasted by the user or written by you: "
+        "required params, types, ranges. A schema or reference list CANNOT "
+        "check text — never approve config text from a listing alone. For "
+        "the user's saved files use validate_config_project"
     ),
     "validate_macro": (
         "Validate a gcode_macro against Klipper's Jinja rules (macro_text='...' required)"
@@ -609,12 +612,13 @@ _MCP_TOOL_SNIPPETS: dict[str, str] = {
         "lines and 'which board is plugged in?'"
     ),
     "get_section_schema": (
-        "VERIFY a section's allowed parameters against the schema "
+        "LIST a section's allowed parameters from the schema "
         "(section='bed_mesh' or sections=['extruder','gcode_arcs']): types, "
-        "defaults, required flags, enum values, numeric bounds. Call BEFORE "
-        "adding or editing a section's parameters — this is the fast check "
-        "for WHICH params and values are legal; get_config_reference_section "
-        "only for prose explanations and examples"
+        "defaults, required flags, enum values, numeric bounds. Use to "
+        "learn WHICH params/values are legal BEFORE writing a new section; "
+        "it cannot check text — for 'is this config correct?' use "
+        "validate_klipper_config; get_config_reference_section only for "
+        "prose explanations and examples"
     ),
     "get_klippy_status": (
         "Get Klipper's live state (ready / startup error / shutdown), the "

--- a/backend/api/ai_routes.py
+++ b/backend/api/ai_routes.py
@@ -594,9 +594,12 @@ _MCP_TOOL_SNIPPETS: dict[str, str] = {
     "validate_config_project": (
         "Validate the user's CURRENT config project on this host (all files, "
         "includes expanded) against the full schema — errors/warnings/infos "
-        "with file+line. No args validates everything; filenames=['printer.cfg'] "
-        "for a subset. Use for 'is my config OK?' and before advising "
-        "FIRMWARE_RESTART; validate_klipper_config is for drafts you wrote"
+        "with file+line. Call this for 'validate/check/review my config', "
+        "'is my config OK?', 'what's wrong with my config' — instead of "
+        "reading config files and judging by eye. No args validates "
+        "everything; filenames=['printer.cfg'] for a subset. Use before "
+        "advising FIRMWARE_RESTART; validate_klipper_config is for drafts "
+        "you wrote"
     ),
     "list_connected_devices": (
         "List USB serial (/dev/serial/by-id paths for [mcu] serial:), UART, "

--- a/backend/api/ai_routes.py
+++ b/backend/api/ai_routes.py
@@ -12,7 +12,7 @@ import httpx
 from fastapi import APIRouter
 from pydantic import BaseModel
 
-from api.printer_memory_routes import (
+from api.printer_memory_routes import (  # noqa: E402
     load_printer_memory,
     printer_memory_to_context,
     is_printer_memory_blank,
@@ -349,6 +349,14 @@ class ChatRequest(BaseModel):
     # a flip changes acceptance AND prompt together. The harness sends this
     # via --full-rewrite-guard for A/B runs.
     fullRewriteGuard: bool = False
+    # Server-side merged-result validation + ONE lean repair pass (#1).
+    # Backend-only switch (env KWC_SERVER_DRAFT_VALIDATION=1): the frontend
+    # never sends this. When enabled, the backend applies the final reply to
+    # contextFiles, validates the MERGED result with the project validator,
+    # and — if new errors appeared — issues exactly one REPAIR-01-shaped
+    # lean repair query instead of relying on the frontend 3-attempt loop.
+    # Disabled (default) keeps the fenced-cfg path byte-identical.
+    serverDraftValidation: bool = False
 
 
 class ChatStopRequest(BaseModel):
@@ -967,6 +975,27 @@ def _minimal_prompt_enabled() -> bool:
     with the env var set, then run the accuracy harness.
     """
     return os.environ.get("KWC_MINIMAL_PROMPT", "0") != "0"
+
+
+def _server_draft_validation_enabled() -> bool:
+    """Server-side merged-result validation + ONE repair pass toggle.
+
+    Env KWC_SERVER_DRAFT_VALIDATION=1 enables the backend apply→validate→
+    one-lean-repair harness (#1). Default OFF: the frontend retry loop stays
+    the only validation path until the A/B harness (REPAIR gate on the
+    accuracy bank) says otherwise.
+    """
+    return os.environ.get("KWC_SERVER_DRAFT_VALIDATION", "0") != "0"
+
+
+def _server_audit_enabled() -> bool:
+    """Deterministic post-apply audit footer toggle (#3).
+
+    Env KWC_POST_APPLY_AUDIT=1. Default OFF for byte-identical rollout; the
+    frontend's ChatMessageList strips no markup so the audit footer renders
+    as a visible note. Only replies that touched config get audited.
+    """
+    return os.environ.get("KWC_POST_APPLY_AUDIT", "0") != "0"
 
 
 def _config_fallback_enabled() -> bool:
@@ -1863,6 +1892,226 @@ async def list_models(req: ModelsRequest):
     return {"models": ids}
 
 
+# ── Server-side merged-result validation + ONE lean repair (#1) ───────
+#
+# When KWC_SERVER_DRAFT_VALIDATION=1, after the tool loop produces a final
+# reply the backend applies it to the loaded context files (ported merge
+# engine, services/ai_draft_apply), validates the MERGED result with the
+# project validator, and — when new errors appear (delta vs baseline, same
+# semantics as the frontend's collectNewValidationErrors) — issues exactly
+# ONE REPAIR-01-shaped repair query (lean: error + imperative fix, previous
+# reply never quoted). If the repair reply validates, it replaces the
+# original; otherwise the ORIGINAL reply stands and `serverRepair` reports
+# the failure so the frontend loop (or the user) can act. The reply is
+# never rejected outright — Apply & Review remains the user's gate.
+#
+# The deterministic audit (#3, services/ai_reply_audit) runs unconditionally
+# (flag-gated only) on every reply that changed config: stated-requirement
+# check, macro precondition table, LED inventory sweep. Notes attach as a
+# footer; they never change routing or acceptance.
+
+def _context_files_to_config_files(context_files: dict[str, dict[str, str]]) -> dict:
+    """Convert the frontend contextFiles payload to parseable ConfigFiles."""
+    from parser.config_parser import parse_config
+
+    configs = {}
+    for filename, meta in context_files.items():
+        content = (meta or {}).get("content", "")
+        if not content.strip():
+            continue
+        try:
+            configs[filename] = parse_config(content, filename)
+        except Exception:
+            logger.warning("Context file parse failed | file=%s", filename)
+    return configs
+
+
+async def _server_validate_and_repair(
+    client: httpx.AsyncClient,
+    req: ChatRequest,
+    headers: dict,
+    final_content: str,
+    current_messages: list[dict],
+    usage_events: list[dict],
+    stop_event: "asyncio.Event | None",
+) -> tuple[str, dict | None]:
+    """Apply → validate merged → ONE lean repair. Returns (content, info).
+
+    ``info`` is the ``serverRepair`` response field: ``None`` when nothing
+    needed repair / repair was not possible (no context files), else a dict
+    ``{attempted, repaired, issuesAfter}``.
+    """
+    from services.ai_draft_apply import apply_reply_to_configs
+    from services.ai_draft_validation import (
+        build_validation_feedback,
+        collect_new_validation_errors,
+        has_only_retry_exempt_issues,
+        suppress_errors_shadowed_by_full_rewrite,
+    )
+    from services.ai_reply_audit import build_audit_footer, run_post_apply_audit
+    from parser.validator import validate_project_configs
+
+    base_configs = _context_files_to_config_files(req.contextFiles)
+    if not base_configs:
+        return final_content, None
+
+    apply_result = apply_reply_to_configs(final_content, base_configs)
+    merged_files = {
+        filename: entry["merged_config"]
+        for filename, entry in apply_result["files"].items()
+    }
+    if not merged_files:
+        # Prose-only reply or apply failure — nothing merged to validate.
+        return final_content, None
+
+    # Baseline = the untouched project; candidate = base with merged files.
+    project = dict(base_configs)
+    project.update(merged_files)
+    baseline_validations = {
+        filename: result.to_dict()
+        for filename, result in validate_project_configs(base_configs).items()
+    }
+    candidate_validations = {
+        filename: result.to_dict()
+        for filename, result in validate_project_configs(project).items()
+    }
+    blocking = suppress_errors_shadowed_by_full_rewrite(
+        collect_new_validation_errors(baseline_validations, candidate_validations)
+    )
+    if not blocking:
+        # Clean apply: run the deterministic audit and attach its footer.
+        notes = _run_audit_on_apply(
+            req, apply_result, merged_files, project,
+            run_post_apply_audit,
+        )
+        if notes:
+            final_content = final_content + build_audit_footer(notes)
+        return final_content, {"attempted": False, "repaired": False, "issuesAfter": []}
+
+    if not _server_draft_validation_enabled():
+        # Audit-only mode (KWC_POST_APPLY_AUDIT without validation): the
+        # deterministic notes still apply; repair stays off.
+        notes = _run_audit_on_apply(
+            req, apply_result, merged_files, project, run_post_apply_audit,
+        )
+        if notes:
+            final_content = final_content + build_audit_footer(notes)
+        return final_content, None
+
+    if has_only_retry_exempt_issues(blocking):
+        # The model cannot fix duplicates/reused pins by regenerating —
+        # do not burn a repair query (retry-exempt semantics).
+        return final_content, {
+            "attempted": False,
+            "repaired": False,
+            "issuesAfter": blocking,
+            "reason": "retry-exempt",
+        }
+
+    # ── ONE lean repair (REPAIR-01 shape) ──
+    feedback = build_validation_feedback(blocking, None)
+    repair_messages = list(current_messages) + [
+        {"role": "user", "content": feedback},
+    ]
+    repair_max_tokens = req.maxTokens
+    if _is_local_provider(req.apiProvider, req.apiUrl):
+        repair_max_tokens = max(req.maxTokens, EMPTY_REPROMPT_MAX_TOKENS)
+    logger.info(
+        "Server repair | issuing ONE lean repair (issue_groups=%d)", len(blocking),
+    )
+    try:
+        repair_payload = _build_provider_payload(
+            req.apiProvider, repair_messages, req.model,
+            max_tokens=repair_max_tokens,
+            temperature=req.temperature,
+            tools=_resolve_native_tools(req.apiProvider, req.apiUrl, req.toolProtocol),
+            merge_system=req.mergeSystemMessages,
+        )
+        repair_content, repair_data = await _query_provider(
+            client, req.apiUrl, headers, repair_payload, req.apiProvider,
+            logger_context="server-repair-1",
+            stop_event=stop_event,
+        )
+        repair_usage = _extract_usage_info(repair_data)
+        if repair_usage:
+            repair_usage["context"] = "server-repair-1"
+            usage_events.append(repair_usage)
+    except ChatStoppedError:
+        raise
+    except (ValueError, httpx.HTTPError) as exc:
+        logger.warning("Server repair query failed | %s", exc)
+        return final_content, {"attempted": True, "repaired": False, "issuesAfter": blocking}
+
+    repair_clean = final_content  # fallback keeps original
+    repaired_content = repair_content
+    for pattern in (
+        MCP_TOOL_BLOCK_RE, ALT_TOOL_CALL_CONTENT_RE, CALL_SYNTAX_CLEANUP_RE,
+        FUNC_CALL_CLEANUP_RE, DSML_CLEANUP_RE, XML_TOOL_CALLS_CLEANUP_RE,
+    ):
+        repaired_content = pattern.sub("", repaired_content).strip()
+    repaired_content = _strip_bracket_tool_calls(repaired_content).strip()
+
+    if repaired_content:
+        repair_apply = apply_reply_to_configs(repaired_content, base_configs)
+        repair_merged = {
+            filename: entry["merged_config"]
+            for filename, entry in repair_apply["files"].items()
+        }
+        if repair_merged:
+            repair_project = dict(base_configs)
+            repair_project.update(repair_merged)
+            repair_candidate = {
+                filename: result.to_dict()
+                for filename, result in validate_project_configs(repair_project).items()
+            }
+            repair_blocking = suppress_errors_shadowed_by_full_rewrite(
+                collect_new_validation_errors(baseline_validations, repair_candidate)
+            )
+            if not repair_blocking:
+                notes = _run_audit_on_apply(
+                    req, repair_apply, repair_merged, repair_project,
+                    run_post_apply_audit,
+                )
+                if notes:
+                    repaired_content = repaired_content + build_audit_footer(notes)
+                logger.info("Server repair | repaired=1")
+                return repaired_content, {
+                    "attempted": True, "repaired": True, "issuesAfter": [],
+                }
+            # Repair still dirty: keep the ORIGINAL reply (never show a
+            # worse one) but report the exact remaining issues.
+            return repair_clean, {
+                "attempted": True, "repaired": False, "issuesAfter": repair_blocking,
+            }
+
+    return final_content, {"attempted": True, "repaired": False, "issuesAfter": blocking}
+
+
+def _run_audit_on_apply(req, apply_result, merged_files, project, audit_fn) -> list[str]:
+    """Collect the audit inputs from an apply result and run all checks."""
+    changed_headers: list[str] = []
+    changed_gcode: list[tuple[str, str]] = []
+    for entry in apply_result["files"].values():
+        for change in entry["changes"]:
+            header = change.get("fullHeader", "")
+            if header and header not in changed_headers:
+                changed_headers.append(header)
+        merged_cfg = entry["merged_config"]
+        for section in merged_cfg.sections:
+            if section.full_header in changed_headers and section.section_type == "gcode_macro":
+                body = section.get_value("gcode", "")
+                if body:
+                    changed_gcode.append((section.full_header, body))
+    if not changed_headers:
+        return []
+    return audit_fn(
+        _latest_user_message_text(req.messages),
+        project,
+        changed_gcode,
+        changed_headers,
+    )
+
+
 @router.post("/ai/chat")
 async def chat_proxy(req: ChatRequest):
     """Proxy chat messages to the user's configured API provider."""
@@ -2273,6 +2522,31 @@ async def chat_proxy(req: ChatRequest):
             if not mcp_tool_names and executed_tool_names:
                 mcp_tool_names = list(dict.fromkeys(executed_tool_names))
 
+            # ── Server-side merged-result validation + ONE lean repair (#1) ──
+            # Flag-gated (KWC_SERVER_DRAFT_VALIDATION=1). Needs the loaded
+            # config content (contextFiles); replies that merge cleanly get
+            # the deterministic audit footer (#3) when KWC_POST_APPLY_AUDIT=1.
+            # The frontend fenced-cfg path is untouched: worst case the reply
+            # stands as-is and `serverRepair` reports what happened.
+            server_repair_info = None
+            server_audit_enabled = _server_audit_enabled()
+            if (
+                final_content
+                and (
+                    _server_draft_validation_enabled()
+                    or server_audit_enabled
+                )
+            ):
+                try:
+                    final_content, server_repair_info = await _server_validate_and_repair(
+                        client, req, headers, final_content,
+                        current_messages, usage_events, stop_event,
+                    )
+                except ChatStoppedError:
+                    raise
+                except Exception:
+                    logger.exception("Server draft validation failed | replying unchanged")
+
             logger.info(
                 "Returning response | final_chars=%d tool_turns=%d tools=%s empty=%s",
                 len(final_content), tool_turns,
@@ -2298,6 +2572,11 @@ async def chat_proxy(req: ChatRequest):
                 "mcpToolNames": mcp_tool_names,
                 "toolCalls": executed_tool_calls,
                 "repromptCount": empty_reprompts,
+                # Set when KWC_SERVER_DRAFT_VALIDATION ran ({attempted,
+                # repaired, issuesAfter[, reason]}); null otherwise. The
+                # frontend may use it to skip its own retry loop when the
+                # server already repaired the reply.
+                "serverRepair": server_repair_info,
                 "usage": {
                     "completionTokens": sum(
                         (e.get("completionTokens") or 0) for e in usage_events

--- a/backend/api/ai_routes.py
+++ b/backend/api/ai_routes.py
@@ -588,6 +588,34 @@ _MCP_TOOL_SNIPPETS: dict[str, str] = {
     "validate_macro": (
         "Validate a gcode_macro against Klipper's Jinja rules (macro_text='...' required)"
     ),
+    "validate_config_project": (
+        "Validate the user's CURRENT config project on this host (all files, "
+        "includes expanded) against the full schema — errors/warnings/infos "
+        "with file+line. No args validates everything; filenames=['printer.cfg'] "
+        "for a subset. Use for 'is my config OK?' and before advising "
+        "FIRMWARE_RESTART; validate_klipper_config is for drafts you wrote"
+    ),
+    "list_connected_devices": (
+        "List USB serial (/dev/serial/by-id paths for [mcu] serial:), UART, "
+        "and CAN devices on this host, with CAN UUIDs from canbus_query "
+        "(scan_can_uuids=false skips the bus scan). Use for serial:/canbus_uuid "
+        "lines and 'which board is plugged in?'"
+    ),
+    "get_section_schema": (
+        "Get a section's exact allowed parameters from the schema "
+        "(section='bed_mesh' or sections=['extruder','gcode_arcs']): types, "
+        "defaults, required flags, enum values, numeric bounds — use to check "
+        "WHICH params a section accepts; get_config_reference_section for "
+        "explanations"
+    ),
+    "get_klippy_status": (
+        "Get Klipper's live state (ready / startup error / shutdown), the "
+        "active print job, and klippy.log error context (attached "
+        "automatically when not ready; include_log_excerpt=true with optional "
+        "section_name/error_text forces it while ready). Call BEFORE "
+        "recommending FIRMWARE_RESTART — it warns if a print would be "
+        "interrupted"
+    ),
     "generate_macro_template": (
         "Generate a ready-to-use macro template (macro_name='PRINT_START'|'PRINT_END'|"
         "'PAUSE'|'RESUME'|'CANCEL_PRINT'; include_bed_mesh option)"

--- a/backend/api/ai_routes.py
+++ b/backend/api/ai_routes.py
@@ -2119,10 +2119,12 @@ async def _server_validate_and_repair(
         collect_new_validation_errors(baseline_validations, candidate_validations)
     )
     if not blocking:
-        # Clean apply: run the deterministic audit and attach its footer.
-        notes = _run_audit_on_apply(
-            req, apply_result, merged_files, project,
-            run_post_apply_audit,
+        # Clean apply: run the deterministic audit (ONLY when its own flag
+        # is on — the outer gate lets us in for validation alone) and
+        # attach its footer.
+        notes = (
+            _run_audit_on_apply(req, apply_result, merged_files, project, run_post_apply_audit)
+            if _server_audit_enabled() else []
         )
         if notes:
             final_content = final_content + build_audit_footer(notes)
@@ -2131,8 +2133,9 @@ async def _server_validate_and_repair(
     if not _server_draft_validation_enabled():
         # Audit-only mode (KWC_POST_APPLY_AUDIT without validation): the
         # deterministic notes still apply; repair stays off.
-        notes = _run_audit_on_apply(
-            req, apply_result, merged_files, project, run_post_apply_audit,
+        notes = (
+            _run_audit_on_apply(req, apply_result, merged_files, project, run_post_apply_audit)
+            if _server_audit_enabled() else []
         )
         if notes:
             final_content = final_content + build_audit_footer(notes)
@@ -2208,9 +2211,9 @@ async def _server_validate_and_repair(
                 collect_new_validation_errors(baseline_validations, repair_candidate)
             )
             if not repair_blocking:
-                notes = _run_audit_on_apply(
-                    req, repair_apply, repair_merged, repair_project,
-                    run_post_apply_audit,
+                notes = (
+                    _run_audit_on_apply(req, repair_apply, repair_merged, repair_project, run_post_apply_audit)
+                    if _server_audit_enabled() else []
                 )
                 if notes:
                     repaired_content = repaired_content + build_audit_footer(notes)

--- a/backend/api/ai_routes.py
+++ b/backend/api/ai_routes.py
@@ -2233,10 +2233,13 @@ def _run_audit_on_apply(req, apply_result, merged_files, project, audit_fn) -> l
                 changed_headers.append(header)
         merged_cfg = entry["merged_config"]
         for section in merged_cfg.sections:
-            if section.full_header in changed_headers and section.section_type == "gcode_macro":
-                body = section.get_value("gcode", "")
-                if body:
-                    changed_gcode.append((section.full_header, body))
+            # Any section with a gcode param: gcode_macro/delayed_gcode AND
+            # idle_timeout/force_move etc. — the idle_timeout LED class
+            # (#TRIDENT-15) lives on [idle_timeout], not a macro.
+            body = (section.get_value("gcode", "")
+                    if section.full_header in changed_headers else "")
+            if body:
+                changed_gcode.append((section.full_header, body))
     if not changed_headers:
         return []
     return audit_fn(

--- a/backend/api/ai_routes.py
+++ b/backend/api/ai_routes.py
@@ -327,6 +327,11 @@ class ChatRequest(BaseModel):
     # server-side only — it is NOT injected into the first prompt; the
     # fallback uses it when the model answers without calling any tool.
     contextFiles: dict[str, dict[str, str]] = {}
+    # The editor's active file, mirroring the frontend draft pipeline's
+    # activeFile input to buildAssistantDraftTargetConfigs (finding #5).
+    # Used ONLY for server-side merged-result target resolution when the
+    # reply carries no explicit '# file:' hint; never injected into prompts.
+    activeFile: str = ''
     # Tool-calling protocol override (harness A/B runs). "auto" keeps the
     # provider-based split (local http -> text ```tool protocol, cloud
     # https -> native function calling); "native" forces OpenAI native
@@ -355,13 +360,11 @@ class ChatRequest(BaseModel):
     # via --full-rewrite-guard for A/B runs.
     fullRewriteGuard: bool = False
     # Server-side merged-result validation + ONE lean repair pass (#1).
-    # Backend-only switch (env KWC_SERVER_DRAFT_VALIDATION=1): the frontend
-    # never sends this. When enabled, the backend applies the final reply to
-    # contextFiles, validates the MERGED result with the project validator,
-    # and — if new errors appeared — issues exactly one REPAIR-01-shaped
-    # lean repair query instead of relying on the frontend 3-attempt loop.
-    # Disabled (default) keeps the fenced-cfg path byte-identical.
-    serverDraftValidation: bool = False
+    # Server-side draft validation/audit are backend-only env switches
+    # (KWC_SERVER_DRAFT_VALIDATION / KWC_POST_APPLY_AUDIT) — deliberately
+    # NOT request fields: per-request control would let a compromised UI
+    # toggle the harness off. (Review finding #3: the old
+    # serverDraftValidation field here was never read and never sent.)
 
 
 class ChatStopRequest(BaseModel):
@@ -1274,9 +1277,12 @@ def _parse_kwargs(args_text: str) -> dict:
 
 # Unterminated ```tool fence: the model opened a tool block and the stream
 # ended (or it forgot the closing fence). Such a fence is never legitimate
-# content — everything after it is part of the broken call.
+# content. Bounded at the first BLANK line (review finding #11): fence
+# bodies never contain blank lines, but qwen-class models sometimes open a
+# broken fence and then recover with real prose — consuming to
+# end-of-content silently deleted that answer.
 UNTERMINATED_TOOL_FENCE_RE = re.compile(
-    r"```tool\b(?:(?!```)[\s\S])*$"
+    r"```tool\b(?:[^\n]*\n)?(?:(?!```)[^\n]+\n)*(?:(?!```)[^\n]*$)?"
 )
 # Python-call form inside a ```tool fence: name(k=v, ...) / call name(...).
 _FENCED_PY_CALL_RE = re.compile(
@@ -1442,7 +1448,13 @@ def _recover_tool_call(token: str, args_text: str) -> tuple[str, dict] | None:
 
 
 def _execute_tool_call(tool_call: dict) -> str:
-    """Execute a single MCP tool call and return the text result."""
+    """Execute a single MCP tool call and return the text result.
+
+    SYNC — some handlers (list_connected_devices, get_klippy_status) do
+    blocking host I/O for seconds. From the async chat loop call
+    _execute_tool_call_async instead; direct calls are for sync contexts
+    only (tests).
+    """
     name = tool_call.get("name", "")
     arguments = tool_call.get("arguments", {})
 
@@ -1471,6 +1483,17 @@ def _execute_tool_call(tool_call: dict) -> str:
         item["text"] for item in content if item.get("type") == "text"
     ]
     return "\n\n".join(text_parts) if text_parts else "Tool returned no content."
+
+
+async def _execute_tool_call_async(tool_call: dict) -> str:
+    """Off-thread wrapper for the chat loop (review finding #14).
+
+    list_connected_devices runs CAN/USB scans and get_klippy_status probes
+    host endpoints; both block for seconds. Running them inline froze the
+    event loop — every other request (health checks, saves, other chats)
+    stalled behind one tool call. asyncio.to_thread keeps the loop free.
+    """
+    return await asyncio.to_thread(_execute_tool_call, tool_call)
 
 
 # Client-facing tool-call detail records are capped so a huge tool output
@@ -2081,7 +2104,10 @@ async def _server_validate_and_repair(
     needed repair / repair was not possible (no context files), else a dict
     ``{attempted, repaired, issuesAfter}``.
     """
-    from services.ai_draft_apply import apply_reply_to_configs
+    from services.ai_draft_apply import (
+        MAX_ASSISTANT_HINT_USER_MESSAGES,
+        apply_reply_to_configs,
+    )
     from services.ai_draft_validation import (
         build_validation_feedback,
         collect_new_validation_errors,
@@ -2095,7 +2121,22 @@ async def _server_validate_and_repair(
     if not base_configs:
         return final_content, None
 
-    apply_result = apply_reply_to_configs(final_content, base_configs)
+    # Mirror useAssistantDraft.getAssistantMessageHintTexts: the reply plus
+    # up to 3 preceding user messages, so file targets named only by the
+    # user resolve to the same file the client's draft pipeline picks
+    # (finding #5).
+    user_hints = [
+        m.get("content", "")
+        for m in req.messages
+        if m.get("role") == "user" and m.get("content")
+    ][-MAX_ASSISTANT_HINT_USER_MESSAGES:]
+    hint_texts = [final_content, *user_hints]
+
+    apply_result = apply_reply_to_configs(
+        final_content, base_configs,
+        active_file=req.activeFile or None,
+        hint_texts=hint_texts,
+    )
     merged_files = {
         filename: entry["merged_config"]
         for filename, entry in apply_result["files"].items()
@@ -2185,7 +2226,6 @@ async def _server_validate_and_repair(
         logger.warning("Server repair query failed | %s", exc)
         return final_content, {"attempted": True, "repaired": False, "issuesAfter": blocking}
 
-    repair_clean = final_content  # fallback keeps original
     repaired_content = repair_content
     for pattern in (
         MCP_TOOL_BLOCK_RE, ALT_TOOL_CALL_CONTENT_RE, CALL_SYNTAX_CLEANUP_RE,
@@ -2195,7 +2235,11 @@ async def _server_validate_and_repair(
     repaired_content = _strip_bracket_tool_calls(repaired_content).strip()
 
     if repaired_content:
-        repair_apply = apply_reply_to_configs(repaired_content, base_configs)
+        repair_apply = apply_reply_to_configs(
+            repaired_content, base_configs,
+            active_file=req.activeFile or None,
+            hint_texts=[repaired_content, *user_hints],
+        )
         repair_merged = {
             filename: entry["merged_config"]
             for filename, entry in repair_apply["files"].items()
@@ -2223,7 +2267,7 @@ async def _server_validate_and_repair(
                 }
             # Repair still dirty: keep the ORIGINAL reply (never show a
             # worse one) but report the exact remaining issues.
-            return repair_clean, {
+            return final_content, {
                 "attempted": True, "repaired": False, "issuesAfter": repair_blocking,
             }
 
@@ -2524,7 +2568,7 @@ async def chat_proxy(req: ChatRequest):
                 # follow-up messages in the format the provider expects.
                 results = []
                 for tool_call in tool_calls[:MAX_MCP_TOOL_TURNS]:
-                    result_text = _execute_tool_call(tool_call)
+                    result_text = await _execute_tool_call_async(tool_call)
                     logger.info(
                         "Tool executed | name=%s result_chars=%d",
                         tool_call["name"], len(result_text),
@@ -2687,9 +2731,13 @@ async def chat_proxy(req: ChatRequest):
                     clean_assistant = XML_TOOL_CALLS_CLEANUP_RE.sub("", clean_assistant).strip()
                     if clean_assistant:
                         current_messages.append({"role": "assistant", "content": clean_assistant})
+                    reprompt_results = [
+                        await _execute_tool_call_async(c)
+                        for c in reprompt_calls[:MAX_MCP_TOOL_TURNS]
+                    ]
                     for reprompt_call, result_text in zip(
                         reprompt_calls[:MAX_MCP_TOOL_TURNS],
-                        [_execute_tool_call(c) for c in reprompt_calls[:MAX_MCP_TOOL_TURNS]],
+                        reprompt_results,
                     ):
                         executed_tool_names.append(reprompt_call["name"])
                         executed_tool_calls.append(

--- a/backend/api/ai_routes.py
+++ b/backend/api/ai_routes.py
@@ -997,11 +997,16 @@ def _server_draft_validation_enabled() -> bool:
 def _server_audit_enabled() -> bool:
     """Deterministic post-apply audit footer toggle (#3).
 
-    DEFAULTS TO ENABLED (same 2026-09-09 A/B: footers appeared only on
-    config-touching replies and only with real observations — zero noise
-    across 138 replies). Set env KWC_POST_APPLY_AUDIT=0 to disable.
+    DEFAULTS TO DISABLED (2026-09-10 design review): the stated-requirement
+    regex parses English prose, which fails Sir's standing bar — harness-tier
+    checks must parse structure (AST/config), not prose. Checks 2/3
+    (precondition table, LED inventory) are structural but ship together with
+    check 1; the whole module is scheduled for removal when tool-mediated
+    editing lands (see .hermes/plans/2026-09-10_tool-mediated-config-editing.md,
+    Phase 6). Set env KWC_POST_APPLY_AUDIT=1 to re-enable (harness probes
+    HARNESS-01..03 and dogfooding still work with it on).
     """
-    return os.environ.get("KWC_POST_APPLY_AUDIT", "1") != "0"
+    return os.environ.get("KWC_POST_APPLY_AUDIT", "0") == "1"
 
 
 def _config_fallback_enabled() -> bool:

--- a/backend/api/ai_routes.py
+++ b/backend/api/ai_routes.py
@@ -585,8 +585,9 @@ _MCP_TOOL_SNIPPETS: dict[str, str] = {
     "search_example_configs": "Search example configs by board or printer (query='voron', limit=N)",
     "read_example_config": "Read a full example config file (filename='generic-....cfg')",
     "validate_klipper_config": (
-        "Validate config section block against the klipper config rules "
-        "(config_text='...' required)"
+        "Validate a config draft YOU wrote (config_text='...' required) — "
+        "for a section/snippet in your reply, not the user's saved files; "
+        "use validate_config_project to check what's actually on disk"
     ),
     "validate_macro": (
         "Validate a gcode_macro against Klipper's Jinja rules (macro_text='...' required)"

--- a/backend/api/ai_routes.py
+++ b/backend/api/ai_routes.py
@@ -1079,8 +1079,14 @@ def _extract_tool_calls(text: str) -> list[dict]:
         try:
             parsed = json.loads(raw_json)
         except json.JSONDecodeError:
-            continue
+            parsed = None
         if not isinstance(parsed, dict):
+            # Broken JSON inside an explicit tool fence — attempt mechanical
+            # recovery (python-call form, smart/single quotes) before giving
+            # up. The fence is unambiguous tool intent, not prose.
+            recovered_call = _recover_fenced_tool_call(raw_json)
+            if recovered_call:
+                calls.append(recovered_call)
             continue
         name = parsed.get("name", "")
         arguments = parsed.get("arguments", {})
@@ -1247,6 +1253,123 @@ def _parse_kwargs(args_text: str) -> dict:
         arg_value = arg_match.group(2).strip().strip('"').strip("'")
         arguments[arg_name] = arg_value
     return arguments
+
+
+# Unterminated ```tool fence: the model opened a tool block and the stream
+# ended (or it forgot the closing fence). Such a fence is never legitimate
+# content — everything after it is part of the broken call.
+UNTERMINATED_TOOL_FENCE_RE = re.compile(
+    r"```tool\b(?:(?!```)[\s\S])*$"
+)
+# Python-call form inside a ```tool fence: name(k=v, ...) / call name(...).
+_FENCED_PY_CALL_RE = re.compile(
+    r"^(?:call[\s:]?\s*)?(\w+)\s*\((.*)\)\s*$",
+    re.DOTALL,
+)
+# Brace-call form inside a ```tool fence: name{k=v, ...} / call name{...}.
+_FENCED_BRACE_CALL_RE = re.compile(
+    r"^(?:call[\s:]?\s*)?(\w+)\s*\{(.*)\}\s*$",
+    re.DOTALL,
+)
+
+
+def _recover_fenced_tool_call(raw_json: str) -> dict | None:
+    """Recover a tool call from a ```tool fence whose JSON failed to parse.
+
+    A ```tool fence is explicit tool-call intent, so repairs are scoped to
+    fence bodies ONLY (never guessed from prose, per the intent law). Small
+    models (qwen 4B class) produce three recurring breakage shapes here:
+    python-style ``name(k=v)``, single/smart-quoted pseudo-JSON, and
+    unescaped quotes inside values. All are mechanically recoverable.
+    """
+    # 1) Smart quotes → ASCII, then plain JSON retry.
+    normalized = (
+        raw_json.replace("\u201c", '"').replace("\u201d", '"')
+        .replace("\u2018", "'").replace("\u2019", "'")
+    )
+    if normalized != raw_json:
+        try:
+            parsed = json.loads(normalized)
+        except json.JSONDecodeError:
+            parsed = None
+        if isinstance(parsed, dict):
+            name = parsed.get("name", "")
+            arguments = parsed.get("arguments", {})
+            if isinstance(name, str) and name and isinstance(arguments, dict):
+                return {"name": name, "arguments": arguments}
+    # 2) Python call form: name(k=v, ...).
+    call_match = _FENCED_PY_CALL_RE.match(normalized.strip())
+    if call_match and call_match.group(1):
+        return {
+            "name": call_match.group(1),
+            "arguments": _parse_kwargs(call_match.group(2)),
+        }
+    # 3) Brace call form: name{k=v, ...}. The brace body may itself be
+    #    JSON (llama.cpp `call:tool{"name": ..., "arguments": {...}}`
+    #    decoration) — try that before treating it as bare kwargs.
+    brace_match = _FENCED_BRACE_CALL_RE.match(normalized.strip())
+    if brace_match and brace_match.group(1):
+        try:
+            parsed = json.loads("{" + brace_match.group(2) + "}")
+        except json.JSONDecodeError:
+            parsed = None
+        if isinstance(parsed, dict):
+            name = parsed.get("name", "")
+            arguments = parsed.get("arguments", {})
+            if isinstance(name, str) and name and isinstance(arguments, dict):
+                return {"name": name, "arguments": arguments}
+        return {
+            "name": brace_match.group(1),
+            "arguments": _parse_kwargs(brace_match.group(2)),
+        }
+    # 4) Single-quoted pseudo-JSON (only when there are no double quotes to
+    #    protect): {"name": ...} with ' throughout.
+    if "'" in normalized and '"' not in normalized:
+        try:
+            parsed = json.loads(normalized.replace("'", '"'))
+        except json.JSONDecodeError:
+            parsed = None
+        if isinstance(parsed, dict):
+            name = parsed.get("name", "")
+            arguments = parsed.get("arguments", {})
+            if isinstance(name, str) and name and isinstance(arguments, dict):
+                return {"name": name, "arguments": arguments}
+    return None
+
+
+def _malformed_tool_call_detected(text: str, calls: list[dict]) -> bool:
+    """True when the reply contains tool-call intent that failed to parse.
+
+    Deterministic post-hoc detection over explicit ```tool protocol fences
+    only: a fence body that mentions a name/call shape but yielded no call,
+    or an unterminated ```tool fence (truncated stream). Prose that merely
+    mentions tools never triggers this.
+    """
+    if calls:
+        return False
+    for fence in MCP_TOOL_BLOCK_RE.finditer(text):
+        body = fence.group(1)
+        if re.search(r"\bname\b|\bcall\b|\w+\s*[({]", body):
+            return True
+    return bool(UNTERMINATED_TOOL_FENCE_RE.search(text))
+
+
+# One protocol-correction re-prompt for a malformed tool call. The broken
+# call is NEVER quoted (REPAIR-01: models copy broken drafts verbatim) —
+# the model only gets the exact format and a clean path back.
+MALFORMED_TOOL_REPROMPT_LIMIT = 1
+MALFORMED_TOOL_FORMAT_FEEDBACK = (
+    "Your previous response contained a tool call that could not be parsed, "
+    "so it was not executed. Do not copy or repeat your previous response. "
+    'To call a tool, respond with exactly one fenced block in this format:\n\n'
+    "```tool\n"
+    '{"name": "<tool_name>", "arguments": {"key": "value"}}\n'
+    "```\n\n"
+    'Use double quotes around every name and string value, keep the JSON on '
+    'valid one-line or multi-line form, and always close the fence. If you '
+    "no longer need a tool, answer the user's question directly in text "
+    "instead."
+)
 
 
 def _strip_bracket_tool_calls(text: str) -> str:
@@ -2185,6 +2308,9 @@ async def chat_proxy(req: ChatRequest):
             current_messages = list(messages)
             executed_tool_names: list[str] = []
             executed_tool_calls: list[dict] = []
+            # Re-prompts issued to correct a malformed ```tool fence (see the
+            # malformed tool-call guard in the loop below).
+            malformed_reprompts = 0
 
             # ── Config-grounding fallback (Phase 4) ──
             # If the model didn't call any tools on the first pass, inject the
@@ -2303,6 +2429,46 @@ async def chat_proxy(req: ChatRequest):
                 native_calls = _extract_native_tool_calls(req.apiProvider, current_data)
                 tool_calls = native_calls or _extract_tool_calls(current_content)
                 if not tool_calls:
+                    # ── Malformed tool-call guard ──
+                    # A ```tool fence that failed to parse (or an unterminated
+                    # fence) is unambiguous tool intent — without this, the
+                    # loop sees "no tool calls, non-empty text", stops, and
+                    # the raw broken markup leaks into the chat bubble. Issue
+                    # ONE format-correction re-prompt (never quoting the
+                    # broken call — REPAIR-01) instead of terminating.
+                    if (
+                        malformed_reprompts < MALFORMED_TOOL_REPROMPT_LIMIT
+                        and _malformed_tool_call_detected(current_content, tool_calls)
+                    ):
+                        malformed_reprompts += 1
+                        tool_turns += 1
+                        logger.warning(
+                            "Malformed tool call | re-prompting with format "
+                            "correction (%d/%d) preview=%s",
+                            malformed_reprompts, MALFORMED_TOOL_REPROMPT_LIMIT,
+                            current_content[:120].replace("\n", " "),
+                        )
+                        current_messages.append({
+                            "role": "user",
+                            "content": MALFORMED_TOOL_FORMAT_FEEDBACK,
+                        })
+                        malformed_payload = _build_provider_payload(
+                            req.apiProvider, current_messages, req.model,
+                            max_tokens=req.maxTokens,
+                            temperature=req.temperature,
+                            tools=native_tools,
+                            merge_system=req.mergeSystemMessages,
+                        )
+                        current_content, current_data = await _query_provider(
+                            client, req.apiUrl, headers, malformed_payload, req.apiProvider,
+                            logger_context=f"malformed-reprompt-{malformed_reprompts}",
+                            stop_event=stop_event,
+                        )
+                        malformed_usage = _extract_usage_info(current_data)
+                        if malformed_usage:
+                            malformed_usage["context"] = f"malformed-reprompt-{malformed_reprompts}"
+                            usage_events.append(malformed_usage)
+                        continue
                     if tool_turns > 0:
                         logger.info("Tool call loop done | turns=%d final_chars=%d", tool_turns, len(current_content))
                     break
@@ -2404,6 +2570,7 @@ async def chat_proxy(req: ChatRequest):
                 or FUNC_CALL_CLEANUP_RE.search(current_content)
                 or DSML_CLEANUP_RE.search(current_content)
                 or XML_TOOL_CALLS_CLEANUP_RE.search(current_content)
+                or UNTERMINATED_TOOL_FENCE_RE.search(current_content)
             )
             final_content = MCP_TOOL_BLOCK_RE.sub("", current_content).strip()
             final_content = ALT_TOOL_CALL_CONTENT_RE.sub("", final_content).strip()
@@ -2411,6 +2578,10 @@ async def chat_proxy(req: ChatRequest):
             final_content = FUNC_CALL_CLEANUP_RE.sub("", final_content).strip()
             final_content = _strip_bracket_tool_calls(final_content).strip()
             final_content = DSML_CLEANUP_RE.sub("", final_content).strip()
+            # An unterminated ```tool fence (truncated broken call) would
+            # otherwise leak raw markup into the bubble — it always extends
+            # to end of content, so a tail-strip is safe.
+            final_content = UNTERMINATED_TOOL_FENCE_RE.sub("", final_content).strip()
             # If the cleanup left nothing but the original was a tool call,
             # don't restore the raw tool call text — return empty instead.
             if not final_content and not had_tool_blocks:

--- a/backend/api/ai_routes.py
+++ b/backend/api/ai_routes.py
@@ -54,7 +54,12 @@ _mcp_server = McpServer()
 # Match fenced code blocks tagged ```tool ... ```
 # Captures the JSON payload which we parse with json.loads
 MCP_TOOL_BLOCK_RE = re.compile(
-    r"```tool\s*\n(.+?)\n```",
+    # The closing fence may sit on the SAME line as the JSON
+    # (`{"name": ...}```) — qwen3.5-4b does this constantly (observed live
+    # 2026-09-09 accuracy bank, LIVE-06/07). Requiring a newline before the
+    # closer made such calls undetectable AND un-strippable: raw markup
+    # reached the chat bubble. Consumers strip() the group themselves.
+    r"```tool\s*\n(.+?)```",
     re.DOTALL,
 )
 # A fenced ```printer-memory block signals a complete structured proposal —
@@ -980,22 +985,23 @@ def _minimal_prompt_enabled() -> bool:
 def _server_draft_validation_enabled() -> bool:
     """Server-side merged-result validation + ONE repair pass toggle.
 
-    Env KWC_SERVER_DRAFT_VALIDATION=1 enables the backend apply→validate→
-    one-lean-repair harness (#1). Default OFF: the frontend retry loop stays
-    the only validation path until the A/B harness (REPAIR gate on the
-    accuracy bank) says otherwise.
+    DEFAULTS TO ENABLED (2026-09-09 A/B: both flags ON across the full 69-q
+    bank on gemma-4-12b + qwen3.5-4b with zero false-positive repairs, zero
+    latency complaints, and the harness at its best gemma scores; repair and
+    audit paths verified unit-level + live smoke). Set env
+    KWC_SERVER_DRAFT_VALIDATION=0 to revert to the frontend-only retry path.
     """
-    return os.environ.get("KWC_SERVER_DRAFT_VALIDATION", "0") != "0"
+    return os.environ.get("KWC_SERVER_DRAFT_VALIDATION", "1") != "0"
 
 
 def _server_audit_enabled() -> bool:
     """Deterministic post-apply audit footer toggle (#3).
 
-    Env KWC_POST_APPLY_AUDIT=1. Default OFF for byte-identical rollout; the
-    frontend's ChatMessageList strips no markup so the audit footer renders
-    as a visible note. Only replies that touched config get audited.
+    DEFAULTS TO ENABLED (same 2026-09-09 A/B: footers appeared only on
+    config-touching replies and only with real observations — zero noise
+    across 138 replies). Set env KWC_POST_APPLY_AUDIT=0 to disable.
     """
-    return os.environ.get("KWC_POST_APPLY_AUDIT", "0") != "0"
+    return os.environ.get("KWC_POST_APPLY_AUDIT", "1") != "0"
 
 
 def _config_fallback_enabled() -> bool:
@@ -1086,6 +1092,12 @@ def _extract_tool_calls(text: str) -> list[dict]:
             # up. The fence is unambiguous tool intent, not prose.
             recovered_call = _recover_fenced_tool_call(raw_json)
             if recovered_call:
+                # Counted so the A/B can separate silent recoveries from
+                # re-prompt corrections (only the latter logs a WARNING).
+                logger.debug(
+                    "Recovered malformed tool fence | name=%s preview=%s",
+                    recovered_call["name"], raw_json[:100].replace("\n", " "),
+                )
                 calls.append(recovered_call)
             continue
         name = parsed.get("name", "")

--- a/backend/api/ai_routes.py
+++ b/backend/api/ai_routes.py
@@ -550,11 +550,14 @@ _MCP_TOOL_SNIPPETS: dict[str, str] = {
         "get_config_reference_section(section_name=...)"
     ),
     "get_config_reference_section": (
-        "VERIFY a config section's valid name and parameters in "
-        "Config_Reference (section_name='firmware_retraction'); use BEFORE "
-        "adding or editing a section — never invent section names or params "
-        "from memory. list_sections=true returns ONLY the section headers "
-        "to pick from; sections=['a','b'] fetches several in one call"
+        "READ the Config_Reference PROSE for a section — what the parameters "
+        "do, setup examples, detailed semantics (section_name="
+        "'firmware_retraction'). Use when designing a section you don't "
+        "fully understand yet. For a quick check of allowed param names, "
+        "defaults, enums, and bounds, call get_section_schema instead — "
+        "never invent section names or params from memory either way. "
+        "list_sections=true returns ONLY the section headers to pick from; "
+        "sections=['a','b'] fetches several in one call"
     ),
     "read_user_config": (
         "Read a user config file (filename='printer.cfg' required): "
@@ -602,11 +605,12 @@ _MCP_TOOL_SNIPPETS: dict[str, str] = {
         "lines and 'which board is plugged in?'"
     ),
     "get_section_schema": (
-        "Get a section's exact allowed parameters from the schema "
+        "VERIFY a section's allowed parameters against the schema "
         "(section='bed_mesh' or sections=['extruder','gcode_arcs']): types, "
-        "defaults, required flags, enum values, numeric bounds — use to check "
-        "WHICH params a section accepts; get_config_reference_section for "
-        "explanations"
+        "defaults, required flags, enum values, numeric bounds. Call BEFORE "
+        "adding or editing a section's parameters — this is the fast check "
+        "for WHICH params and values are legal; get_config_reference_section "
+        "only for prose explanations and examples"
     ),
     "get_klippy_status": (
         "Get Klipper's live state (ready / startup error / shutdown), the "
@@ -649,11 +653,14 @@ def _build_mcp_tool_context() -> str:
         "validate_macro for drafts. Do not guess when a tool can answer. "
         "read_user_config / list_user_config_sections show only what ALREADY "
         "exists in the user's files; list_config_reference_sections / "
-        "get_config_reference_section / search_klipper_docs show what Klipper "
-        "SUPPORTS. When the user asks to ADD or SETUP a section or parameter, "
-        "look it up with list_config_reference_sections (then "
-        "get_config_reference_section) or search_klipper_docs first — a valid "
-        "Klipper section may not be in the user's config yet.",
+        "get_config_reference_section / get_section_schema / "
+        "search_klipper_docs show what Klipper SUPPORTS. When the user asks "
+        "to ADD or SETUP a section or parameter, look it up first — a valid "
+        "Klipper section may not be in the user's config yet. To verify "
+        "which PARAMETERS and values a section accepts, call "
+        "get_section_schema (fast, exact types/defaults/enums/bounds); use "
+        "get_config_reference_section only when you need the prose "
+        "explanation or examples of what the section does.",
         "",
         "Text format (used by providers without native function calling): put a JSON ",
         "code block tagged `tool` in your reply:",

--- a/backend/api/native_routes.py
+++ b/backend/api/native_routes.py
@@ -23,6 +23,7 @@ from services.native_services import (
     list_flash_profiles,
     list_config_files,
     load_flash_profile,
+    load_native_project,
     query_canbus_uuids,
     read_config_file,
     write_config_file,
@@ -145,67 +146,21 @@ def read_config_files(data: dict):
         raise HTTPException(status_code=400, detail="No filenames provided")
 
     base = Path(config_path)
-    # Validate all paths are under the config directory (don't resolve symlinks)
-    for fn in filenames:
-        if '..' in fn or fn.startswith('/'):
-            raise HTTPException(status_code=400, detail=f"Invalid filename: {fn}")
-        candidate = base / fn
-        # Check the un-resolved path is under base
-        try:
-            candidate.relative_to(base)
-        except ValueError:
-            raise HTTPException(status_code=400, detail=f"Invalid filename: {fn}")
-
-    configs = {}
-    raw_texts = {}
-    board_infos = {}
-    for fn in filenames:
-        file_path = base / fn
-        if not file_path.exists():
-            continue
-        text = read_config_file(str(file_path))
-        config = parse_config(text, fn)
-        configs[fn] = config
-        raw_texts[fn] = text
-        board_infos[fn] = detect_board_from_config(config)
-
-    # Expand to the on-disk include closure. list_config_files hides files
-    # whose symlink target escapes the config root (traversal guard), but
-    # Klipper follows include symlinks wherever they point at load
-    # (configfile.py _resolve_include: os.path.join(dirname, include_spec)
-    # then a plain open). Third-party configs (KAMP, moonraker-obico,
-    # mainsail macros) are commonly symlinked INTO the config dir from
-    # elsewhere, so a native project must load them or every such include
-    # becomes a false "missing include" error on a config Klipper loads fine.
-    # Includes resolve relative to the directory of the INCLUDING file —
-    # mirroring Klipper. Only ACTIVE (non-commented) includes are followed;
-    # globs are skipped (never resolvable in-memory, legal when empty).
-    pending = list(configs)
-    while pending:
-        fn = pending.pop()
-        for include_spec in configs[fn].includes:
-            spec = include_spec.strip()
-            if not spec or glob.has_magic(spec):
-                continue
-            inc_dir = os.path.dirname(fn.replace("\\", "/"))
-            rel = os.path.normpath(
-                os.path.join(inc_dir, spec) if inc_dir else spec
-            )
-            # The include ENTRY must stay lexically inside the config dir (the
-            # same boundary read_config_files enforces for requested names);
-            # its symlink target may live anywhere, exactly like Klipper.
-            if os.path.isabs(rel) or Path(rel).parts[0] == "..":
-                continue
-            if rel in configs:
-                continue
-            file_path = base / rel
-            if not file_path.exists():  # follows symlinks
-                continue
-            text = read_config_file(str(file_path))
-            configs[rel] = parse_config(text, rel)
-            raw_texts[rel] = text
-            board_infos[rel] = detect_board_from_config(configs[rel])
-            pending.append(rel)
+    # Read + on-disk include-closure expansion lives in the shared service
+    # loader (also used by the MCP validate_config_project tool), so the
+    # V2.6.0 symlink-closure semantics can't fork between surfaces:
+    # list_config_files hides files whose symlink target escapes the config
+    # root (traversal guard), but Klipper follows include symlinks wherever
+    # they point at load (configfile.py _resolve_include). Third-party
+    # configs (KAMP, moonraker-obico, mainsail macros) are commonly symlinked
+    # INTO the config dir from elsewhere, so a native project must load them
+    # or every such include becomes a false "missing include" error on a
+    # config Klipper loads fine.
+    try:
+        configs, raw_texts, _skipped = load_native_project(base, filenames)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    board_infos = {fn: detect_board_from_config(cfg) for fn, cfg in configs.items()}
 
     validations = validate_project_configs(configs)
     results = {

--- a/backend/mcp_server.py
+++ b/backend/mcp_server.py
@@ -652,10 +652,14 @@ class McpServer:
             {
                 "name": "validate_klipper_config",
                 "description": (
-                    "Validate that a new or existing config section block is valid "
-                    "and free of errors. Parse and validate a Klipper config block. "
-                    "Returns structured results: parsed sections with their parameters, "
-                    "any errors or warnings, and the raw config text."
+                    "Validate a config text BLOCK YOU WROTE in this "
+                    "conversation (a draft section or snippet). Parse and "
+                    "validate a Klipper config block. Returns structured "
+                    "results: parsed sections with their parameters, any "
+                    "errors or warnings, and the raw config text. To check "
+                    "the user's ACTUAL saved config files instead, use "
+                    "validate_config_project — this tool only validates the "
+                    "text you pass it."
                 ),
                 "inputSchema": {
                     "type": "object",

--- a/backend/mcp_server.py
+++ b/backend/mcp_server.py
@@ -1014,6 +1014,151 @@ class McpServer:
                     "required": ["macro_text"],
                 },
             },
+            {
+                "name": "validate_config_project",
+                "description": (
+                    "Validate the user's CURRENT Klipper project — every "
+                    "config file on this host with includes expanded the way "
+                    "Klipper loads them — against the full config schema. "
+                    "Reports every active finding by severity: errors (Klipper "
+                    "would refuse to start or a value is invalid), warnings "
+                    "(likely problems; acknowledged ones are already hidden), "
+                    "and info (legal-but-noteworthy, e.g. merged duplicate "
+                    "sections), each with file, section, parameter, and line "
+                    "number. Read-only: changes nothing on disk. Use it to "
+                    "check the current state after an edit, before advising a "
+                    "FIRMWARE_RESTART, or when the user asks 'is my config "
+                    "OK?'. For validating a DRAFT snippet you wrote in chat, "
+                    "use validate_klipper_config instead."
+                ),
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "filenames": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": (
+                                "Optional subset of config files to validate "
+                                "(e.g. ['printer.cfg', 'macros.cfg']). Their "
+                                "include closure is still expanded. Omit to "
+                                "validate the whole project."
+                            ),
+                        },
+                    },
+                },
+            },
+            {
+                "name": "list_connected_devices",
+                "description": (
+                    "List the serial devices attached to this host for [mcu] "
+                    "and CAN wiring: USB serial devices by their "
+                    "/dev/serial/by-id/ path (the value that belongs in a "
+                    "config's serial: parameter), UART devices (/dev/ttyAMA0 "
+                    "etc. for serial: /dev/ttyS... on-board MCUs), CAN "
+                    "interfaces with up/down state and bitrate, and — when a "
+                    "scan runs — each interface's Klipper CAN UUIDs from "
+                    "canbus_query. Use when setting or debugging a "
+                    "canbus_uuid, serial: or CAN interface line, or when the "
+                    "user asks which board is plugged in. The scan takes a "
+                    "few seconds; set scan_can_uuids=false to only enumerate "
+                    "interfaces without probing the bus."
+                ),
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "scan_can_uuids": {
+                            "type": "boolean",
+                            "description": (
+                                "Probe each CAN interface for Klipper CAN "
+                                "UUIDs (default true). Set false to skip the "
+                                "bus scan."
+                            ),
+                        },
+                    },
+                },
+            },
+            {
+                "name": "get_section_schema",
+                "description": (
+                    "Look up the exact parameter spec of Klipper config "
+                    "sections from the structured schema: every parameter's "
+                    "type (float/int/bool/pin/enum/multi_line), default "
+                    "value, required flag, allowed enum values, and numeric "
+                    "bounds — plus whether the section takes a name (e.g. "
+                    "[heater_generic my_heater]) and which sections it "
+                    "requires. Faster and more precise than reading the "
+                    "Config_Reference prose when you only need to know WHICH "
+                    "parameters are allowed and what values they accept. "
+                    "Pass sections=['bed_mesh', 'input_shaper'] to fetch "
+                    "several in one call. For explanations and examples, use "
+                    "get_config_reference_section instead."
+                ),
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "section": {
+                            "type": "string",
+                            "description": (
+                                "Section type name, with or without brackets "
+                                "(e.g. 'bed_mesh' or '[extruder]')"
+                            ),
+                        },
+                        "sections": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": (
+                                "Optional list of section types to fetch in "
+                                "one call (e.g. ['extruder', 'gcode_arcs'])."
+                            ),
+                        },
+                    },
+                },
+            },
+            {
+                "name": "get_klippy_status",
+                "description": (
+                    "Report Klipper's live state on this host: ready / "
+                    "startup error / shutdown, the state message, and the "
+                    "active print job (state and filename, via Moonraker). "
+                    "When Klipper is NOT ready, recent klippy.log error "
+                    "context is attached automatically so you can diagnose "
+                    "without a second call. Optionally attach a klippy.log "
+                    "excerpt for a section or error even while ready "
+                    "(include_log_excerpt=true, optionally section_name / "
+                    "error_text to match). Use this BEFORE recommending "
+                    "FIRMWARE_RESTART — restarting interrupts an active "
+                    "print — and whenever the user says the printer won't "
+                    "start, has a config error, or the app shows Klipper not "
+                    "ready."
+                ),
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "include_log_excerpt": {
+                            "type": "boolean",
+                            "description": (
+                                "Also pull a klippy.log excerpt even when "
+                                "Klipper is ready (default false; excerpts "
+                                "attach automatically on startup errors)."
+                            ),
+                        },
+                        "section_name": {
+                            "type": "string",
+                            "description": (
+                                "Optional Klipper section (e.g. 'probe') to "
+                                "focus the log excerpt on."
+                            ),
+                        },
+                        "error_text": {
+                            "type": "string",
+                            "description": (
+                                "Optional error text to match in klippy.log "
+                                "(e.g. the message from state_message)."
+                            ),
+                        },
+                    },
+                },
+            },
         ]
 
     # ── Tool Handlers ─────────────────────────────────────────────
@@ -1037,6 +1182,10 @@ class McpServer:
             "calculate_rotation_distance": self._handle_calculate_rotation_distance,
             "generate_macro_template": self._handle_generate_macro_template,
             "validate_macro": self._handle_validate_macro,
+            "validate_config_project": self._handle_validate_config_project,
+            "list_connected_devices": self._handle_list_connected_devices,
+            "get_section_schema": self._handle_get_section_schema,
+            "get_klippy_status": self._handle_get_klippy_status,
         }
 
         handler = handlers.get(name)
@@ -2538,6 +2687,343 @@ class McpServer:
         return "\n".join(parts)
 
     # ── Printer Memory ────────────────────────────────────────────
+
+    # ── Live context tools (validate / devices / schema / klippy) ──
+
+    def _handle_validate_config_project(self, args: dict[str, Any]) -> str:
+        """Validate the live config project with the full schema engine.
+
+        Mirrors what the app's save-gate sees: seeds come from the native
+        config path (or explicit filenames), expands through the shared
+        on-disk include closure, then runs validate_project_configs so
+        cross-file checks (duplicate singleton sections, TMC header refs)
+        and acknowledgement suppression apply exactly as in the UI.
+        """
+        from services.native_services import (
+            is_native_platform,
+            load_native_project,
+            list_config_files,
+        )
+        from parser.validator import validate_project_configs
+
+        if not is_native_platform():
+            return (
+                "validate_config_project is only available when KWC runs "
+                "natively on the printer host (Raspberry Pi/SBC)."
+            )
+
+        config_dir = _system_config_path()
+        if not config_dir.is_dir():
+            return (
+                f"No config directory found at {config_dir} — there are no "
+                "config files to validate."
+            )
+
+        files_raw = args.get("filenames")
+        seed: list[str] = []
+        if files_raw:
+            if isinstance(files_raw, str):
+                names = [
+                    s.strip().strip("[]").strip("\"'")
+                    for s in re.split(r"[,\n]", files_raw)
+                    if s.strip()
+                ]
+            else:
+                names = [str(s).strip() for s in files_raw if str(s).strip()]
+            # Resolve through the same fuzzy resolver read_user_config uses,
+            # so 'printer' finds printer.cfg the way models expect.
+            for name in names:
+                resolved = self._resolve_user_config_file(name)
+                seed.append(resolved.name if resolved is not None else name)
+        else:
+            seed = [f["name"] for f in list_config_files(str(config_dir))]
+
+        if not seed:
+            return "No config files found to validate."
+
+        try:
+            configs, _raw, skipped = load_native_project(config_dir, seed)
+        except ValueError as exc:
+            return f"Invalid config filename: {exc}"
+
+        if not configs:
+            return (
+                "None of the requested files exist under "
+                f"{config_dir}. Use list_user_configs to see available files."
+            )
+
+        validations = validate_project_configs(configs)
+
+        def _loc(finding: dict) -> str:
+            # Findings arrive as to_dict() dicts: keys mirror ValidationError.
+            loc = f"[{finding.get('section', '')}]"
+            if finding.get("param"):
+                loc += f" {finding['param']}"
+            if finding.get("line_number"):
+                loc += f" (line {finding['line_number']})"
+            return loc
+
+        error_files = 0
+        warn_files = 0
+        parts: list[str] = []
+        for filename in sorted(validations):
+            result = validations[filename].to_dict()
+            findings = result["errors"]
+            errs = [f for f in findings if f["severity"] == "error"]
+            warns = [f for f in findings if f["severity"] == "warning"]
+            infos = [f for f in findings if f["severity"] == "info"]
+            if errs:
+                error_files += 1
+            if warns:
+                warn_files += 1
+            parts.append(f"## {filename}")
+            if not findings:
+                parts.append("✅ No active errors, warnings, or info findings.")
+            for label, group in (("Errors", errs), ("Warnings", warns), ("Info", infos)):
+                if not group:
+                    continue
+                parts.append(f"### {label} ({len(group)})")
+                for f_item in group:
+                    parts.append(f"- {_loc(f_item)}: {f_item['message']}")
+            parts.append("")
+
+        parts.append(
+            f"Project summary: {len(validations)} file(s) validated, "
+            f"{error_files} with errors, {warn_files} with warnings."
+        )
+        if skipped:
+            parts.append(
+                "Include specs skipped (glob/escaping/missing on disk): "
+                + ", ".join(sorted(set(skipped)))
+            )
+        return "\n".join(parts)
+
+    def _handle_list_connected_devices(self, args: dict[str, Any]) -> str:
+        """Serial/CAN devices — the same data as the comm-line dropdowns."""
+        import services.native_services as ns
+
+        if not ns.is_native_platform():
+            return (
+                "Device detection is only available when KWC runs natively "
+                "on the printer host (Raspberry Pi/SBC)."
+            )
+
+        scan_uuids = bool(args.get("scan_can_uuids", True))
+        devices = ns.get_all_devices()
+
+        parts: list[str] = ["# Connected devices\n"]
+
+        usb = devices.get("usb_serial", [])
+        parts.append(f"## USB serial ({len(usb)})")
+        if usb:
+            for d in usb:
+                by_id = d.get("by_id") or d["path"]
+                parts.append(f"- {d['description']} → {by_id}")
+            parts.append(
+                "Use the /dev/serial/by-id/ path as the [mcu] serial: value."
+            )
+        else:
+            parts.append("- none detected")
+        parts.append("")
+
+        uart = devices.get("uart", [])
+        parts.append(f"## UART ({len(uart)})")
+        if uart:
+            for d in uart:
+                parts.append(f"- {d['path']} ({d['description']})")
+        else:
+            parts.append("- none detected")
+        parts.append("")
+
+        can = devices.get("can", [])
+        parts.append(f"## CAN interfaces ({len(can)})")
+        if not can:
+            parts.append("- none detected")
+        for iface in can:
+            bitrate = iface.get("bitrate")
+            extra = f", {bitrate} bps" if bitrate else ""
+            parts.append(f"- {iface['name']} ({iface.get('state', 'unknown')}{extra})")
+            if scan_uuids:
+                query = ns.query_canbus_uuids(iface["name"])
+                if query.get("error"):
+                    parts.append(f"  UUID scan: {query['error']}")
+                elif query.get("uuids"):
+                    for uuid in query["uuids"]:
+                        parts.append(f"  canbus_uuid: {uuid}")
+                else:
+                    parts.append("  UUID scan: no Klipper CAN nodes answered")
+        parts.append(
+            "\nFor a [mcu_canbus]-style device use canbus_uuid: <uuid> with "
+            "interface: <can0>."
+            if scan_uuids and can else
+            "\nSet scan_can_uuids=true (default) to probe interfaces for Klipper CAN UUIDs."
+        )
+        return "\n".join(parts)
+
+    def _handle_get_section_schema(self, args: dict[str, Any]) -> str:
+        """Typed parameter spec for one or more sections from config_schema."""
+        from parser.config_schema import get_all_section_types, get_section_def
+
+        raw_single = str(args.get("section") or args.get("section_name") or "").strip()
+        sections_raw = args.get("sections")
+        names: list[str] = []
+        if sections_raw:
+            if isinstance(sections_raw, str):
+                names = [
+                    s.strip().strip("[]").strip("\"'")
+                    for s in re.split(r"[,\n]", sections_raw)
+                    if s.strip()
+                ]
+            else:
+                names = [str(s).strip() for s in sections_raw if str(s).strip()]
+        if raw_single:
+            names.insert(0, raw_single.strip("[]"))
+        if not names:
+            return (
+                "Please provide a section (section='bed_mesh') or "
+                "sections=['bed_mesh', 'input_shaper']."
+            )
+
+        parts: list[str] = []
+        for raw in names:
+            key = raw.strip("[]").strip()
+            sec = get_section_def(key)
+            if sec is None:
+                import difflib
+
+                close = difflib.get_close_matches(key, get_all_section_types(), n=3)
+                hint = f" Close matches: {', '.join(close)}." if close else ""
+                parts.append(
+                    f"'{key}' is not a known section type.{hint} Use "
+                    "list_config_reference_sections for the full list.\n"
+                )
+                continue
+
+            header = f"## [{sec.section_type}] — {sec.display_name}"
+            meta_bits: list[str] = []
+            if sec.is_named:
+                ref = f" (a {sec.name_references})" if sec.name_references else ""
+                meta_bits.append(f"named section{ref}: write [{sec.section_type} your_name]")
+            if sec.max_instances == 1:
+                meta_bits.append("only ONE instance allowed across the config")
+            elif sec.max_instances > 1:
+                meta_bits.append(f"max {sec.max_instances} instances")
+            if sec.requires:
+                meta_bits.append("requires sections: " + ", ".join(f"[{r}]" for r in sec.requires))
+            if sec.description:
+                meta_bits.append(sec.description)
+
+            parts.append(header)
+            for bit in meta_bits:
+                parts.append(f"- {bit}")
+            if sec.params:
+                parts.append(f"\nParameters ({len(sec.params)}):")
+                for p in sec.params:
+                    bits = [p.param_type.value]
+                    if p.required:
+                        bits.append("required")
+                    if p.default not in (None, ""):
+                        bits.append(f"default: {p.default}")
+                    if p.enum_values:
+                        bits.append("one of: " + ", ".join(p.enum_values))
+                    bounds: list[str] = []
+                    if p.min_val is not None:
+                        bounds.append(f">= {p.min_val}")
+                    if p.max_val is not None:
+                        bounds.append(f"<= {p.max_val}")
+                    if p.strict_above is not None:
+                        bounds.append(f"> {p.strict_above} (strict)")
+                    if p.strict_below is not None:
+                        bounds.append(f"< {p.strict_below} (strict)")
+                    if bounds:
+                        bits.append(" / ".join(bounds) + (f" {p.unit}" if p.unit else ""))
+                    if p.rel_above:
+                        bits.append(f"must be > {p.rel_above}")
+                    if p.rel_below:
+                        bits.append(f"must be < {p.rel_below}")
+                    if p.rel_between:
+                        bits.append(f"between {p.rel_between[0]} and {p.rel_between[1]}")
+                    if p.rel_min:
+                        bits.append(f">= {p.rel_min}")
+                    if p.rel_max:
+                        bits.append(f"<= {p.rel_max}")
+                    line = f"- {p.name} ({'; '.join(bits)})"
+                    if p.description:
+                        line += f" — {p.description}"
+                    parts.append(line)
+            else:
+                parts.append("- (no parameters)")
+            parts.append("")
+
+        return "\n".join(parts)
+
+    def _handle_get_klippy_status(self, args: dict[str, Any]) -> str:
+        """Live klippy state + print state; failure context auto-attaches."""
+        import services.native_services as ns
+
+        include_excerpt = bool(args.get("include_log_excerpt", False))
+        section_name = str(args.get("section_name") or "").strip() or None
+        error_text = str(args.get("error_text") or "").strip() or None
+
+        try:
+            status = ns.query_klipper_status()
+        except FileNotFoundError as exc:
+            # Klipper not reachable — still try the log; it survives crashes.
+            excerpt = ""
+            try:
+                log = ns.get_klippy_log_excerpt(
+                    section_name=section_name, error_text=error_text
+                )
+                excerpt = log.get("excerpt") or ""
+            except (RuntimeError, OSError):
+                pass
+            parts = [
+                f"Klipper is not responding: {exc}",
+                "Klipper may be stopped or failing at startup.",
+            ]
+            if excerpt:
+                parts.append(f"\n## klippy.log excerpt\n```\n{excerpt}\n```")
+            return "\n".join(parts)
+        except RuntimeError as exc:
+            return f"Klipper status query failed: {exc}"
+
+        state = status.get("state", "unknown")
+        parts = [f"Klipper state: {state}"]
+        if status.get("state_message"):
+            parts.append(f"State message: {status['state_message']}")
+
+        if status.get("is_printing"):
+            name = status.get("print_filename") or "a job"
+            parts.append(
+                f"⚠️ An ACTIVE print is running ({name}, "
+                f"state: {status.get('print_state')}). A FIRMWARE_RESTART or "
+                "config apply will interrupt it — warn the user first."
+            )
+
+        recent = status.get("recent_errors") or []
+        if recent:
+            parts.append(f"\n## Recent klippy errors ({len(recent)})")
+            for err in recent[:8]:
+                parts.append(f"- {err}")
+
+        want_excerpt = include_excerpt or (state != "ready")
+        if want_excerpt and not error_text and status.get("state_message"):
+            error_text = status["state_message"]
+        if want_excerpt:
+            try:
+                log = ns.get_klippy_log_excerpt(
+                    section_name=section_name, error_text=error_text
+                )
+                if log.get("excerpt"):
+                    matched = log.get("matched_on") or "recent"
+                    parts.append(
+                        f"\n## klippy.log excerpt (matched: {matched}, "
+                        f"from {log.get('log_path')})\n```\n{log['excerpt']}\n```"
+                    )
+            except (RuntimeError, OSError) as exc:
+                parts.append(f"\n(klippy.log excerpt unavailable: {exc})")
+
+        return "\n".join(parts)
 
     # ── JSON-RPC / MCP Protocol ─────────────────────────────────
 

--- a/backend/services/ai_draft_apply.py
+++ b/backend/services/ai_draft_apply.py
@@ -1,0 +1,1345 @@
+"""Backend port of the KWC AI-draft apply/merge pipeline.
+
+Mirrors the following TypeScript modules (frontend) line for line where the
+semantics matter:
+
+- frontend/src/utils/chatUtils.ts
+    extractConfigCodeBlocks, extractAssistantFileHint, CONFIG_CODE_LANGUAGES,
+    ASSISTANT_FILE_HINT_RE, rewriteConfigEqualsSeparators,
+    extractMentionedConfigFilenames, resolveAssistantTargetFile
+- frontend/src/utils/miniDiff.ts
+    isMiniDiffBlock, applyMiniDiffBlock, stripMiniDiffMarkers
+- frontend/src/utils/jinjaBlockRepair.ts
+    repairUnclosedJinjaInConfigText (+ its section/body handlers)
+- frontend/src/utils/assistantDraftMerge.ts
+    preprocessDeleteMarkers, mergeAssistantSectionsIntoConfig
+- frontend/src/hooks/useAssistantDraft.ts
+    buildAssistantDraftTargetConfigs + prepareAssistantDraftPreview
+    (the top-level ``apply_reply_to_configs`` convenience below)
+
+The backend uses the parser/writer from ``parser.config_parser`` /
+``parser.config_writer`` so the server can validate the merged result and do a
+single deterministic Jinja-repair pass.  Everything is pure stdlib plus the
+backend ``parser`` package.  Only ASCII whitespace is treated as comment/body
+content, matching the JS regexes.
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+# Make the backend ``parser`` package importable regardless of the current
+# working directory (repo root vs. backend root).  Existing backend modules
+# import ``from parser.config_parser import ...``; this bootstrap keeps that
+# style working when the module is loaded as ``backend.services.ai_draft_apply``
+# from the repo root (e.g. during import checks or tests).
+_BACKEND_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _BACKEND_ROOT not in sys.path:
+    sys.path.insert(0, _BACKEND_ROOT)
+
+from parser.config_parser import (  # noqa: E402
+    ConfigFile,
+    ConfigParam,
+    ConfigSection,
+    parse_config,
+)
+from parser.config_writer import smart_export  # noqa: E402
+
+
+# ── chatUtils: constants used by several functions ──────────────────────
+
+CONFIG_CODE_LANGUAGES = frozenset(
+    ['', 'cfg', 'conf', 'ini', 'klipper', 'printercfg']
+)
+ASSISTANT_FILE_HINT_RE = re.compile(r'^[#;]\s*file\s*:\s*(.+?)\s*$', re.IGNORECASE)
+
+# A fenced ```code block: open fence, optional non-empty/backtick language,
+# then the block body until the closing ```.  Mirrors /```([^\n`]*)\n([\s\S]*?)```/g.
+RE_CODE_BLOCK = re.compile(r'```([^\n`]*)\n([\s\S]*?)```')
+
+# Raw-content fallback: delete marker ``*[section]`` or a ``# file:`` hint
+# anywhere in the text (multiline).  Mirrors /^\s*(?:[*]\[[^\]]+\]|[#;]\s*file\s*:)/m.
+RE_CONFIG_LIKE = re.compile(r'^\s*(?:\*\[[^\]]+\]|[#;]\s*file\s*:)', re.MULTILINE)
+
+# ``name = value`` param assignment inside a cfg block (optional leading
+# indent and an optional ``#`` comment prefix).
+RE_EQUALS_PARAM = re.compile(
+    r'^(\s*)(#?\s*[A-Za-z0-9_][A-Za-z0-9_-]*)\s*=\s*(.*)$'
+)
+
+
+# ── chatUtils: extractConfigCodeBlocks ──────────────────────────────────
+
+def extract_config_code_blocks(content: str) -> list[str]:
+    """Return fenced code blocks whose language is a Klipper config language.
+
+    Mirrors ``extractConfigCodeBlocks``:
+    - blocks whose language (lowercased) is in ``CONFIG_CODE_LANGUAGES`` are
+      returned first, in order;
+    - if none of those exist, the first block fenced with *any* other language
+      is returned;
+    - if there are no fenced blocks at all but the raw text contains a
+      ``*[section]`` delete marker or a ``# file:`` hint, the whole ``content``
+      is returned;
+    - otherwise an empty list is returned.
+    """
+    config_blocks: list[str] = []
+    fallback_blocks: list[str] = []
+
+    for match in RE_CODE_BLOCK.finditer(content):
+        language = match.group(1).strip().lower()
+        block = match.group(2).strip()
+        if not block:
+            continue
+        if language in CONFIG_CODE_LANGUAGES:
+            config_blocks.append(block)
+        else:
+            fallback_blocks.append(block)
+
+    if config_blocks:
+        return config_blocks
+    if fallback_blocks:
+        return [fallback_blocks[0]]
+
+    if RE_CONFIG_LIKE.search(content):
+        return [content]
+
+    return []
+
+
+# ── chatUtils: extractAssistantFileHint ─────────────────────────────────
+
+def extract_assistant_file_hint(
+    block: str, loaded_filenames: list[str]
+) -> tuple[str, str | None]:
+    """Strip a leading ``# file: <name>`` hint line from a cfg block.
+
+    Returns ``(config_text_without_hint_line, file_hint_or_None)``.  The lookup
+    maps each loaded filename to its exact name and bare basename (case
+    insensitive) so a hint such as ``printer.cfg`` matches ``config/printer.cfg``.
+    """
+    available_by_lower: dict[str, str] = {}
+    for filename in loaded_filenames:
+        lower = filename.lower()
+        available_by_lower.setdefault(lower, filename)
+        base = re.sub(r'^.*[\\/]', '', filename).lower()
+        if base and base != lower:
+            available_by_lower.setdefault(base, filename)
+
+    lines = re.split(r'\r?\n', block)
+    file_hint: str | None = None
+    file_hint_line_index = -1
+
+    for index, line in enumerate(lines):
+        trimmed = line.strip()
+        if not trimmed:
+            continue
+        hint_match = ASSISTANT_FILE_HINT_RE.match(trimmed)
+        if hint_match:
+            raw_name = hint_match.group(1).strip()
+            file_hint = available_by_lower.get(raw_name.lower(), raw_name)
+            file_hint_line_index = index
+            break
+
+    if file_hint_line_index == -1:
+        return block, file_hint
+
+    config_text = '\n'.join(
+        line for idx, line in enumerate(lines) if idx != file_hint_line_index
+    ).strip()
+    return config_text, file_hint
+
+
+# ── chatUtils: rewriteConfigEqualsSeparators ────────────────────────────
+
+def rewrite_config_equals_separators(content: str) -> str:
+    """Rewrite ``key = value`` param assignments to ``key: value`` inside cfg blocks.
+
+    Only touches lines inside fenced blocks whose language is a config
+    language, and only lines that look like a Klipper param assignment.
+    """
+
+    def _rewrite_block(whole: str, language: str, block: str) -> str:
+        if language.strip().lower() not in CONFIG_CODE_LANGUAGES:
+            return whole
+        rewritten = '\n'.join(
+            RE_EQUALS_PARAM.sub(
+                lambda m: f"{m.group(1)}{m.group(2)}: {m.group(3)}",
+                line,
+            )
+            for line in re.split(r'\r?\n', block)
+        )
+        return f'```{language}\n{rewritten}```'
+
+    return RE_CODE_BLOCK.sub(_rewrite_block, content)
+
+
+# ── chatUtils: filename helpers used by target resolution ───────────────
+
+def _basename(filename: str) -> str:
+    """Strip any path prefix, returning just the basename (JS basename())."""
+    return re.split(r'[\\/]', filename)[-1]
+
+
+def _escape_regex(value: str) -> str:
+    return re.escape(value)
+
+
+def extract_mentioned_config_filenames(
+    texts: list[str], available_filenames: list[str]
+) -> list[str]:
+    """Return the available filenames mentioned (case-insensitively) in texts."""
+    matches: list[str] = []
+    for filename in available_filenames:
+        pattern = re.compile(
+            rf'(^|[^A-Za-z0-9_.-]){_escape_regex(filename)}(?=$|[^A-Za-z0-9_.-])',
+            re.IGNORECASE,
+        )
+        if any(pattern.search(text) for text in texts):
+            matches.append(filename)
+    return matches
+
+
+def _score_assistant_target_file(
+    config: ConfigFile, assistant_sections: list[ConfigSection]
+) -> tuple[int, int]:
+    full_headers = {section.full_header for section in config.sections}
+    section_types = {section.section_type for section in config.sections}
+    exact_matches = 0
+    section_type_matches = 0
+    for section in assistant_sections:
+        if section.full_header in full_headers:
+            exact_matches += 1
+            continue
+        if section.section_type in section_types:
+            section_type_matches += 1
+    return exact_matches, section_type_matches
+
+
+def _resolve_filename(
+    hint: str, config_files: dict[str, ConfigFile]
+) -> str | None:
+    if hint in config_files:
+        return hint
+    hint_base = _basename(hint).lower()
+    for key in config_files:
+        if _basename(key).lower() == hint_base:
+            return key
+    return None
+
+
+def resolve_assistant_target_file(
+    assistant_config: ConfigFile,
+    config_files: dict[str, ConfigFile],
+    active_file: str,
+    hinted_filenames: list[str],
+) -> str | None:
+    """Resolve which loaded config file the assistant's sections target.
+
+    Mirrors ``resolveAssistantTargetFile``.
+    """
+    available_filenames = list(config_files.keys())
+    unique_hints = list(dict.fromkeys(hinted_filenames))
+
+    if len(unique_hints) == 1:
+        resolved = _resolve_filename(unique_hints[0], config_files)
+        return resolved if resolved is not None else unique_hints[0]
+
+    if not available_filenames:
+        return None
+
+    existing_hints: list[str] = []
+    for filename in unique_hints:
+        resolved = _resolve_filename(filename, config_files)
+        if resolved is not None:
+            existing_hints.append(resolved)
+
+    if len(existing_hints) == 1:
+        return existing_hints[0]
+
+    if len(existing_hints) > 1:
+        scored: list[tuple[str, int, int]] = []
+        for filename in existing_hints:
+            exact, s_type = _score_assistant_target_file(
+                config_files[filename], assistant_config.sections
+            )
+            scored.append((filename, exact, s_type))
+        scored.sort(key=lambda item: (-item[1], -item[2]))
+        return scored[0][0]
+
+    scores: list[tuple[str, int, int, int]] = []
+    for filename in available_filenames:
+        exact, s_type = _score_assistant_target_file(
+            config_files[filename], assistant_config.sections
+        )
+        active = 1 if filename == active_file else 0
+        scores.append((filename, exact, s_type, active))
+    scores.sort(key=lambda item: (-item[1], -item[2], -item[3], item[0]))
+
+    best = scores[0]
+    if best[1] > 0 or best[2] > 0:
+        return best[0]
+    if active_file in config_files:
+        return active_file
+    return available_filenames[0] if available_filenames else None
+
+
+# ── assistantDraftMerge: delete-marker preprocessing ────────────────────
+
+DELETE_SECTION_TYPE = 'delete_section'
+# /^\*\[([^\]]+)\]\s*$/gm
+DELETE_MARKER_RE = re.compile(r'^\*\[([^\]]+)\]\s*$', re.MULTILINE)
+
+
+def preprocess_delete_markers(text: str) -> str:
+    """Convert ``*[section_name]`` lines into ``[delete_section]`` blocks."""
+    return DELETE_MARKER_RE.sub(
+        lambda m: f'[delete_section]\nsection: {m.group(1).strip()}', text
+    )
+
+
+# ── assistantDraftMerge: section/param clones ───────────────────────────
+
+def _clone_param(param: ConfigParam) -> ConfigParam:
+    return ConfigParam(
+        key=param.key,
+        value=param.value,
+        comment=param.comment,
+        is_commented_out=param.is_commented_out,
+        line_number=param.line_number,
+        separator=param.separator,
+        raw_comment_suffix=param.raw_comment_suffix,
+        raw_line=param.raw_line,
+    )
+
+
+def _clone_section(section: ConfigSection) -> ConfigSection:
+    return ConfigSection(
+        section_type=section.section_type,
+        section_name=section.section_name,
+        full_header=section.full_header,
+        params=[_clone_param(p) for p in section.params],
+        header_comments=list(section.header_comments),
+        line_number=section.line_number,
+        trailing_comments=list(section.trailing_comments),
+        trailing_blank_lines=section.trailing_blank_lines,
+        is_commented_out=section.is_commented_out,
+    )
+
+
+# ── assistantDraftMerge: section index ──────────────────────────────────
+
+def _build_section_index(sections: list[ConfigSection]) -> dict[str, list[int]]:
+    section_index: dict[str, list[int]] = {}
+    for index, section in enumerate(sections):
+        section_index.setdefault(section.full_header, []).append(index)
+    return section_index
+
+
+def _collect_includes(sections: list[ConfigSection]) -> list[str]:
+    return [s.section_name for s in sections if s.section_type == 'include']
+
+
+def _is_delete_section(section: ConfigSection) -> bool:
+    if section.section_type != DELETE_SECTION_TYPE:
+        return False
+    for p in section.params:
+        if p.key == 'section' and p.value.strip():
+            return True
+    return False
+
+
+def _get_delete_target(section: ConfigSection) -> str | None:
+    for p in section.params:
+        if p.key == 'section':
+            return p.value.strip()
+    return None
+
+
+# ── assistantDraftMerge: param merge ────────────────────────────────────
+
+def _pick_matching_param_index(
+    params: list[ConfigParam],
+    key: str,
+    is_commented_out: bool,
+    used_indexes: dict[int, int],
+) -> int | None:
+    for index, param in enumerate(params):
+        if index not in used_indexes and param.key == key \
+                and param.is_commented_out == is_commented_out:
+            return index
+    for index, param in enumerate(params):
+        if index not in used_indexes and param.key == key \
+                and not param.is_commented_out:
+            return index
+    for index, param in enumerate(params):
+        if index not in used_indexes and param.key == key:
+            return index
+    return None
+
+
+def _merge_assistant_params(
+    existing_params: list[ConfigParam], assistant_params: list[ConfigParam]
+) -> list[ConfigParam]:
+    unlinked_ai_keys = {
+        p.key for p in assistant_params if p.key != '_comment_'
+    }
+    matched_existing_indexes: dict[int, int] = {}
+
+    for ai_index, ai_param in enumerate(assistant_params):
+        if ai_param.key == '_comment_':
+            continue
+        match_index = _pick_matching_param_index(
+            existing_params, ai_param.key, ai_param.is_commented_out,
+            matched_existing_indexes,
+        )
+        if match_index is not None:
+            matched_existing_indexes[match_index] = ai_index
+            unlinked_ai_keys.discard(ai_param.key)
+
+    ai_key_set = {p.key for p in assistant_params if p.key != '_comment_'}
+    result: list[ConfigParam] = []
+    used_ai_keys: set[str] = set()
+
+    for existing_index, existing_param in enumerate(existing_params):
+        if existing_param.key == '_comment_':
+            result.append(_clone_param(existing_param))
+            continue
+
+        matched_ai_index = matched_existing_indexes.get(existing_index)
+        if matched_ai_index is not None:
+            ai_param = assistant_params[matched_ai_index]
+            if ai_param is not None:
+                cloned_ai = _clone_param(ai_param)
+                merged = _clone_param(existing_param)
+                merged.key = cloned_ai.key
+                merged.value = cloned_ai.value
+                merged.line_number = cloned_ai.line_number
+                merged.raw_comment_suffix = cloned_ai.raw_comment_suffix
+                merged.raw_line = cloned_ai.raw_line
+                merged.is_commented_out = existing_param.is_commented_out
+                merged.comment = cloned_ai.comment or existing_param.comment
+                merged.separator = (
+                    cloned_ai.separator
+                    if cloned_ai.separator is not None
+                    else existing_param.separator
+                )
+                result.append(merged)
+                used_ai_keys.add(existing_param.key)
+                continue
+
+        if existing_param.key in ai_key_set:
+            result.append(_clone_param(existing_param))
+            continue
+
+        # Unmatched existing param whose key is not in the AI's output:
+        # excluded (the AI intentionally removed it).
+
+    # Append unlinked AI params (new params / key renames).
+    for param in assistant_params:
+        if param.key == '_comment_':
+            continue
+        if param.key not in used_ai_keys and param.key in unlinked_ai_keys:
+            result.append(_clone_param(param))
+            used_ai_keys.add(param.key)
+
+    # Append AI comments/blank lines that aren't duplicates.
+    pushed_comment_values: set[str] = set()
+    for param in assistant_params:
+        if param.key != '_comment_':
+            continue
+        if param.value in pushed_comment_values:
+            continue
+        in_existing = any(
+            ep.key == '_comment_' and ep.value == param.value
+            for ep in existing_params
+        )
+        if not in_existing:
+            result.append(_clone_param(param))
+            pushed_comment_values.add(param.value)
+
+    return result
+
+
+# ── assistantDraftMerge: section merge ──────────────────────────────────
+
+def _merge_assistant_section(
+    existing_section: ConfigSection, assistant_section: ConfigSection
+) -> ConfigSection:
+    return ConfigSection(
+        section_type=assistant_section.section_type,
+        section_name=assistant_section.section_name,
+        full_header=assistant_section.full_header,
+        # TS: existing ?? assistant (existing is always present)
+        line_number=existing_section.line_number,
+        # TS: assistant ?? existing (assistant is always present)
+        is_commented_out=assistant_section.is_commented_out,
+        header_comments=(
+            list(existing_section.header_comments)
+            if len(existing_section.header_comments) > 0
+            else list(assistant_section.header_comments)
+        ),
+        trailing_comments=(
+            list(existing_section.trailing_comments)
+            if len(existing_section.trailing_comments) > 0
+            else list(assistant_section.trailing_comments)
+        ),
+        trailing_blank_lines=assistant_section.trailing_blank_lines,
+        params=_merge_assistant_params(
+            existing_section.params, assistant_section.params
+        ),
+    )
+
+
+def _build_assistant_draft_change_id(
+    filename: str, section: ConfigSection, assistant_section_index: int
+) -> str:
+    return f'{filename}:{assistant_section_index}:{section.full_header}'
+
+
+def merge_assistant_sections(
+    base_config: ConfigFile,
+    assistant_config: ConfigFile,
+    selected_ids: list[str] | None = None,
+) -> dict:
+    """Merge the assistant's sections into the base config.
+
+    Mirrors ``mergeAssistantSectionsIntoConfig``, returning
+    ``{'merged_config': ConfigFile, 'changes': list[dict]}`` where each change
+    is ``{'id': str, 'filename': str, 'fullHeader': str, 'mode': str}`` with
+    ``mode`` in ``{'update', 'add', 'delete'}`` and ids built as
+    ``f"{filename}:{index}:{full_header}"``.
+    """
+    base_sections = list(base_config.sections or [])
+    assistant_sections = list(assistant_config.sections or [])
+    section_index = _build_section_index(base_sections)
+    replacements: dict[int, ConfigSection] = {}
+    inserts_by_anchor: dict[int, list[ConfigSection]] = {}
+    seen_headers: dict[str, int] = {}
+    selected_id_set = (
+        None if selected_ids is None else set(selected_ids)
+    )
+    deleted_indexes: set[int] = set()
+    changes: list[dict] = []
+    last_anchor_index = len(base_sections) - 1 if base_sections else -1
+
+    for assistant_section_index, assistant_section in enumerate(assistant_sections):
+        seen_count = seen_headers.get(assistant_section.full_header, 0)
+        seen_headers[assistant_section.full_header] = seen_count + 1
+        change_id = _build_assistant_draft_change_id(
+            base_config.filename, assistant_section, assistant_section_index
+        )
+        should_apply = selected_id_set is None or change_id in selected_id_set
+
+        if _is_delete_section(assistant_section):
+            target_name = _get_delete_target(assistant_section)
+            if target_name:
+                target_indexes = section_index.get(target_name)
+                existing_index = target_indexes[0] if target_indexes else None
+                changes.append({
+                    'id': change_id,
+                    'filename': base_config.filename,
+                    'fullHeader': target_name,
+                    'mode': 'delete',
+                })
+                if existing_index is not None:
+                    if should_apply:
+                        deleted_indexes.add(existing_index)
+                continue
+            continue
+
+        target_indexes = section_index.get(assistant_section.full_header)
+        existing_index = (
+            target_indexes[seen_count]
+            if target_indexes is not None and seen_count < len(target_indexes)
+            else None
+        )
+        if existing_index is not None:
+            changes.append({
+                'id': change_id,
+                'filename': base_config.filename,
+                'fullHeader': assistant_section.full_header,
+                'mode': 'update',
+            })
+            last_anchor_index = existing_index
+            if not should_apply:
+                continue
+            existing_section = base_sections[existing_index]
+            replacements[existing_index] = _merge_assistant_section(
+                existing_section, assistant_section
+            )
+            continue
+
+        changes.append({
+            'id': change_id,
+            'filename': base_config.filename,
+            'fullHeader': assistant_section.full_header,
+            'mode': 'add',
+        })
+        if not should_apply:
+            continue
+        inserts_by_anchor.setdefault(last_anchor_index, []).append(
+            _clone_section(assistant_section)
+        )
+
+    merged_sections: list[ConfigSection] = []
+    leading_sections = inserts_by_anchor.get(-1)
+    if leading_sections:
+        merged_sections.extend(leading_sections)
+
+    pending_deleted_comments: list[str] = []
+
+    for index, section in enumerate(base_sections):
+        if index in deleted_indexes:
+            if section.header_comments:
+                pending_deleted_comments.extend(section.header_comments)
+            anchored_sections = inserts_by_anchor.get(index)
+            if anchored_sections:
+                merged_sections.extend(anchored_sections)
+            continue
+
+        merged_section = (
+            replacements.get(index) if index in replacements
+            else _clone_section(section)
+        )
+
+        if pending_deleted_comments:
+            merged_section.header_comments = (
+                list(pending_deleted_comments)
+                + list(merged_section.header_comments)
+            )
+            pending_deleted_comments = []
+
+        merged_sections.append(merged_section)
+        anchored_sections = inserts_by_anchor.get(index)
+        if anchored_sections:
+            merged_sections.extend(anchored_sections)
+
+    merged_config = ConfigFile(
+        filename=base_config.filename,
+        sections=merged_sections,
+        includes=_collect_includes(merged_sections),
+        header_comments=(
+            list(base_config.header_comments)
+            if len(base_config.header_comments) > 0
+            else list(assistant_config.header_comments)
+        ),
+        raw_text=base_config.raw_text,
+    )
+
+    return {'merged_config': merged_config, 'changes': changes}
+
+
+# ── miniDiff: regexes and helpers ───────────────────────────────────────
+
+RE_MINI_DIFF_REMOVAL = re.compile(r'^\s*-(.*)$')
+RE_MINI_DIFF_ADDITION = re.compile(r'^\s*\+(.*)$')
+# /^\s*(\[[^\]]+\])\s*$/
+RE_SECTION_HEADER = re.compile(r'^\s*(\[[^\]]+\])\s*$')
+# jinjaBlockRepair's SECTION_HEADER_RE captures the INNER name (no brackets).
+# /^\s*\[([^\]]+)\]\s*$/
+RE_SECTION_HEADER_INNER = re.compile(r'^\s*\[([^\]]+)\]\s*$')
+# /^\s*\*\[[^\]]+\]\s*$/
+RE_DELETE_MARKER = re.compile(r'^\s*\*\[[^\]]+\]\s*$')
+# /^(\w[\w]*)\s*[:=]/
+RE_PARAM_LINE = re.compile(r'^(\w[\w]*)\s*[:=]')
+
+
+def _normalize_line(line: str) -> str:
+    """Strip CR and trailing whitespace only (JS normalizeLine)."""
+    return line.rstrip()
+
+
+def _leading_whitespace(line: str) -> str:
+    """Leading spaces/tabs of a line (cosmetic in Klipper configs)."""
+    match = re.match(r'^[ \t]*', line)
+    return match.group(0) if match else ''
+
+
+def _is_gcode_body_key(key: str) -> bool:
+    return key == 'gcode' or key.endswith('_gcode')
+
+
+def _last_section_param_key(section_lines: list[str]) -> str | None:
+    for index in range(len(section_lines) - 1, -1, -1):
+        line = section_lines[index]
+        if line.strip() == '' or line.startswith('#'):
+            continue
+        if line.startswith('['):
+            break
+        param_match = RE_PARAM_LINE.match(line)
+        if param_match:
+            return param_match.group(1)
+    return None
+
+
+def _section_has_gcode_body(section_lines: list[str]) -> bool:
+    key = _last_section_param_key(section_lines)
+    return key is not None and _is_gcode_body_key(key)
+
+
+def _section_content_end(
+    base_lines: list[str], header_index: int, end_index: int
+) -> int:
+    """Trim the trailing column-0 comment block that belongs to the next section."""
+    last = end_index - 1
+    while last > header_index and base_lines[last].strip() == '':
+        last -= 1
+    if last <= header_index:
+        return end_index
+    if not base_lines[last].startswith('#'):
+        return end_index
+    if _section_has_gcode_body(base_lines[header_index:end_index]):
+        return end_index
+    start = last
+    while start > header_index and base_lines[start].startswith('#'):
+        start -= 1
+    return start + 1
+
+
+def is_mini_diff_block(text: str) -> bool:
+    """True when the block looks like a mini-diff edit of an existing section."""
+    lines = re.split(r'\r?\n', text)
+    has_header = False
+    has_marker = False
+    for line in lines:
+        if RE_DELETE_MARKER.search(line):
+            return False
+        if RE_SECTION_HEADER.search(line):
+            has_header = True
+            continue
+        if RE_MINI_DIFF_REMOVAL.search(line) or RE_MINI_DIFF_ADDITION.search(line):
+            has_marker = True
+    return has_header and has_marker
+
+
+def strip_mini_diff_markers(text: str) -> str:
+    """Strip the ``-``/``+`` mini-diff markers from a block, producing plain text."""
+    out: list[str] = []
+    for line in re.split(r'\r?\n', text):
+        marker = re.match(r'^(\s*)[-+](.*)$', line)
+        if not marker:
+            out.append(line)
+            continue
+        content = marker.group(2)
+        trimmed = content.lstrip()
+        out.append(trimmed if RE_PARAM_LINE.match(trimmed) else content)
+    return '\n'.join(out)
+
+
+def _extract_section_ops(
+    lines: list[str], header_index: int
+) -> list[dict]:
+    ops: list[dict] = []
+    current: dict | None = None
+
+    for index in range(header_index + 1, len(lines)):
+        line = lines[index]
+        if RE_SECTION_HEADER.search(line):
+            break
+
+        removal_match = RE_MINI_DIFF_REMOVAL.match(line)
+        if removal_match:
+            current = {'removal': removal_match.group(1), 'additions': []}
+            ops.append(current)
+            continue
+
+        addition_match = RE_MINI_DIFF_ADDITION.match(line)
+        if addition_match:
+            if current is not None:
+                current['additions'].append(addition_match.group(1))
+            else:
+                current = {
+                    'removal': None,
+                    'additions': [addition_match.group(1)],
+                }
+                ops.append(current)
+            continue
+
+    return ops
+
+
+def _find_base_index(base: list[str], used: set[int], predicate) -> int:
+    for index, line in enumerate(base):
+        if index not in used and predicate(line):
+            return index
+    return -1
+
+
+def _apply_ops_to_section(
+    section_lines: list[str], ops: list[dict]
+) -> list[str] | None:
+    base = [_normalize_line(line) for line in section_lines]
+    used: set[int] = set()
+    op_to_index: dict[int, int] = {}
+    op_to_indent: dict[int, str] = {}
+    append_additions: list[str] = []
+
+    for op_index, op in enumerate(ops):
+        if op['removal'] is None:
+            append_additions.extend(op['additions'])
+            continue
+
+        normalized_removal = _normalize_line(op['removal'])
+        stripped_removal = normalized_removal.lstrip()
+
+        match_index = _find_base_index(
+            base, used, lambda line: line == normalized_removal
+        )
+        if match_index == -1:
+            match_index = _find_base_index(
+                base, used, lambda line: line.lstrip() == stripped_removal
+            )
+        if match_index == -1 and _section_has_gcode_body(section_lines) \
+                and stripped_removal.strip() != '':
+            no_comment_removal = stripped_removal.split('#')[0].rstrip()
+            if no_comment_removal != '':
+                match_index = _find_base_index(
+                    base, used,
+                    lambda line: (
+                        line.lstrip().split('#')[0].rstrip()
+                        == no_comment_removal
+                    ),
+                )
+
+        if match_index == -1:
+            return None
+
+        used.add(match_index)
+        op_to_index[op_index] = match_index
+        op_to_indent[op_index] = _leading_whitespace(base[match_index])
+
+    result: list[str] = []
+    last_non_empty_index = -1
+
+    for index in range(len(section_lines)):
+        matched_op_index = -1
+        for op_index, base_index in op_to_index.items():
+            if base_index == index:
+                matched_op_index = op_index
+                break
+
+        if matched_op_index != -1:
+            op = ops[matched_op_index]
+            base_indent = op_to_indent.get(matched_op_index, '')
+            diff_indent = _leading_whitespace(op['removal'] or '')
+            additions: list[str] = []
+            for addition in op['additions']:
+                relative_indent = (
+                    len(_leading_whitespace(addition)) - len(diff_indent)
+                )
+                pad = ' ' * relative_indent if relative_indent > 0 else ''
+                additions.append(
+                    base_indent + pad + _normalize_line(addition).lstrip()
+                )
+            result.extend(additions)
+            for a in range(len(additions)):
+                if additions[a].strip() != '':
+                    last_non_empty_index = len(result) - 1
+            continue
+
+        result.append(section_lines[index])
+        if section_lines[index].strip() != '':
+            last_non_empty_index = len(result) - 1
+
+    if append_additions:
+        is_gcode_body = _section_has_gcode_body(section_lines)
+        normalized_additions: list[str] = []
+        for addition in append_additions:
+            line = _normalize_line(addition)
+            normalized_additions.append(line if is_gcode_body else line.lstrip())
+        result[last_non_empty_index + 1:last_non_empty_index + 1] = (
+            normalized_additions
+        )
+
+    return result
+
+
+def apply_mini_diff_block(block_text: str, base_file_text: str) -> dict:
+    """Apply a mini-diff cfg block against the current text of its target file.
+
+    Returns ``{'applied': bool, 'text': str}``.  On success ``text`` contains
+    only the edited sections materialized in full; on failure ``applied`` is
+    ``False`` and ``text`` is the original block (caller falls back to a full
+    section write).
+    """
+    if not is_mini_diff_block(block_text):
+        return {'applied': False, 'text': block_text}
+
+    block_lines = re.split(r'\r?\n', block_text)
+    base_lines = re.split(r'\r?\n', base_file_text)
+    output_sections: list[str] = []
+    any_failed = False
+
+    for block_index in range(len(block_lines)):
+        header_match = RE_SECTION_HEADER.match(block_lines[block_index])
+        if not header_match:
+            continue
+        header = header_match.group(1)
+
+        ops = _extract_section_ops(block_lines, block_index)
+        if not ops:
+            continue
+
+        header_index = -1
+        for bi, base_line in enumerate(base_lines):
+            base_match = RE_SECTION_HEADER.match(base_line)
+            if base_match and base_match.group(1) == header:
+                header_index = bi
+                break
+        if header_index == -1:
+            any_failed = True
+            continue
+
+        end_index = len(base_lines)
+        for scan in range(header_index + 1, len(base_lines)):
+            if RE_SECTION_HEADER.match(base_lines[scan]):
+                end_index = scan
+                break
+
+        section_lines = base_lines[
+            header_index:_section_content_end(base_lines, header_index, end_index)
+        ]
+        reconstructed = _apply_ops_to_section(section_lines, ops)
+        if reconstructed is None:
+            any_failed = True
+            continue
+
+        output_sections.append('\n'.join(reconstructed))
+
+    if any_failed or not output_sections:
+        return {'applied': False, 'text': block_text}
+    return {'applied': True, 'text': '\n\n'.join(output_sections)}
+
+
+# ── jinjaBlockRepair: constants and helpers ─────────────────────────────
+
+JINJA_CLOSER_BY_OPENER: dict[str, str] = {
+    'if': 'endif',
+    'for': 'endfor',
+    'while': 'endwhile',
+    'raw': 'endraw',
+    'macro': 'endmacro',
+    'block': 'endblock',
+    'filter': 'endfilter',
+    'call': 'endcall',
+    'with': 'endwith',
+}
+JINJA_OPENERS = set(JINJA_CLOSER_BY_OPENER.keys())
+
+# /{%\s*([a-zA-Z_]+)/g
+RE_JINJA_TAG = re.compile(r'{%\s*([a-zA-Z_]+)')
+# /^\s*gcode\s*[:=]\s*(#.*)?$/
+RE_GCODE_PARAM = re.compile(r'^\s*gcode\s*[:=]\s*(#.*)?$')
+# /^\s*[A-Za-z0-9_][A-Za-z0-9_.-]*\s*[:=]/
+RE_PARAM_KEY = re.compile(r'^\s*[A-Za-z0-9_][A-Za-z0-9_.-]*\s*[:=]')
+
+MACRO_SECTION_PREFIXES = ['gcode_macro ', 'delayed_gcode ']
+
+
+def _jinja_leading_whitespace(line: str) -> str:
+    match = re.match(r'^\s*', line)
+    return match.group(0) if match else ''
+
+
+def strip_inline_comment(line: str) -> str:
+    """Mirror Klipper's config parsing for one line (``_strip_inline_comments``)."""
+    hash_pos = line.find('#')
+    if hash_pos >= 0:
+        line = line[:hash_pos]
+    semi_match = re.search(r'(^|\s);', line)
+    if semi_match:
+        line = line[:semi_match.start() + len(semi_match.group(1)) + 1]
+    return line
+
+
+def find_unclosed_jinja_blocks_detailed(body: str) -> list[dict]:
+    """Return blocks still open at EOF, in open order, each ``{'opener','indent'}``."""
+    stack: list[dict] = []
+    for raw_line in body.split('\n'):
+        line = strip_inline_comment(raw_line)
+        for match in RE_JINJA_TAG.finditer(line):
+            tag = match.group(1)
+            if stack and stack[-1]['opener'] == 'raw':
+                if tag == 'endraw':
+                    stack.pop()
+                continue
+            if tag in JINJA_OPENERS:
+                stack.append({
+                    'opener': tag,
+                    'indent': _jinja_leading_whitespace(line),
+                })
+            elif tag == 'elif' or tag == 'else':
+                pass
+            elif tag.startswith('end'):
+                opener = tag[3:]
+                if stack and stack[-1]['opener'] == opener:
+                    stack.pop()
+    return stack
+
+
+def find_unclosed_jinja_blocks(body: str) -> list[str]:
+    return [block['opener'] for block in find_unclosed_jinja_blocks_detailed(body)]
+
+
+def repair_unclosed_jinja_block(body: str) -> dict | None:
+    """Append missing closers for unclosed blocks at the end of a gcode body."""
+    unclosed = find_unclosed_jinja_blocks_detailed(body)
+    if not unclosed:
+        return None
+    added: list[str] = []
+    for block in reversed(unclosed):
+        closer = JINJA_CLOSER_BY_OPENER.get(block['opener'])
+        if not closer:
+            continue
+        added.append(f"{block['indent']}{{% {closer} %}}")
+    if not added:
+        return None
+    added_text = '\n'.join(added)
+    if body.endswith('\n'):
+        repaired = body + added_text + '\n'
+    else:
+        repaired = body + '\n' + added_text
+    return {'repaired': repaired, 'added': added}
+
+
+def repair_unclosed_jinja_in_section_text(section_text: str) -> dict | None:
+    """Repair the gcode body of one macro section's raw text."""
+    lines = section_text.split('\n')
+    gcode_index = -1
+    for index, line in enumerate(lines):
+        if RE_GCODE_PARAM.match(line):
+            gcode_index = index
+            break
+    if gcode_index == -1:
+        return None
+
+    body_end = len(lines)
+    for index in range(gcode_index + 1, len(lines)):
+        line = lines[index]
+        if line.strip() == '':
+            continue
+        if RE_SECTION_HEADER.match(line):
+            body_end = index
+            break
+        if RE_PARAM_KEY.match(line):
+            body_end = index
+            break
+
+    body = '\n'.join(lines[gcode_index + 1:body_end])
+    repair = repair_unclosed_jinja_block(body)
+    if repair is None:
+        return None
+
+    repaired_body_lines = repair['repaired'].split('\n')
+    return {
+        'text': '\n'.join(
+            lines[:gcode_index + 1]
+            + repaired_body_lines
+            + lines[body_end:]
+        ),
+        'added': repair['added'],
+    }
+
+
+def repair_unclosed_jinja_in_config_text(config_text: str) -> dict:
+    """Repair every macro section in a raw cfg block with an unclosed Jinja block.
+
+    Returns ``{'text': str, 'repaired_sections': list[str]}`` where
+    ``repaired_sections`` holds the full headers of the sections touched.
+    """
+    lines = config_text.split('\n')
+    repaired_sections: list[str] = []
+    out: list[str] = []
+    section_start = -1
+    current_header = ''
+
+    def _flush_section(end_index: int) -> None:
+        nonlocal section_start, current_header
+        if section_start == -1:
+            return
+        section_lines = lines[section_start:end_index]
+        header_lower = current_header.lower()
+        if any(prefix in header_lower for prefix in MACRO_SECTION_PREFIXES):
+            repair = repair_unclosed_jinja_in_section_text(
+                '\n'.join(section_lines)
+            )
+            if repair:
+                out.extend(repair['text'].split('\n'))
+                repaired_sections.append(current_header)
+                return
+        out.extend(section_lines)
+
+    for index, line in enumerate(lines):
+        match = RE_SECTION_HEADER_INNER.match(line)
+        if match:
+            if section_start == -1:
+                out.extend(lines[:index])
+            else:
+                _flush_section(index)
+            section_start = index
+            current_header = match.group(1).strip()
+    _flush_section(len(lines))
+
+    if not repaired_sections:
+        return {'text': config_text, 'repaired_sections': []}
+    return {'text': '\n'.join(out), 'repaired_sections': repaired_sections}
+
+
+# ── configDiff: normalizeDiffText (for change detection) ────────────────
+
+def _normalize_diff_text(text: str) -> str:
+    lines = re.sub(r'\r\n?', '\n', text).split('\n')
+    lines = [re.sub(r'[ \t]+$', '', line) for line in lines]
+    normalized: list[str] = []
+    previous_blank = False
+    for line in lines:
+        is_blank = len(line.strip()) == 0
+        if is_blank and previous_blank:
+            continue
+        normalized.append(line)
+        previous_blank = is_blank
+    return '\n'.join(normalized)
+
+
+# ── Parsing / config text helpers ───────────────────────────────────────
+
+def parse_cfg_sections(text: str, filename: str) -> ConfigFile:
+    """Parse a config string into a ``ConfigFile`` via ``parser.parse_config``."""
+    return parse_config(text, filename)
+
+
+def _get_config_text(
+    filename: str, base_configs: dict[str, ConfigFile]
+) -> str:
+    """Current text of a base config (mirrors api.exportConfig/getConfigText)."""
+    cfg = base_configs.get(filename)
+    if cfg is None:
+        return ''
+    return smart_export(cfg)
+
+
+def _clone_config_with_raw_text(config: ConfigFile, raw_text: str) -> ConfigFile:
+    return ConfigFile(
+        filename=config.filename,
+        sections=list(config.sections),
+        includes=list(config.includes),
+        header_comments=list(config.header_comments),
+        raw_text=raw_text,
+    )
+
+
+# ── Top-level apply pipeline ────────────────────────────────────────────
+
+def apply_reply_to_configs(
+    reply_content: str, base_configs: dict[str, ConfigFile]
+) -> dict:
+    """Build merged configs from an assistant reply, mirroring the frontend.
+
+    Combines ``buildAssistantDraftTargetConfigs`` + ``prepareAssistantDraftPreview``
+    minus the preview: returns ``{'files': {...}, 'repaired_sections': [...],
+    'full_rewrite_sections': [...], 'errors': [...]}``.
+
+    Each entry of ``files`` maps ``filename`` to ``{'merged_config': ConfigFile,
+    'merged_text': str, 'changes': list[dict]}``.  ``errors`` holds
+    human-readable strings for the conditions under which the TS frontend
+    throws (no config block, no target file, no change, no sections).
+    """
+    errors: list[str] = []
+
+    config_blocks = extract_config_code_blocks(reply_content)
+    if not config_blocks:
+        return {
+            'files': {},
+            'repaired_sections': [],
+            'full_rewrite_sections': [],
+            'errors': [
+                'The assistant response did not include a config code block to review.'
+            ],
+        }
+
+    loaded_config_filenames = list(base_configs.keys())
+    # activeFile is not a parameter of the backend API; default to the first
+    # loaded config file so target resolution and mini-diff base lookups behave
+    # sensibly instead of binding to an empty filename.
+    active_file = loaded_config_filenames[0] if loaded_config_filenames else ''
+
+    hint_texts = [reply_content]
+    mentioned_filenames = extract_mentioned_config_filenames(
+        hint_texts, loaded_config_filenames
+    )
+
+    grouped_targets: dict[str, ConfigFile] = {}
+    repaired_sections: list[str] = []
+    full_rewrite_sections: list[dict] = []
+
+    for config_block in config_blocks:
+        config_text, file_hint = extract_assistant_file_hint(
+            config_block, loaded_config_filenames
+        )
+        if not config_text.strip():
+            continue
+
+        assistant_parse_filename = (
+            file_hint
+            or (mentioned_filenames[0] if mentioned_filenames else None)
+            or active_file
+            or (loaded_config_filenames[0] if loaded_config_filenames else None)
+            or 'printer.cfg'
+        )
+
+        draft_config_text = config_text
+        block_is_mini_diff = is_mini_diff_block(draft_config_text)
+        mini_diff_apply_failed = False
+        if block_is_mini_diff:
+            base_file_text = _get_config_text(
+                assistant_parse_filename, base_configs
+            )
+            if base_file_text:
+                applied = apply_mini_diff_block(
+                    draft_config_text, base_file_text
+                )
+                if applied['applied']:
+                    draft_config_text = applied['text']
+                else:
+                    mini_diff_apply_failed = True
+        if mini_diff_apply_failed:
+            draft_config_text = strip_mini_diff_markers(draft_config_text)
+
+        repair_result = repair_unclosed_jinja_in_config_text(draft_config_text)
+        if repair_result['repaired_sections']:
+            draft_config_text = repair_result['text']
+            repaired_sections.extend(repair_result['repaired_sections'])
+
+        processed_config_text = preprocess_delete_markers(draft_config_text)
+        assistant_result = parse_cfg_sections(
+            processed_config_text, assistant_parse_filename
+        )
+
+        if not assistant_result.sections:
+            continue
+
+        target_file = resolve_assistant_target_file(
+            assistant_result,
+            base_configs,
+            active_file,
+            [file_hint] if file_hint else mentioned_filenames,
+        )
+        if not target_file:
+            return {
+                'files': {},
+                'repaired_sections': [],
+                'full_rewrite_sections': [],
+                'errors': [
+                    'Unable to determine which config file should receive the assistant changes.'
+                ],
+            }
+
+        if not block_is_mini_diff or mini_diff_apply_failed:
+            for section in assistant_result.sections:
+                full_rewrite_sections.append({
+                    'filename': target_file,
+                    'full_header': section.full_header,
+                })
+
+        existing_target = grouped_targets.get(target_file)
+        if existing_target is not None:
+            grouped_targets[target_file] = ConfigFile(
+                filename=existing_target.filename,
+                includes=list(dict.fromkeys(
+                    list(existing_target.includes) + list(assistant_result.includes)
+                )),
+                header_comments=(
+                    list(existing_target.header_comments)
+                    if len(existing_target.header_comments) > 0
+                    else list(assistant_result.header_comments)
+                ),
+                sections=list(existing_target.sections)
+                    + list(assistant_result.sections),
+                raw_text=existing_target.raw_text,
+            )
+        else:
+            grouped_targets[target_file] = ConfigFile(
+                filename=target_file,
+                includes=list(assistant_result.includes),
+                header_comments=list(assistant_result.header_comments),
+                sections=list(assistant_result.sections),
+                raw_text=assistant_result.raw_text,
+            )
+
+    if not grouped_targets:
+        return {
+            'files': {},
+            'repaired_sections': [],
+            'full_rewrite_sections': [],
+            'errors': [
+                'The assistant response did not include any complete config sections to merge.'
+            ],
+        }
+
+    files: dict[str, dict] = {}
+
+    for target_file, assistant_config in grouped_targets.items():
+        base_text = _get_config_text(target_file, base_configs)
+
+        if not base_text:
+            # New file proposed by the assistant — merge against an empty base.
+            empty_base_config = ConfigFile(
+                filename=target_file,
+                includes=[],
+                header_comments=[],
+                sections=[],
+                raw_text='',
+            )
+            merged = merge_assistant_sections(
+                empty_base_config, assistant_config
+            )
+            merged_config = merged['merged_config']
+            merged_text = smart_export(
+                _clone_config_with_raw_text(merged_config, '')
+            )
+            files[target_file] = {
+                'merged_config': merged_config,
+                'merged_text': merged_text,
+                'changes': merged['changes'],
+            }
+            continue
+
+        base_result = parse_cfg_sections(base_text, target_file)
+        base_config = ConfigFile(
+            filename=target_file,
+            sections=list(base_result.sections),
+            includes=list(base_result.includes),
+            header_comments=list(base_result.header_comments),
+            raw_text=base_text,
+        )
+
+        merged = merge_assistant_sections(base_config, assistant_config)
+        merged_config = merged['merged_config']
+        merged_text = smart_export(
+            _clone_config_with_raw_text(merged_config, base_text)
+        )
+
+        text_changed = (
+            _normalize_diff_text(base_text)
+            != _normalize_diff_text(merged_text)
+        )
+        if not text_changed and not merged['changes']:
+            continue
+
+        files[target_file] = {
+            'merged_config': merged_config,
+            'merged_text': merged_text,
+            'changes': merged['changes'],
+        }
+
+    if not files:
+        errors.append('The assistant response does not change the current draft.')
+
+    return {
+        'files': files,
+        'repaired_sections': repaired_sections,
+        'full_rewrite_sections': full_rewrite_sections,
+        'errors': errors,
+    }

--- a/backend/services/ai_draft_apply.py
+++ b/backend/services/ai_draft_apply.py
@@ -54,6 +54,10 @@ CONFIG_CODE_LANGUAGES = frozenset(
 )
 ASSISTANT_FILE_HINT_RE = re.compile(r'^[#;]\s*file\s*:\s*(.+?)\s*$', re.IGNORECASE)
 
+# Mirror of MAX_ASSISTANT_HINT_USER_MESSAGES in draftValidation.ts: how many
+# preceding user messages contribute file-target hints.
+MAX_ASSISTANT_HINT_USER_MESSAGES = 3
+
 # A fenced ```code block: open fence, optional non-empty/backtick language,
 # then the block body until the closing ```.  Mirrors /```([^\n`]*)\n([\s\S]*?)```/g.
 RE_CODE_BLOCK = re.compile(r'```([^\n`]*)\n([\s\S]*?)```')
@@ -805,21 +809,27 @@ def _apply_ops_to_section(
             # Key-tolerant fallback for PARAM-SHAPED removals: models
             # routinely emit a stale old value (e.g. `-probe_count: 7,7`
             # against a section that already reads `3,3`). When the removed
-            # line is `key: value`/`key= value` shaped and the KEY exists in
-            # the base section, the intent is unambiguous — trust the key
-            # over the value. Without this the whole block aborts, the
-            # strip+full-section-write fallback keeps BOTH sides of every
-            # -/+ pair, and first-wins parsing silently selects the OLD
-            # value while dropping untouched section params (2026-09-09
-            # HARNESS-03 finding; the stated-requirement audit caught the
-            # corruption it caused). G-code lines are not param-shaped and
-            # never key-match — stale gcode content still falls back.
+            # line is `key: value`/`key= value` shaped and the KEY exists
+            # exactly ONCE among the section's unused lines, the intent is
+            # unambiguous — trust the key over the value. Without this the
+            # whole block aborts, the strip+full-section-write fallback
+            # keeps BOTH sides of every -/+ pair, and first-wins parsing
+            # silently selects the OLD value while dropping untouched
+            # section params (2026-09-09 HARNESS-03 finding; mirrored in
+            # frontend/src/utils/miniDiff.ts). Duplicate same-key lines
+            # (e.g. multiple `serial:` in [mcu]) stay AMBIGUOUS and fail
+            # the block instead of silently editing the wrong line
+            # (2026-09-10 review finding #12). G-code lines are not
+            # param-shaped and never key-match — stale gcode still falls
+            # back.
             removal_key = _param_key(stripped_removal)
-            if removal_key is not None:
-                match_index = _find_base_index(
-                    base, used,
-                    lambda line: _param_key(line.lstrip()) == removal_key,
-                )
+            if removal_key:
+                candidates = [
+                    index for index, line in enumerate(base)
+                    if index not in used and _param_key(line.lstrip()) == removal_key
+                ]
+                if len(candidates) == 1:
+                    match_index = candidates[0]
         if match_index == -1 and _section_has_gcode_body(section_lines) \
                 and stripped_removal.strip() != '':
             no_comment_removal = stripped_removal.split('#')[0].rstrip()
@@ -1162,7 +1172,10 @@ def _clone_config_with_raw_text(config: ConfigFile, raw_text: str) -> ConfigFile
 # ── Top-level apply pipeline ────────────────────────────────────────────
 
 def apply_reply_to_configs(
-    reply_content: str, base_configs: dict[str, ConfigFile]
+    reply_content: str,
+    base_configs: dict[str, ConfigFile],
+    active_file: str | None = None,
+    hint_texts: list[str] | None = None,
 ) -> dict:
     """Build merged configs from an assistant reply, mirroring the frontend.
 
@@ -1174,6 +1187,14 @@ def apply_reply_to_configs(
     'merged_text': str, 'changes': list[dict]}``.  ``errors`` holds
     human-readable strings for the conditions under which the TS frontend
     throws (no config block, no target file, no change, no sections).
+
+    ``active_file`` and ``hint_texts`` mirror the TS inputs: the editor's
+    active file, and the reply plus up to MAX_ASSISTANT_HINT_USER_MESSAGES
+    preceding user messages (useAssistantDraft.getAssistantMessageHintTexts).
+    Server callers with conversation context pass both; the defaults (first
+    loaded file, reply-only hints) exist for context-free callers and
+    resolve targets less accurately than the frontend would (2026-09-10
+    review finding #5).
     """
     errors: list[str] = []
 
@@ -1189,12 +1210,18 @@ def apply_reply_to_configs(
         }
 
     loaded_config_filenames = list(base_configs.keys())
-    # activeFile is not a parameter of the backend API; default to the first
-    # loaded config file so target resolution and mini-diff base lookups behave
-    # sensibly instead of binding to an empty filename.
-    active_file = loaded_config_filenames[0] if loaded_config_filenames else ''
+    # Target resolution inputs mirror the TS hook (finding #5). When the
+    # caller supplies active_file, prefer it when loaded; otherwise fall
+    # back to the first loaded config file.
+    if active_file and active_file in base_configs:
+        resolved_active_file = active_file
+    else:
+        resolved_active_file = loaded_config_filenames[0] if loaded_config_filenames else ''
 
-    hint_texts = [reply_content]
+    if hint_texts is None:
+        hint_texts = [reply_content]
+    elif reply_content not in hint_texts:
+        hint_texts = [reply_content, *hint_texts]
     mentioned_filenames = extract_mentioned_config_filenames(
         hint_texts, loaded_config_filenames
     )
@@ -1213,7 +1240,7 @@ def apply_reply_to_configs(
         assistant_parse_filename = (
             file_hint
             or (mentioned_filenames[0] if mentioned_filenames else None)
-            or active_file
+            or resolved_active_file
             or (loaded_config_filenames[0] if loaded_config_filenames else None)
             or 'printer.cfg'
         )
@@ -1252,7 +1279,7 @@ def apply_reply_to_configs(
         target_file = resolve_assistant_target_file(
             assistant_result,
             base_configs,
-            active_file,
+            resolved_active_file,
             [file_hint] if file_hint else mentioned_filenames,
         )
         if not target_file:

--- a/backend/services/ai_draft_apply.py
+++ b/backend/services/ai_draft_apply.py
@@ -646,6 +646,16 @@ RE_DELETE_MARKER = re.compile(r'^\s*\*\[[^\]]+\]\s*$')
 RE_PARAM_LINE = re.compile(r'^(\w[\w]*)\s*[:=]')
 
 
+def _param_key(line: str) -> str | None:
+    """Param key of a `key: value` / `key= value` line, else None.
+
+    G-code command lines (`SET_LED LED=x`, `G28`), jinja tags, and comments
+    never match — the mini-diff key-tolerant fallback relies on that to keep
+    stale gcode removals falling back instead of key-matching."""
+    match = RE_PARAM_LINE.match(line)
+    return match.group(1) if match else None
+
+
 def _normalize_line(line: str) -> str:
     """Strip CR and trailing whitespace only (JS normalizeLine)."""
     return line.rstrip()
@@ -791,6 +801,25 @@ def _apply_ops_to_section(
             match_index = _find_base_index(
                 base, used, lambda line: line.lstrip() == stripped_removal
             )
+        if match_index == -1 and stripped_removal.strip() != '':
+            # Key-tolerant fallback for PARAM-SHAPED removals: models
+            # routinely emit a stale old value (e.g. `-probe_count: 7,7`
+            # against a section that already reads `3,3`). When the removed
+            # line is `key: value`/`key= value` shaped and the KEY exists in
+            # the base section, the intent is unambiguous — trust the key
+            # over the value. Without this the whole block aborts, the
+            # strip+full-section-write fallback keeps BOTH sides of every
+            # -/+ pair, and first-wins parsing silently selects the OLD
+            # value while dropping untouched section params (2026-09-09
+            # HARNESS-03 finding; the stated-requirement audit caught the
+            # corruption it caused). G-code lines are not param-shaped and
+            # never key-match — stale gcode content still falls back.
+            removal_key = _param_key(stripped_removal)
+            if removal_key is not None:
+                match_index = _find_base_index(
+                    base, used,
+                    lambda line: _param_key(line.lstrip()) == removal_key,
+                )
         if match_index == -1 and _section_has_gcode_body(section_lines) \
                 and stripped_removal.strip() != '':
             no_comment_removal = stripped_removal.split('#')[0].rstrip()

--- a/backend/services/ai_draft_validation.py
+++ b/backend/services/ai_draft_validation.py
@@ -23,10 +23,6 @@ import re
 # Mirror of RETRY_EXEMPT_CODES in draftValidation.ts.
 RETRY_EXEMPT_CODES = frozenset({"project_duplicate", "shared_pin"})
 
-# Mirror of MAX_ASSISTANT_DRAFT_VALIDATION_ATTEMPTS (frontend keeps 3 for
-# its own loop; the server harness does ONE repair, per the design doc).
-SERVER_REPAIR_LIMIT = 1
-
 _JINJA_INNERMOST_BLOCK_RE = re.compile(
     r"The innermost block that needs to be closed is '([a-z_]+)'", re.IGNORECASE
 )

--- a/backend/services/ai_draft_validation.py
+++ b/backend/services/ai_draft_validation.py
@@ -1,0 +1,198 @@
+"""Server-side merged-result validation for AI chat replies (#1).
+
+Port of the validated frontend logic in
+``frontend/src/utils/draftValidation.ts`` (REPAIR-01 wording is measured —
+encode, don't re-derive; see kwc-ai-chat-pipeline skill):
+
+- delta semantics: candidate errors minus baseline multiset (pre-existing
+  user-config errors never block a draft),
+- retry-exempt codes (``project_duplicate``, ``shared_pin``): the model
+  can't fix these by regenerating,
+- REPAIR-01 feedback shape: never quote the previous reply, lean context
+  only, exact validator error + imperative fix, Jinja closer commands
+  derived from the Klippy "innermost block" message.
+
+Used by ``chat_proxy`` when KWC_SERVER_DRAFT_VALIDATION is enabled: the
+backend applies the reply (ai_draft_apply), validates the MERGED result,
+and issues at most ONE lean repair query.
+"""
+from __future__ import annotations
+
+import re
+
+# Mirror of RETRY_EXEMPT_CODES in draftValidation.ts.
+RETRY_EXEMPT_CODES = frozenset({"project_duplicate", "shared_pin"})
+
+# Mirror of MAX_ASSISTANT_DRAFT_VALIDATION_ATTEMPTS (frontend keeps 3 for
+# its own loop; the server harness does ONE repair, per the design doc).
+SERVER_REPAIR_LIMIT = 1
+
+_JINJA_INNERMOST_BLOCK_RE = re.compile(
+    r"The innermost block that needs to be closed is '([a-z_]+)'", re.IGNORECASE
+)
+_JINJA_CLOSER_BY_OPENER = {
+    "if": "endif",
+    "for": "endfor",
+    "while": "endwhile",
+    "raw": "endraw",
+    "macro": "endmacro",
+    "block": "endblock",
+    "filter": "endfilter",
+    "call": "endcall",
+    "with": "endwith",
+}
+
+
+def _error_key(filename: str, error: dict) -> str:
+    return "::".join(
+        [
+            filename,
+            error.get("severity", ""),
+            error.get("section", ""),
+            error.get("param", ""),
+            error.get("message", ""),
+        ]
+    )
+
+
+def _is_blocking(error: dict) -> bool:
+    return error.get("severity") in ("error", "warning")
+
+
+def is_retry_exempt(error: dict) -> bool:
+    return bool(error.get("code")) and error["code"] in RETRY_EXEMPT_CODES
+
+
+def collect_new_validation_errors(
+    baseline_validations: dict[str, dict],
+    candidate_validations: dict[str, dict],
+) -> list[dict]:
+    """Mirror of collectNewValidationErrors: candidate minus baseline multiset.
+
+    Returns ``[{"filename": str, "errors": [error-dict, ...]}, ...]`` sorted
+    by filename, exactly like the TS grouped-issue list.
+    """
+    baseline_counts: dict[str, int] = {}
+    for filename, result in baseline_validations.items():
+        for error in result.get("errors", []):
+            if not _is_blocking(error):
+                continue
+            key = _error_key(filename, error)
+            baseline_counts[key] = baseline_counts.get(key, 0) + 1
+
+    blocking_by_file: dict[str, list[dict]] = {}
+    for filename in sorted(candidate_validations):
+        result = candidate_validations[filename]
+        for error in result.get("errors", []):
+            if not _is_blocking(error):
+                continue
+            key = _error_key(filename, error)
+            remaining = baseline_counts.get(key, 0)
+            if remaining > 0:
+                baseline_counts[key] = remaining - 1
+                continue
+            blocking_by_file.setdefault(filename, []).append(error)
+
+    return [{"filename": f, "errors": errs} for f, errs in blocking_by_file.items()]
+
+
+def has_only_retry_exempt_issues(blocking_issues: list[dict]) -> bool:
+    issues = [e for group in blocking_issues for e in group["errors"]]
+    return bool(issues) and all(is_retry_exempt(e) for e in issues)
+
+
+def suppress_errors_shadowed_by_full_rewrite(blocking_issues: list[dict]) -> list[dict]:
+    """Mirror of suppressValidationErrorsShadowedByFullRewrite: when the
+    full-rewrite guard flags a section, drop other errors for the same
+    file+section — they are guard artifacts and fight its directive."""
+    guard_keys = set()
+    for group in blocking_issues:
+        for error in group["errors"]:
+            if error.get("code") == "macro_full_rewrite":
+                guard_keys.add(f"{group['filename']}::{error.get('section', '')}")
+    if not guard_keys:
+        return blocking_issues
+    out = []
+    for group in blocking_issues:
+        kept = [
+            e for e in group["errors"]
+            if f"{group['filename']}::{e.get('section', '')}" in guard_keys
+            or e.get("code") == "macro_full_rewrite"
+        ]
+        if kept:
+            out.append({"filename": group["filename"], "errors": kept})
+    return out
+
+
+def derive_jinja_repair_commands(blocking_issues: list[dict]) -> list[str]:
+    """Mirror of deriveJinjaRepairCommands (validated wording)."""
+    commands: list[str] = []
+    seen = set()
+    for group in blocking_issues:
+        for error in group["errors"]:
+            if error.get("code") != "macro_jinja_unterminated":
+                continue
+            match = _JINJA_INNERMOST_BLOCK_RE.search(error.get("message", ""))
+            if not match:
+                continue
+            closer = _JINJA_CLOSER_BY_OPENER.get(match.group(1).lower())
+            if not closer:
+                continue
+            section = f"[{error['section']}]" if error.get("section") else ""
+            key = f"{section}:{closer}"
+            if key in seen:
+                continue
+            seen.add(key)
+            commands.append(
+                f"The innermost open Jinja block in {section or 'the macro'} is "
+                f"'{match.group(1)}' — append {{% {closer} %}} at the end of its gcode body."
+            )
+    return commands
+
+
+def format_validation_issues(blocking_issues: list[dict], failure_reason: str | None) -> str:
+    lines: list[str] = []
+    if failure_reason:
+        lines.append(f"- {failure_reason}")
+    for group in blocking_issues:
+        lines.append(f"File: {group['filename']}")
+        for error in group["errors"]:
+            section = error.get("section", "")
+            param = error.get("param", "")
+            location = f"[{section}] {param}" if param else f"[{section}]"
+            lines.append(f"- {location}: {error.get('message', '')}")
+    return "\n".join(lines)
+
+
+def build_validation_feedback(
+    blocking_issues: list[dict],
+    failure_reason: str | None,
+    allow_explanation_only: bool = False,
+) -> str:
+    """Mirror of buildAssistantDraftValidationFeedback — REPAIR-01 shape.
+
+    NOTE: unlike the frontend version this never receives the invalid
+    content; nothing quotes the previous reply by construction.
+    """
+    formatted = format_validation_issues(blocking_issues, failure_reason) or (
+        "- The previous reply did not include a complete applicable cfg draft."
+    )
+    repair_commands = derive_jinja_repair_commands(blocking_issues)
+    parts = [
+        "Your cfg changes failed validation after merging into the current project.",
+        "Return a corrected replacement reply that fixes every problem below and still satisfies the user request.",
+        'If you return config changes, return only changed content inside fenced cfg code blocks and keep any required "# file: <filename>" hint. To edit an existing section use a mini-diff (section header plus only the changed lines, "-" removed / "+" added with original indentation); unchanged lines are preserved automatically. To add a new section, write it in full.',
+        "Do NOT copy or repeat your previous reply. Emit a fresh mini-diff with ONLY the corrected lines.",
+        "If you need the current content of any affected section, fetch it yourself with read_user_config (filename=..., section=...) instead of reconstructing it from memory.",
+        (
+            "If the remaining problems are duplicate sections or reused pins and you cannot resolve them safely from the current config, do not return another invalid cfg block. Instead, clearly explain the conflict, mention the exact section or pin involved, and say what must change before a valid config can be produced."
+            if allow_explanation_only
+            else "Do not ask the user to apply manual fixes for these validation issues."
+        ),
+        "",
+        "Validation problems to fix:",
+        formatted,
+    ]
+    if repair_commands:
+        parts.extend(["", "Direct fixes:"] + [f"- {c}" for c in repair_commands])
+    return "\n".join(parts)

--- a/backend/services/ai_reply_audit.py
+++ b/backend/services/ai_reply_audit.py
@@ -96,6 +96,24 @@ def check_stated_requirements(
     available = _merged_param_values(merged_files)
     notes: list[str] = []
     for key, values in requested.items():
+        if key not in available:
+            # Typo/alias tolerance: 'max_acceleration' → real param
+            # 'max_accel' (prefix match). The validator rejects unknown
+            # params outright, so an unknown stated key with a close real
+            # sibling means the repair pipeline already resolved it —
+            # check the sibling instead of crying wolf. GUARDED: siblings
+            # must be ≥8 chars and ≥half the requested key's length, or a
+            # bare `probe` would swallow `probe_count` (different params).
+            aliases = [
+                k for k in available
+                if (k.startswith(key) or key.startswith(k))
+                and min(len(k), len(key)) >= 8
+                and min(len(k), len(key)) * 2 >= max(len(k), len(key))
+            ]
+            if aliases:
+                key = min(aliases, key=len)
+            # Unknown key with no sibling: fall through so it is flagged as
+            # "no value" — the requirement demonstrably did not land.
         have = available.get(key, [])
         for want in values:
             # Grid values: "5x5" matches stored "5,5" / "5, 5" / "5x5".
@@ -105,11 +123,15 @@ def check_stated_requirements(
             norm_have = [_norm_grid(h) for h in have]
             if any(_num_eq(want, h) or _norm_grid(want) == h for h in norm_have):
                 continue
+            if not have:
+                found_desc = "no value"
+            elif len(have) == 1:
+                found_desc = f"`{have[0]}`"
+            else:
+                found_desc = f"`{have[0]}` (found: {', '.join('`' + h + '`' for h in have[:4])})"
             notes.append(
                 f"Your message asked for `{key}` = `{want}`, but the merged config has "
-                f"{'`' + have[0] + '`' if have else 'no'}"
-                + (f" (found: {', '.join('`' + h + '`' for h in have[:4])})" if len(have) > 1 else "")
-                + " for that parameter. Review whether the change landed."
+                f"{found_desc} for that parameter. Review whether the change landed."
             )
     return notes
 
@@ -169,27 +191,48 @@ def check_macro_preconditions(changed_gcode_bodies: list[tuple[str, str]]) -> li
 # ── 3. LED / sibling-section inventory sweep ─────────────────────────
 
 _LED_TYPE_RE = re.compile(r"^(neopixel|dotstar|led|pca9533|pca9685)\b")
+# LED commands in changed gcode count as touching that LED even when the
+# EDITED section isn't an LED section (TRIDENT-15 class: SET_LED added to
+# [idle_timeout] for one strip only). Literal command-argument matching on
+# the AST-enumerated strip names — deterministic, observation-only.
+_LED_CMD_RE = re.compile(r"\bSET_LED\b|\bSTOP_LED_EFFECTS\b|\bSET_LED_EFFECTS\b",
+                         re.IGNORECASE)
 
 
 def check_led_inventory(
     changed_section_headers: list[str],
     project_files: dict[str, ConfigFile],
+    changed_gcode_bodies: list[tuple[str, str]] | None = None,
 ) -> list[str]:
-    """If the change touched an LED section, list every LED section in the
-    project so none is silently left inconsistent."""
+    """If the change touched an LED section (or runs an LED command naming
+    a strip), list every LED section in the project so none is silently
+    left inconsistent."""
     touched_led = [h for h in changed_section_headers if _LED_TYPE_RE.match(h)]
-    if not touched_led:
+    touched_names = {h.split(None, 1)[1] for h in touched_led if " " in h}
+    for _, body in changed_gcode_bodies or []:
+        if not _LED_CMD_RE.search(body):
+            continue
+        for filename, cfg in project_files.items():
+            for section in cfg.sections:
+                if _LED_TYPE_RE.match(section.full_header) and " " in section.full_header:
+                    strip_name = section.full_header.split(None, 1)[1]
+                    if re.search(rf"\b{re.escape(strip_name)}\b", body):
+                        touched_names.add(strip_name)
+    if not touched_names:
         return []
     inventory: list[str] = []
     for filename, cfg in project_files.items():
         for section in cfg.sections:
-            if _LED_TYPE_RE.match(section.full_header) and section.full_header not in touched_led:
+            if not _LED_TYPE_RE.match(section.full_header):
+                continue
+            strip_name = section.full_header.split(None, 1)[1] if " " in section.full_header else ""
+            if strip_name and strip_name not in touched_names:
                 inventory.append(f"[{section.full_header}] ({filename})")
     if not inventory:
         return []
     return [
         "This change touches "
-        + ", ".join(f"`[{h}]`" for h in touched_led)
+        + ", ".join(f"`{n}`" for n in sorted(touched_names))
         + ". Other LED sections in the project were NOT changed: "
         + ", ".join(inventory)
         + ". Check whether they need the same change."
@@ -217,5 +260,7 @@ def run_post_apply_audit(
     notes: list[str] = []
     notes.extend(check_stated_requirements(user_message, merged_files))
     notes.extend(check_macro_preconditions(changed_gcode_bodies))
-    notes.extend(check_led_inventory(changed_section_headers, merged_files))
+    notes.extend(check_led_inventory(
+        changed_section_headers, merged_files, changed_gcode_bodies
+    ))
     return notes

--- a/backend/services/ai_reply_audit.py
+++ b/backend/services/ai_reply_audit.py
@@ -1,0 +1,221 @@
+"""Deterministic post-apply audit for AI chat replies (#3).
+
+Three checks that run UNCONDITIONALLY on harness code after a reply is
+produced — never model-callable tools (the "model must choose to call it"
+gap is exactly what this design rejects, see kwc-ai-chat-pipeline skill):
+
+1. ``check_stated_requirements`` — regex over the user's own message for
+   literal stated values ("set max_accel to 12000", "probe_count: 3x3")
+   and verifies each appears in the applied/merged config. Source: the
+   user's message + the merged ConfigFiles (AST), not model output.
+2. ``check_macro_preconditions`` — static precondition table on gcode
+   bodies that were added/changed (BED_MESH_CALIBRATE needs homing, etc.).
+   Source: static Klipper knowledge, no parsing guesswork.
+3. ``check_led_inventory`` — when a change touches an LED-ish section,
+   enumerate ALL LED/strip sections in the project from the AST so the
+   model can't silently leave siblings inconsistent (TRIDENT-15/16 class).
+
+Every check only ever ATTACHES an observation note. A wrong check is a
+useless note; it never changes routing, the model's input, or whether the
+reply is accepted (intent-guessing law). Notes are appended to the final
+reply under a clearly-marked audit footer.
+"""
+from __future__ import annotations
+
+import re
+
+from parser.config_parser import ConfigFile
+
+# ── 1. Stated-requirement checker ────────────────────────────────────
+
+# "<verb> <param> to/at/= <value>" and "<param> to/at/= <value>" where the
+# param looks like a Klipper snake_case key. Verb list keeps us from
+# matching prose questions ("what is max_velocity?" has no target value).
+_REQ_VERB_RE = re.compile(
+    r"\b(?:set|change|update|make|raise|lower|increase|decrease|adjust|tune)\b"
+    r"[^.\n]{0,40}?\b([a-z][a-z0-9_]{2,})\b(?:\s+(?:to|at|=|->|:))\s+"
+    r"(-?\d+(?:\.\d+)?)\b",
+    re.IGNORECASE,
+)
+# Bare "<param> = <value>" / "<param>: <value>" phrasing ("max_accel: 12000").
+_REQ_BARE_RE = re.compile(
+    r"\b([a-z][a-z0-9_]{2,})\s*(?:=|:)\s*(-?\d+(?:\.\d+)?)(?!\s*(?:x|px)\b)",
+)
+# "<param> NxM" grid values (probe_count 3x3, mesh_pps 2x2).
+_REQ_GRID_RE = re.compile(
+    r"\b(probe_count|mesh_pps|speed_vompute)\b\s*(?:=|:|to|at)?\s*(\d+)\s*[xX]\s*(\d+)",
+)
+
+# Params so generic that a bare mention would produce noise; the verb form
+# is required for these.
+_BARE_SKIP_PARAMS = frozenset(
+    {"value", "count", "size", "number", "length", "width", "height", "min", "max", "timeout", "pin", "name"}
+)
+
+
+def _num_eq(a: str, b: str) -> bool:
+    try:
+        return float(a) == float(b)
+    except ValueError:
+        return a.strip() == b.strip()
+
+
+def _merged_param_values(merged_files: dict[str, ConfigFile]) -> dict[str, list[str]]:
+    """param key -> [values] across every section of every merged file."""
+    out: dict[str, list[str]] = {}
+    for cfg in merged_files.values():
+        for section in cfg.sections:
+            for param in section.params:
+                if param.is_commented_out:
+                    continue
+                out.setdefault(param.key, []).append(param.value)
+    return out
+
+
+def check_stated_requirements(
+    user_message: str,
+    merged_files: dict[str, ConfigFile],
+) -> list[str]:
+    """Literal values the user asked for that are NOT in the merged result."""
+    requested: dict[str, list[str]] = {}
+    for m in _REQ_VERB_RE.finditer(user_message):
+        requested.setdefault(m.group(1).lower(), []).append(m.group(2))
+    for m in _REQ_BARE_RE.finditer(user_message):
+        key = m.group(1).lower()
+        if key in _BARE_SKIP_PARAMS:
+            continue
+        requested.setdefault(key, []).append(m.group(2))
+    grids: list[tuple[str, str]] = []
+    for m in _REQ_GRID_RE.finditer(user_message):
+        grids.append((m.group(1).lower(), f"{m.group(2)}x{m.group(3)}"))
+        requested.setdefault(m.group(1).lower(), []).append(f"{m.group(2)}x{m.group(3)}")
+
+    if not requested:
+        return []
+
+    available = _merged_param_values(merged_files)
+    notes: list[str] = []
+    for key, values in requested.items():
+        have = available.get(key, [])
+        for want in values:
+            # Grid values: "5x5" matches stored "5,5" / "5, 5" / "5x5".
+            def _norm_grid(v: str) -> str:
+                return re.sub(r"[\s,]+", "x", v.strip().lower()).rstrip("x")
+
+            norm_have = [_norm_grid(h) for h in have]
+            if any(_num_eq(want, h) or _norm_grid(want) == h for h in norm_have):
+                continue
+            notes.append(
+                f"Your message asked for `{key}` = `{want}`, but the merged config has "
+                f"{'`' + have[0] + '`' if have else 'no'}"
+                + (f" (found: {', '.join('`' + h + '`' for h in have[:4])})" if len(have) > 1 else "")
+                + " for that parameter. Review whether the change landed."
+            )
+    return notes
+
+
+# ── 2. Macro precondition table ──────────────────────────────────────
+
+# command -> (precondition note, regex that satisfies it anywhere EARLIER in
+# the same macro body). Static Klipper knowledge; keep entries only where a
+# violation is a real runtime failure, not a style preference.
+_PRECONDITIONS: list[tuple[str, re.Pattern, str, re.Pattern]] = [
+    (
+        "BED_MESH_CALIBRATE",
+        re.compile(r"\bBED_MESH_CALIBRATE\b"),
+        "bed mesh calibration requires the toolhead to be homed first",
+        re.compile(r"\bG28\b|\bQUAD_GANTRY_LEVEL\b"),
+    ),
+    (
+        "PROBE_CALIBRATE",
+        re.compile(r"\bPROBE_CALIBRATE\b"),
+        "probe calibration requires a homed, stable toolhead",
+        re.compile(r"\bG28\b"),
+    ),
+    (
+        "QGL",
+        re.compile(r"\bQUAD_GANTRY_LEVEL\b"),
+        "quad gantry level requires the printer homed and usually heated",
+        re.compile(r"\bG28\b"),
+    ),
+    (
+        "CALIBRATE_Z_OFFSET",
+        re.compile(r"\bCALIBRATE_Z_OFFSET\b"),
+        "z-offset calibration requires the toolhead homed",
+        re.compile(r"\bG28\b"),
+    ),
+]
+
+
+def check_macro_preconditions(changed_gcode_bodies: list[tuple[str, str]]) -> list[str]:
+    """(section_header, gcode_body) for macros that were added/changed."""
+    notes: list[str] = []
+    for header, body in changed_gcode_bodies:
+        for name, cmd_re, note, satisfied_re in _PRECONDITIONS:
+            match = cmd_re.search(body)
+            if not match:
+                continue
+            before = body[: match.start()]
+            if satisfied_re.search(before) or satisfied_re.search(body[match.end():]):
+                continue
+            notes.append(
+                f"`[{header}]` calls {name}, which {note}, but the macro never runs "
+                f"`G28`. Consider adding a homing step (or confirming the macro is "
+                f"only ever called after homing)."
+            )
+    return notes
+
+
+# ── 3. LED / sibling-section inventory sweep ─────────────────────────
+
+_LED_TYPE_RE = re.compile(r"^(neopixel|dotstar|led|pca9533|pca9685)\b")
+
+
+def check_led_inventory(
+    changed_section_headers: list[str],
+    project_files: dict[str, ConfigFile],
+) -> list[str]:
+    """If the change touched an LED section, list every LED section in the
+    project so none is silently left inconsistent."""
+    touched_led = [h for h in changed_section_headers if _LED_TYPE_RE.match(h)]
+    if not touched_led:
+        return []
+    inventory: list[str] = []
+    for filename, cfg in project_files.items():
+        for section in cfg.sections:
+            if _LED_TYPE_RE.match(section.full_header) and section.full_header not in touched_led:
+                inventory.append(f"[{section.full_header}] ({filename})")
+    if not inventory:
+        return []
+    return [
+        "This change touches "
+        + ", ".join(f"`[{h}]`" for h in touched_led)
+        + ". Other LED sections in the project were NOT changed: "
+        + ", ".join(inventory)
+        + ". Check whether they need the same change."
+    ]
+
+
+# ── Footer assembly ──────────────────────────────────────────────────
+
+_AUDIT_HEADER = "\n\n---\n_Harness checks (automatic, not the model):_"
+
+
+def build_audit_footer(notes: list[str]) -> str:
+    if not notes:
+        return ""
+    return _AUDIT_HEADER + "\n" + "\n".join(f"- {n}" for n in notes)
+
+
+def run_post_apply_audit(
+    user_message: str,
+    merged_files: dict[str, ConfigFile],
+    changed_gcode_bodies: list[tuple[str, str]],
+    changed_section_headers: list[str],
+) -> list[str]:
+    """Run all three audits; returns the combined observation notes."""
+    notes: list[str] = []
+    notes.extend(check_stated_requirements(user_message, merged_files))
+    notes.extend(check_macro_preconditions(changed_gcode_bodies))
+    notes.extend(check_led_inventory(changed_section_headers, merged_files))
+    return notes

--- a/backend/services/native_services.py
+++ b/backend/services/native_services.py
@@ -238,6 +238,81 @@ def is_backup_config_file(name: str) -> bool:
     return bool(_BACKUP_CONFIG_RE.match(Path(name).name))
 
 
+def load_native_project(base: Path, seed_files: list[str]) -> tuple[dict, dict, list[str]]:
+    """Read seed config files from ``base`` and expand to the ON-DISK include
+    closure, mirroring Klipper's configfile.py _resolve_include.
+
+    Shared by the /api/native/config-files/read route and the MCP
+    validate_config_project tool so the V2.6.0 symlink-closure semantics
+    (third-party .cfg files symlinked INTO the config dir are followed even
+    though list_config_files hides them behind the traversal guard; include
+    specs resolve relative to the INCLUDING file; only ACTIVE includes are
+    followed; globs are skipped) can never fork between the two surfaces.
+
+    Returns ``(configs, raw_texts, skipped_includes)``:
+      - configs: filename -> parsed ConfigFile (keys are POSIX relative paths)
+      - raw_texts: filename -> file text
+      - skipped_includes: include specs skipped as glob/escaping/missing
+    Raises ValueError on a requested filename that escapes the config dir.
+    """
+    # Validate requested paths stay under base (don't resolve symlinks).
+    for fn in seed_files:
+        if '..' in fn or fn.startswith('/'):
+            raise ValueError(f"Invalid filename: {fn}")
+        candidate = base / fn
+        try:
+            candidate.relative_to(base)
+        except ValueError:
+            raise ValueError(f"Invalid filename: {fn}")
+
+    from parser.config_parser import parse_config
+
+    configs: dict = {}
+    raw_texts: dict[str, str] = {}
+    skipped: list[str] = []
+    for fn in seed_files:
+        file_path = base / fn
+        if not file_path.exists():
+            continue
+        text = read_config_file(str(file_path))
+        configs[fn] = parse_config(text, fn)
+        raw_texts[fn] = text
+
+    pending = list(configs)
+    while pending:
+        fn = pending.pop()
+        for include_spec in configs[fn].includes:
+            spec = include_spec.strip()
+            if not spec:
+                continue
+            inc_dir = os.path.dirname(fn.replace("\\", "/"))
+            rel = os.path.normpath(
+                os.path.join(inc_dir, spec) if inc_dir else spec
+            )
+            # The include ENTRY must stay lexically inside the config dir (the
+            # same boundary the requested-name check enforces); its symlink
+            # target may live anywhere, exactly like Klipper.
+            if os.path.isabs(rel) or Path(rel).parts[0] == "..":
+                skipped.append(spec)
+                continue
+            if rel in configs:
+                continue
+            if glob.has_magic(rel):
+                # Globs are never resolvable in-memory; legal when empty.
+                skipped.append(spec)
+                continue
+            file_path = base / rel
+            if not file_path.exists():  # follows symlinks
+                skipped.append(spec)
+                continue
+            text = read_config_file(str(file_path))
+            configs[rel] = parse_config(text, rel)
+            raw_texts[rel] = text
+            pending.append(rel)
+
+    return configs, raw_texts, skipped
+
+
 def list_config_files(config_dir: str) -> list[dict]:
     """List .cfg files in the given directory and its subdirectories.
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "klipper-wire-configurator",
   "private": true,
-  "version": "2.6.1",
+  "version": "2.6.2",
   "type": "module",
   "scripts": {
     "prepare:reference": "node scripts/generate-examples.js",

--- a/frontend/src/components/dialogs/ChatDialog.tsx
+++ b/frontend/src/components/dialogs/ChatDialog.tsx
@@ -376,6 +376,10 @@ const ChatDialog: React.FC<ChatDialogProps> = ({
           temperature: parseTemperature(editTemperature),
           toolProtocol: editToolProtocol,
           fullRewriteGuard: FULL_REWRITE_GUARD_ENABLED,
+          // Server-side target resolution mirror (finding #5): the backend's
+          // merged-result validation resolves an edit's target file with the
+          // same activeFile the client's draft pipeline uses.
+          activeFile,
         };
 
         // Build context messages

--- a/frontend/src/hooks/useAssistantDraft.ts
+++ b/frontend/src/hooks/useAssistantDraft.ts
@@ -48,6 +48,8 @@ import { normalizeDiffText } from '../utils/configDiff';
 import { isMiniDiffBlock, applyMiniDiffBlock, stripMiniDiffMarkers } from '../utils/miniDiff';
 import { repairUnclosedJinjaInConfigText } from '../utils/jinjaBlockRepair';
 import type { ReplyValidator } from '../utils/replyValidation';
+import { serverRetryExemptWarning } from '../utils/replyValidation';
+import type { ServerRepairVerdict } from '../services/api';
 
 // Full-rewrite guard flag: when disabled (default), the model may return an
 // existing macro/Jinja section as a full block write and it is accepted;
@@ -85,6 +87,8 @@ interface AssistantReplyAttempt {
   assistantMessage: ChatMessage;
   conversationMessages: ChatMessage[];
   warningMessage: string | null;
+  /** Backend merged-result verdict for this reply (finding #4). */
+  serverRepair?: ServerRepairVerdict | null;
 }
 
 interface ChatRequestBase {
@@ -534,7 +538,12 @@ export function useAssistantDraft() {
         }
       }
 
-      return { assistantMessage, conversationMessages: conversationTrail, warningMessage };
+      return {
+        assistantMessage,
+        conversationMessages: conversationTrail,
+        warningMessage,
+        serverRepair: response.serverRepair ?? null,
+      };
     },
     [],
   );
@@ -703,8 +712,22 @@ export function useAssistantDraft() {
 
         // Duplicate-section / shared-pin issues the AI cannot resolve are
         // advisory only after one retry — keep the reply and warn instead.
-        const giveUp =
+        let giveUp =
           context.isRetry && hasOnlyRetryExemptAssistantValidationIssues(outcome.blockingIssues);
+
+        // Finding #4: when the server-side pass already classified this
+        // reply's remaining issues as retry-exempt, do NOT burn the client
+        // retry round discovering the same thing — give up immediately
+        // (warning carries the server's exact findings).
+        let warningOnGiveUp: string | null = null;
+        const issuesPresent = outcome.blockingIssues.some((g) => g.errors.length > 0);
+        if (issuesPresent && !giveUp) {
+          const serverWarning = serverRetryExemptWarning(context.serverRepair);
+          if (serverWarning) {
+            giveUp = true;
+            warningOnGiveUp = serverWarning;
+          }
+        }
 
         return {
           applicable: true,
@@ -720,12 +743,12 @@ export function useAssistantDraft() {
           failureReason: null,
           giveUp,
           repairCount: outcome.repairedSections.length,
-          warningOnGiveUp: giveUp
+          warningOnGiveUp: warningOnGiveUp ?? (giveUp
             ? [
                 `AI draft still has duplicate section or pin-conflict validation issues after ${context.attemptsUsed + 1} attempts. The assistant response was returned so it can explain the conflict.`,
                 formatAssistantDraftValidationIssues(outcome.blockingIssues, null),
               ].join('\n')
-            : null,
+            : null),
         };
       },
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -875,6 +875,18 @@ export interface AiChatResponse {
   toolCalls?: AiToolCallDetail[];
   /** Number of empty-response re-prompts the backend performed before content. */
   repromptCount?: number;
+  /**
+   * Server-side merged-result validation result (backend
+   * KWC_SERVER_DRAFT_VALIDATION=1). Null when the server pass did not run.
+   * `repaired: true` means the returned content already passed merged
+   * validation — the client retry loop can trust it.
+   */
+  serverRepair?: {
+    attempted: boolean;
+    repaired: boolean;
+    issuesAfter: Array<{ filename: string; errors: unknown[] }>;
+    reason?: string;
+  } | null;
 }
 
 /**

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -854,6 +854,12 @@ export interface AiChatRequest {
    * frontend acceptance behavior.
    */
   fullRewriteGuard?: boolean;
+  /**
+   * The editor's active file. Backend-only use: server-side merged-result
+   * validation resolves an edit's target file with the same activeFile the
+   * client draft pipeline uses (never injected into prompts).
+   */
+  activeFile?: string;
 }
 
 export interface AiToolCallDetail {
@@ -881,12 +887,15 @@ export interface AiChatResponse {
    * `repaired: true` means the returned content already passed merged
    * validation — the client retry loop can trust it.
    */
-  serverRepair?: {
-    attempted: boolean;
-    repaired: boolean;
-    issuesAfter: Array<{ filename: string; errors: unknown[] }>;
-    reason?: string;
-  } | null;
+  serverRepair?: ServerRepairVerdict | null;
+}
+
+/** Wire shape of the backend `serverRepair` response field (finding #4). */
+export interface ServerRepairVerdict {
+  attempted: boolean;
+  repaired: boolean;
+  issuesAfter: Array<{ filename: string; errors: unknown[] }>;
+  reason?: string;
 }
 
 /**

--- a/frontend/src/utils/__tests__/miniDiff.test.ts
+++ b/frontend/src/utils/__tests__/miniDiff.test.ts
@@ -589,6 +589,27 @@ algorithm: bicubic
     );
     expect(result.applied).toBe(false);
   });
+
+  it('duplicate same-key lines stay ambiguous: stale removal fails closed (#12)', () => {
+    const base = '[mcu mcu]\nserial: /dev/ttyUSB0\nserial: /dev/ttyAMA0\nbaud: 250000\n';
+    const result = applyMiniDiffBlock(
+      '[mcu mcu]\n-serial: /dev/ttyS999\n+serial: /dev/ttyUSB5',
+      base,
+    );
+    expect(result.applied).toBe(false);
+  });
+
+  it('duplicate same-key exact-value removal still applies (#12)', () => {
+    const base = '[mcu mcu]\nserial: /dev/ttyUSB0\nserial: /dev/ttyAMA0\nbaud: 250000\n';
+    const result = applyMiniDiffBlock(
+      '[mcu mcu]\n-serial: /dev/ttyAMA0\n+serial: /dev/ttyAMA1',
+      base,
+    );
+    expect(result.applied).toBe(true);
+    expect(result.text).toContain('serial: /dev/ttyUSB0');
+    expect(result.text).toContain('serial: /dev/ttyAMA1');
+    expect(result.text).not.toContain('serial: /dev/ttyAMA0');
+  });
 });
 
 describe('stripMiniDiffMarkers', () => {

--- a/frontend/src/utils/__tests__/miniDiff.test.ts
+++ b/frontend/src/utils/__tests__/miniDiff.test.ts
@@ -289,13 +289,22 @@ gcode:
     expect(result.text).toContain('      M117 homed');
   });
 
-  it('still fails when content differs despite indentation tolerance', () => {
+  it('stale param value still applies via key-tolerant match (HARNESS-03)', () => {
+    // Contract change 2026-09-09: a param-shaped removal whose KEY exists
+    // in the base section applies even when the value is stale. The old
+    // fail-closed behavior here was the HARNESS-03 corruption path: the
+    // aborted block fell back to strip+full-section-write, keeping both
+    // sides of every -/+ pair, and first-wins parsing selected the OLD
+    // value while dropping untouched params.
     const base = `[printer]\nmax_accel: 15500\n`;
     const result = applyMiniDiffBlock(
       '[printer]\n-    max_accel: 99999\n+    max_accel: 18000',
       base,
     );
-    expect(result.applied).toBe(false);
+    expect(result.applied).toBe(true);
+    expect(result.text).toContain('max_accel: 18000');
+    expect(result.text).not.toContain('15500');
+    expect(result.text).not.toContain('99999');
   });
 
   it('appends add-only lines at the end of a plain section', () => {
@@ -487,13 +496,20 @@ algorithm: bicubic
     expect(result.text).toContain('    M104 S0');
   });
 
-  it('does not use comment-tolerant matching on plain (non-gcode) sections', () => {
+  it('applies param removal with omitted trailing comment via key fallback', () => {
+    // Contract change 2026-09-09: this used to fail closed (comment-
+    // tolerant matching was gcode-body-only). The key-tolerant fallback
+    // now matches the `max_accel` key regardless of value/comment drift —
+    // the desired edit lands instead of aborting into the corrupting
+    // full-section-write fallback (HARNESS-03).
     const base = `[printer]\nmax_accel: 15500 #Ellis Tuned\n`;
     const result = applyMiniDiffBlock(
       '[printer]\n-max_accel: 15500\n+max_accel: 18000',
       base,
     );
-    expect(result.applied).toBe(false);
+    expect(result.applied).toBe(true);
+    expect(result.text).toContain('max_accel: 18000');
+    expect(result.text).not.toContain('15500');
   });
 
   it('fails the WHOLE block when one section cannot be applied (atomicity)', () => {
@@ -513,6 +529,62 @@ algorithm: bicubic
     const base = `[gcode_macro A]\ngcode:\n    G28\n`;
     const result = applyMiniDiffBlock(
       '[gcode_macro A]\n-    G28\n+    G28 X0\n\n[gcode_macro NEW_MACRO]\n-    M104\n+    M104 S0',
+      base,
+    );
+    expect(result.applied).toBe(false);
+  });
+
+  // Stale-removal key-tolerant fallback (2026-09-09 HARNESS-03 finding;
+  // mirrored in tests/test_ai_draft_apply.py).
+  it('matches a stale param removal by key and keeps untouched params', () => {
+    const base = [
+      '[bed_mesh]',
+      'speed: 500',
+      'horizontal_move_z: 2',
+      'mesh_min: 5,5',
+      'zero_reference_position: 175, 175',
+      '',
+      'probe_count: 3,3',
+      'algorithm: bicubic',
+      '',
+      '[probe]',
+      'speed: 3',
+      '',
+    ].join('\n');
+    const result = applyMiniDiffBlock(
+      '[bed_mesh]\n-speed: 500\n+speed: 8\n-probe_count: 7,7\n+probe_count: 3,3',
+      base,
+    );
+    expect(result.applied).toBe(true);
+    expect(result.text).toContain('speed: 8');
+    expect(result.text).toContain('probe_count: 3,3');
+    expect(result.text).toContain('horizontal_move_z: 2');
+    expect(result.text).toContain('zero_reference_position: 175, 175');
+    expect(result.text).toContain('algorithm: bicubic');
+  });
+
+  it('key-tolerant delete-only removal removes the param line', () => {
+    const base = '[bed_mesh]\nspeed: 500\nprobe_count: 3,3\n';
+    // stale removal value: matches the `speed` key, not the value
+    const result = applyMiniDiffBlock('[bed_mesh]\n-speed: 999', base);
+    expect(result.applied).toBe(true);
+    expect(result.text).not.toContain('speed:');
+    expect(result.text).toContain('probe_count: 3,3');
+  });
+
+  it('key fallback does NOT invent params whose key is absent (atomic fail)', () => {
+    const base = '[bed_mesh]\nspeed: 500\n';
+    const result = applyMiniDiffBlock(
+      '[bed_mesh]\n-not_a_param: 7,7\n+not_a_param: 3,3',
+      base,
+    );
+    expect(result.applied).toBe(false);
+  });
+
+  it('key fallback never matches stale gcode command lines', () => {
+    const base = '[gcode_macro PARK]\ngcode:\n    G28 X\n    G1 Z5 F1500\n';
+    const result = applyMiniDiffBlock(
+      '[gcode_macro PARK]\n-G1 Z9 F1500\n+G1 Z10 F1500',
       base,
     );
     expect(result.applied).toBe(false);

--- a/frontend/src/utils/__tests__/replyValidation.test.ts
+++ b/frontend/src/utils/__tests__/replyValidation.test.ts
@@ -222,3 +222,96 @@ describe('runReplyValidationPipeline', () => {
     expect(result.retryCount).toBe(1);
   });
 });
+
+describe('serverRetryExemptWarning (finding #4)', () => {
+  it('returns null for absent/clean/non-exempt verdicts', async () => {
+    const { serverRetryExemptWarning } = await import('@/utils/replyValidation');
+    expect(serverRetryExemptWarning(null)).toBeNull();
+    expect(serverRetryExemptWarning(undefined)).toBeNull();
+    expect(
+      serverRetryExemptWarning({ attempted: false, repaired: false, issuesAfter: [] }),
+    ).toBeNull();
+    expect(
+      serverRetryExemptWarning({
+        attempted: true, repaired: false, issuesAfter: [], reason: 'something-else',
+      }),
+    ).toBeNull();
+  });
+
+  it('renders the server findings when reason is retry-exempt', async () => {
+    const { serverRetryExemptWarning } = await import('@/utils/replyValidation');
+    const warning = serverRetryExemptWarning({
+      attempted: false,
+      repaired: false,
+      reason: 'retry-exempt',
+      issuesAfter: [{
+        filename: 'printer.cfg',
+        errors: [{ severity: 'error', section: 'fan', param: 'pin', message: "Pin 'PB3' is used by multiple sections" }],
+      }],
+    });
+    expect(warning).toContain('printer.cfg');
+    expect(warning).toContain('[fan] pin');
+    expect(warning).toContain('cannot fix by regenerating');
+  });
+});
+
+describe('runReplyValidationPipeline serverRepair plumbing', () => {
+  function params(over: Partial<ReplyValidationPipelineParams>): ReplyValidationPipelineParams {
+    return {
+      requestFn: async () => attempt(assistant('y')),
+      requestConversation: [{ role: 'user', content: 'q' }],
+      validationConversation: [user('q')],
+      initialAttempt: attempt(assistant('x')),
+      validators: [],
+      ...over,
+    };
+  }
+
+  it('passes the attempt serverRepair verdict into the validator context', async () => {
+    const verdict = {
+      attempted: false, repaired: false, reason: 'retry-exempt',
+      issuesAfter: [{ filename: 'printer.cfg', errors: [] }],
+    };
+    let seen: unknown = 'unset';
+    const validator: ReplyValidator = {
+      name: 'ctx-probe',
+      maxAttempts: 3,
+      failMode: 'warn',
+      validate: (_content, context) => {
+        seen = context.serverRepair;
+        return { applicable: false, issues: [], failureReason: null };
+      },
+      buildFeedback: () => null,
+      onMaxAttemptsReached: () => null,
+    };
+    const p = params({
+      initialAttempt: { ...attempt(assistant('x')), serverRepair: verdict },
+      requestFn: async () => attempt(assistant('y')),
+      validators: [validator],
+    });
+    await runReplyValidationPipeline(p);
+    expect(seen).toEqual(verdict);
+  });
+
+  it('defaults the context verdict to null when the attempt has none', async () => {
+    let seen: unknown = 'unset';
+    const validator: ReplyValidator = {
+      name: 'ctx-probe',
+      maxAttempts: 3,
+      failMode: 'warn',
+      validate: (_content, context) => {
+        seen = context.serverRepair;
+        return { applicable: false, issues: [], failureReason: null };
+      },
+      buildFeedback: () => null,
+      onMaxAttemptsReached: () => null,
+    };
+    const p = params({
+      initialAttempt: attempt(assistant('x')),
+      requestFn: async () => attempt(assistant('y')),
+      validators: [validator],
+    });
+    await runReplyValidationPipeline(p);
+    expect(seen).toBeNull();
+  });
+});

--- a/frontend/src/utils/miniDiff.ts
+++ b/frontend/src/utils/miniDiff.ts
@@ -48,6 +48,14 @@ const SECTION_HEADER_RE = /^\s*(\[[^\]]+\])\s*$/;
 const DELETE_MARKER_RE = /^\s*\*\[[^\]]+\]\s*$/;
 /** Column-0 param line (`key: value` / `key= value`) — mirrors the parser. */
 const PARAM_LINE_RE = /^(\w[\w]*)\s*[:=]/;
+
+/** Param key of a param-shaped line, else null. G-code command lines,
+ * jinja tags, and comments never match (see the key-tolerant fallback in
+ * applyOpsToSection). */
+function paramKey(line: string): string | null {
+  return PARAM_LINE_RE.exec(line)?.[1] ?? null;
+}
+
 /** Config-file hint line such as `# file: printer.cfg`. */
 const FILE_HINT_RE = /^\s*[#;]\s*file\s*:/i;
 
@@ -338,6 +346,25 @@ function applyOpsToSection(
       matchIndex = base.findIndex(
         (line, index) => !used.has(index) && line.trimStart() === strippedRemoval,
       );
+    }
+    if (matchIndex === -1 && strippedRemoval.trim() !== '') {
+      // Key-tolerant fallback for PARAM-SHAPED removals: models routinely
+      // emit a stale old value (e.g. `-probe_count: 7,7` against a section
+      // that already reads `3,3`). When the removed line is `key: value`/
+      // `key= value` shaped and the KEY exists in the base section, the
+      // intent is unambiguous — trust the key over the value. Without this
+      // the whole block aborts, the strip+full-section-write fallback keeps
+      // BOTH sides of every -/+ pair, and first-wins parsing silently
+      // selects the OLD value while dropping untouched section params
+      // (2026-09-09 HARNESS-03 finding; mirrored in
+      // backend/services/ai_draft_apply.py). G-code lines are not
+      // param-shaped and never key-match — stale gcode still falls back.
+      const removalKey = paramKey(strippedRemoval);
+      if (removalKey) {
+        matchIndex = base.findIndex(
+          (line, index) => !used.has(index) && paramKey(line.trimStart()) === removalKey,
+        );
+      }
     }
     if (matchIndex === -1 && sectionHasGcodeBody(sectionLines) && strippedRemoval.trim() !== '') {
       // gcode-body lines frequently carry trailing `# comments` that the model

--- a/frontend/src/utils/miniDiff.ts
+++ b/frontend/src/utils/miniDiff.ts
@@ -357,13 +357,19 @@ function applyOpsToSection(
       // BOTH sides of every -/+ pair, and first-wins parsing silently
       // selects the OLD value while dropping untouched section params
       // (2026-09-09 HARNESS-03 finding; mirrored in
-      // backend/services/ai_draft_apply.py). G-code lines are not
-      // param-shaped and never key-match — stale gcode still falls back.
+      // backend/services/ai_draft_apply.py). Duplicate same-key lines
+      // (e.g. multiple `serial:` in [mcu]) stay AMBIGUOUS and fail the
+      // block instead of silently editing the wrong line (2026-09-10
+      // review finding #12). G-code lines are not param-shaped and never
+      // key-match — stale gcode still falls back.
       const removalKey = paramKey(strippedRemoval);
       if (removalKey) {
-        matchIndex = base.findIndex(
-          (line, index) => !used.has(index) && paramKey(line.trimStart()) === removalKey,
-        );
+        const candidates = base
+          .map((line, index) => ({ line, index }))
+          .filter(({ line, index }) => !used.has(index) && paramKey(line.trimStart()) === removalKey);
+        if (candidates.length === 1) {
+          matchIndex = candidates[0].index;
+        }
       }
     }
     if (matchIndex === -1 && sectionHasGcodeBody(sectionLines) && strippedRemoval.trim() !== '') {

--- a/frontend/src/utils/replyValidation.ts
+++ b/frontend/src/utils/replyValidation.ts
@@ -12,7 +12,7 @@
  * domain-specific validation and feedback logic.
  */
 import type { ChatMessage } from '../stores/aiStore';
-import type { AiChatRole } from '../services/api';
+import type { AiChatRole, ServerRepairVerdict } from '../services/api';
 import {
   MAX_PRINTER_MEMORY_VALIDATION_ATTEMPTS,
   buildPrinterMemoryValidationFeedback,
@@ -63,6 +63,14 @@ export interface ReplyValidationContext {
   attemptsUsed: number;
   /** From the previous feedback: AI may explain instead of producing output. */
   allowExplanationOnly: boolean;
+  /**
+   * Server-side merged-result validation verdict for THIS attempt
+   * (backend KWC_SERVER_DRAFT_VALIDATION). The validator may trust a
+   * decisive verdict instead of re-deriving the same delta checks
+   * (finding #4): `repaired: true` = the returned content already passed;
+   * `reason: 'retry-exempt'` = only issues regeneration cannot fix.
+   */
+  serverRepair?: ServerRepairVerdict | null;
 }
 
 export interface ReplyValidator {
@@ -83,6 +91,31 @@ export interface ReplyRequestAttempt {
   assistantMessage: ChatMessage;
   conversationMessages: ChatMessage[];
   warningMessage: string | null;
+  /** Backend verdict for this attempt's reply, when the server pass ran. */
+  serverRepair?: ServerRepairVerdict | null;
+}
+
+/**
+ * Trust the backend's retry-exempt verdict (finding #4): when the server
+ * already classified the reply's only remaining issues as ones the model
+ * cannot fix by regenerating (duplicate sections / shared pins), the
+ * client must not burn a retry round discovering the same thing. Returns
+ * the giveUp warning text, or null when the verdict says nothing decisive
+ * (no verdict, clean, or a repairable failure — those stay on the normal
+ * client path).
+ */
+export function serverRetryExemptWarning(verdict?: ServerRepairVerdict | null): string | null {
+  if (!verdict || verdict.reason !== 'retry-exempt') return null;
+  const lines = (verdict.issuesAfter || []).flatMap((group) =>
+    (group.errors as Array<{ section?: string; param?: string; message?: string }>).map((error) => {
+      const location = error.param ? `[${error.section}] ${error.param}` : `[${error.section}]`;
+      return `- ${group.filename}: ${location}: ${error.message ?? 'retry-exempt validation issue'}`;
+    }),
+  );
+  return [
+    'The server-side merged-config validation found only issues the assistant cannot fix by regenerating (duplicate sections or pin conflicts). The response was kept as-is.',
+    ...lines,
+  ].join('\n');
 }
 
 export type ReplyRequestFn = (
@@ -141,6 +174,7 @@ export async function runReplyValidationPipeline(
         isRetry: attemptsUsed > 0,
         attemptsUsed,
         allowExplanationOnly,
+        serverRepair: currentAttempt.serverRepair ?? null,
       };
 
       const result = await validator.validate(currentAttempt.assistantMessage.content, context);

--- a/scripts/ai_chat_accuracy_test.py
+++ b/scripts/ai_chat_accuracy_test.py
@@ -190,7 +190,12 @@ def build_questions() -> list[TestQuestion]:
             title="Docs: [bed_mesh] horizontal_move_z",
             text="What does the `horizontal_move_z` parameter in the `[bed_mesh]` section do, "
                  "and what is its default value?",
-            expected_tools=("search_klipper_docs", "get_config_reference_section"),
+            expected_tools=("search_klipper_docs", "get_config_reference_section",
+                            # get_section_schema legitimately answers parameter/
+                            # default questions (added 2026-09; bank criteria
+                            # predated it — 2026-09-09 A/B flagged PASS_WRONG_TOOL
+                            # for perfect answers routed through it).
+                            "get_section_schema"),
             criteria=(
                 ("contains", "horizontal_move_z"),
                 ("regex", r"\b5\b"),
@@ -201,7 +206,8 @@ def build_questions() -> list[TestQuestion]:
             title="Docs: [probe] section parameters",
             text="List all the parameters supported by the [probe] section in Klipper, "
                  "with their types where possible.",
-            expected_tools=("get_config_reference_section", "search_klipper_docs"),
+            expected_tools=("get_config_reference_section", "search_klipper_docs",
+                            "get_section_schema"),
             criteria=(
                 ("contains", "z_offset"),
                 ("contains", "samples"),
@@ -239,7 +245,8 @@ def build_questions() -> list[TestQuestion]:
             title="Schema: [heater_fan] section schema",
             text="What is the section schema for [heater_fan]? "
                  "List the supported parameters and their types.",
-            expected_tools=("get_config_reference_section",),
+            # get_section_schema is THE purpose-built tool for this now.
+            expected_tools=("get_config_reference_section", "get_section_schema"),
             criteria=(
                 ("contains", "heater_fan"),
                 ("contains", "max_power"),
@@ -382,7 +389,8 @@ def build_questions() -> list[TestQuestion]:
             qid="Q18",
             title="Grounding: pressure_advance default",
             text="What is the default value of pressure_advance in the [extruder] section?",
-            expected_tools=("search_klipper_docs", "get_config_reference_section"),
+            expected_tools=("search_klipper_docs", "get_config_reference_section",
+                            "get_section_schema"),
             criteria=(
                 ("regex", r"default.{0,120}?\b0\b"),
             ),
@@ -507,7 +515,10 @@ def build_macro_questions() -> list[TestQuestion]:
                 # produced the variable names is no longer advertised.
                 ("regex", r"(?:PARK_X[^\n]*100|X100)"),
                 ("regex", r"(?:PARK_Y[^\n]*150|Y150)"),
-                ("regex", r"(?:LIFT_Z[^\n]*20|Z20\b)"),
+                # Variable-name-agnostic: models pick LIFT_Z or Z_LIFT (or
+                # inline Z_LIFT=20 / Z20); requiring the exact identifier
+                # measured model quality zero (2026-09-09 both runs).
+                ("regex", r"(?:LIFT[^\n]*20|Z[^\n]*LIFT[^\n]*20|\bZ20\b)"),
                 ("regex", r"(?:RETRACT[^\n]*3\b|E-?3\b)"),
             ),
         ),
@@ -659,6 +670,39 @@ def _load_kinematics_bugged_printer_cfg() -> str:
             "could not plant kinematics bug — marker not found in printer.cfg"
         )
     return bugged
+
+
+def _load_probe_params_printer_cfg() -> str:
+    """Real Trident printer.cfg with [bed_mesh] probe_count 7,7 -> 3,3.
+
+    HARNESS-03 fixture: the requirement checker's stated-value pattern
+    (`probe_count` `3x3`) is PRE-SATISFIED in the base config, so a correct
+    edit that merely keeps it must produce NO audit footer — this question
+    watches for checker false positives while legitimately exercising the
+    clean-apply audit path."""
+    content = _load_trident_config("printer.cfg")
+    bugged = content.replace("probe_count: 7,7", "probe_count: 3,3", 1)
+    if bugged == content:
+        raise RuntimeError(
+            "could not plant probe_count — marker not found in printer.cfg"
+        )
+    return bugged
+
+
+def _load_trident_led_context() -> tuple[tuple[str, str, str], ...]:
+    """printer.cfg + EBB.cfg + Hotkey.cfg together — all three real LED
+    sections (SB_LEDs, Chamber_LEDs, hotkey_leds) visible in one project.
+
+    HARNESS-02 fixture: the prompt asks to kill "all lights" via
+    idle_timeout; every model tested so far (gemma AND qwen, TRIDENT-15/16
+    history) turns off exactly one strip. With all three sections present
+    the deterministic LED inventory MUST append its footer naming the two
+    untouched strips — this is the audit's live-firing probe. The timeout
+    is left at the stock 1800 so the model has a real edit to make."""
+    return tuple(
+        (fname, TRIDENT_FILE_LABEL, _load_trident_config(fname))
+        for fname in ("printer.cfg", "EBB.cfg", "Hotkey.cfg")
+    )
 
 
 def _context_with(content: str,
@@ -974,6 +1018,76 @@ def build_trident_questions() -> list[TestQuestion]:
                 ("contains", "hotkey_leds"),
             ),
         ),
+        # ── HARNESS-01..03: probes for the server-side apply/validate/
+        # repair (#1) and post-apply audit (#3) machinery. These judge
+        # the HARNESS, not the model: each is engineered so the pipeline
+        # has a deterministic observable, captured via the serverRepair
+        # response field / audit footer in the report JSON.
+        TestQuestion(
+            qid="HARNESS-01",
+            title="Repair-probe: typo'd param name must trigger ONE repair",
+            text=("In printer.cfg set the printer's max_acceleration to 9000. "
+                  "Only change that one value."),
+            # max_acceleration is NOT a real [printer] param (the real one
+            # is max_accel) — a plain user typo. If the model writes it
+            # verbatim, the merged result fails validation (unknown_param)
+            # and the server harness MUST fire its ONE repair pass. Pass =
+            # the reply standing in front of the user carries the correct
+            # param (repaired, or never wrong). The serverRepair field in
+            # the report records whether repair actually fired.
+            context_files=printer_cfg,
+            require_tool=False,
+            criteria=(
+                ("regex", r"max_accel(?!eration)\s*:\s*9000"),
+                ("not_contains", "max_acceleration: 9000"),
+            ),
+        ),
+        TestQuestion(
+            qid="HARNESS-02",
+            title="Audit-probe: partial LED edit must surface the inventory footer",
+            text=("Add SET_LED commands for Chamber_LEDs only to my "
+                  "idle_timeout gcode in printer.cfg, and set the timeout to "
+                  "300 seconds. Do exactly that — no other changes."),
+            # Deterministic partial edit: the user (deliberately) asks for
+            # only ONE strip while all three LED sections (SB_LEDs,
+            # Chamber_LEDs, hotkey_leds) are visible in the project. The
+            # model SHOULD comply — and the deterministic LED inventory
+            # MUST append the 'Harness checks' footer naming the two
+            # untouched strips, because the edit touches an LED via
+            # SET_LED. This is the user-protection path: a real user who
+            # didn't think to say "all LEDs" gets the observation.
+            # (2026-09-09 finding behind this design: when asked for "all
+            # LEDs" with all files attached, gemma turns off ALL three —
+            # TRIDENT-15's historic failure was context visibility, not
+            # capability. So the audit's live-firing probe needs the
+            # partial request, not the complete one.)
+            context_files=_load_trident_led_context(),
+            require_tool=False,
+            criteria=(
+                ("regex", r"timeout\s*:\s*300\b"),
+                ("regex", r"Harness checks"),
+                ("regex", r"SB_LEDs"),
+                ("regex", r"hotkey_leds"),
+            ),
+        ),
+        TestQuestion(
+            qid="HARNESS-03",
+            title="Audit false-positive probe: pre-satisfied requirement = silent footer",
+            text=("Set my bed mesh probe speed to 8 in printer.cfg and keep "
+                  "the current probe_count of 3x3."),
+            # Fixture has probe_count 3,3 PRE-SATISFIED so a correct edit
+            # that keeps it must produce NO requirement-checker note. The
+            # stated-value pattern ('probe_count ... 3x3') is exercised
+            # live; a footer here = checker false positive = product bug.
+            # (Real stock value is 7,7 — fixture only. The real [bed_mesh]
+            # param is 'speed'; 'probe speed' is how users say it.)
+            context_files=_context_with(_load_probe_params_printer_cfg()),
+            require_tool=False,
+            criteria=(
+                ("regex", r"speed\s*:\s*8"),
+                ("not_contains", "Harness checks"),
+            ),
+        ),
         TestQuestion(
             qid="MINIDIFF-01",
             title="Mini-diff: level_bed adaptive (endif invariant)",
@@ -1061,7 +1175,12 @@ def build_ambiguity_questions() -> list[TestQuestion]:
             require_tool=False,
             criteria=(
                 ("regex", r"ender\s*3"),
-                ("regex", r"#\s*file\s*:\s*printer\.cfg"),
+                # Its own docstring: a draft OR a clarifying question are both
+                # legitimate outcomes (2026-09-09: gemma AND qwen both asked
+                # which mainboard — the correct refusal when board hardware is
+                # unknowable). Accept either.
+                ("regex", r"#\s*file\s*:\s*printer\.cfg"
+                          r"|mainboard|board|MCU|provide|need to know"),
             ),
         ),
         TestQuestion(
@@ -1601,13 +1720,27 @@ def extract_printer_memory(content: str) -> tuple[str, dict | None]:
 # ── Evaluation ─────────────────────────────────────────────────────────
 def criterion_ok(kind: str, value: str, content: str,
                  memory: tuple[str, dict | None] | None = None,
-                 tool_calls: list[dict] | None = None) -> bool:
+                 tool_calls: list[dict] | None = None,
+                 server_repair: dict | None = None) -> bool:
     if kind == "contains":
         return value.lower() in content.lower()
     if kind == "not_contains":
         return value.lower() not in content.lower()
     if kind == "regex":
         return re.search(value, content, re.IGNORECASE | re.DOTALL) is not None
+    if kind == "server_repair_or_absent":
+        # HARNESS-01 (repair-probe): pass when the server-side repair
+        # actually fired (attempted=True — machinery proven), OR when the
+        # token never landed in a cfg BLOCK (prose mentions are fine — a
+        # repaired reply legitimately says "removed bogus_param"). Only
+        # FAILS when the invalid token was applied AND the server harness
+        # stayed silent.
+        token = value.lower()
+        if server_repair and server_repair.get("attempted"):
+            return True
+        blocks = re.findall(r"```[a-zA-Z]*\n.*?```", content, re.DOTALL)
+        scope = "\n".join(blocks) if blocks else content
+        return token not in scope.lower()
     if kind == "memory_block":
         return bool(memory and memory[0])
     if kind == "memory_valid":
@@ -1701,6 +1834,10 @@ class QuestionResult:
     checks: list[tuple[str, str, bool]] = field(default_factory=list)
     duration_s: float = 0.0
     usage: dict | None = None
+    # Server-side apply/validate/repair outcome (#1): {attempted, repaired,
+    # issuesAfter} or None when the pipeline was skipped (no config block or
+    # no contextFiles). Tallied across runs to measure the harness itself.
+    server_repair: dict | None = None
 
 
 # ── HTTP helpers (stdlib only) ─────────────────────────────────────────
@@ -1768,8 +1905,17 @@ def chat_request(base_url: str, question: TestQuestion, settings: dict,
     Returns (response_dict, error_string). Exactly one is set.
     """
     request_id = f"accuracy-{question.qid}-{int(time.time())}"
+    # Production parity (2026-09-09): the frontend sends the checked files as
+    # contextFiles so the server-side apply/validate/repair + audit (#1/#3)
+    # can actually run. Without this, the bank tests a path the app never
+    # takes and the server harness is structurally unexercisable.
+    context_files = {
+        filename: {"content": content}
+        for filename, _label, content in question.context_files
+    }
     payload = {
         "messages": _build_chat_messages(question),
+        "contextFiles": context_files,
         "apiKey": settings["api_key"],
         "model": settings["model"],
         "apiUrl": settings["api_url"],
@@ -1872,6 +2018,7 @@ def run_one_question(
         result.tool_turns = int(response.get("mcpToolTurns", 0) or 0)
         result.tool_calls = list(response.get("toolCalls", []) or [])
         result.usage = response.get("usage")
+        result.server_repair = response.get("serverRepair")
 
         log.write(f"Response mcpToolTurns={result.tool_turns} "
                   f"mcpToolNames={result.tool_names}")
@@ -1906,7 +2053,8 @@ def run_one_question(
             memory = extract_printer_memory(result.response)
             for kind, value in q.criteria:
                 ok = criterion_ok(kind, value, result.response, memory=memory,
-                                  tool_calls=result.tool_calls)
+                                  tool_calls=result.tool_calls,
+                                  server_repair=result.server_repair)
                 result.checks.append((kind, value, ok))
             result.answer_ok = all(ok for _, _, ok in result.checks)
             if result.answer_ok and result.tool_ok:

--- a/scripts/ai_chat_accuracy_test.py
+++ b/scripts/ai_chat_accuracy_test.py
@@ -1290,6 +1290,170 @@ def build_setup_questions() -> list[TestQuestion]:
     ]
 
 
+def build_live_context_questions() -> list[TestQuestion]:
+    """Live-context tools (feature/config-mcp-tools, 2026-09): the four
+    host-grounded tools validate_config_project, list_connected_devices,
+    get_section_schema, get_klippy_status — plus the draft-vs-disk and
+    schema-vs-reference routing boundaries.
+
+    HOST PREREQUISITES (run against a NATIVE backend, e.g. the dev Pi
+    :8099): the config dir ON THE SERVER is what the validate/device tools
+    read — the harness attaches no files here; the tool call IS the
+    context. Dev-Pi ground truth these criteria were written against:
+    KAMP_Settings.cfg has missing-include errors (./KAMP/*.cfg not on
+    disk), duplicate [idle_timeout]/M109 sections surface as info, a
+    Klipper RP2040 sits on /dev/serial/by-id/, and NO klippy socket exists
+    (get_klippy_status must report not-responding). On the Trident the
+    ground truth differs (klippy ready) — LIVE-06/07 criteria accept a
+    correct readout of EITHER state; the strong gate is the tool call.
+
+    Routing note: LIVE-04's expected_tools is the schema tool ALONE, so a
+    correct-but-reference answer grades PASS_WRONG_TOOL — that column IS
+    the routing measurement for the 2026-09 snippet reroute; read the
+    tools column, not just the pass count.
+    """
+    return [
+        TestQuestion(
+            qid="LIVE-01",
+            title="Live validate: 'validate my config' must call the project validator",
+            text="can you validate my config? tell me what's wrong with it",
+            # No context_files on purpose: the ONLY way to see the real
+            # errors is the tool. Routing test for the trigger-phrase
+            # snippet (observed 2026-09-07: model instead called
+            # list_user_configs + read_user_config and judged by eye).
+            context_files=(),
+            expected_tools=("validate_config_project",),
+            require_tool=True,
+            criteria=(
+                # Ground truth from the tool output on the dev Pi: the
+                # ERRORS are the KAMP missing includes. The model must
+                # relay error findings, not claim the config is clean.
+                ("regex", r"kamp|include"),
+                ("regex", r"error"),
+            ),
+        ),
+        TestQuestion(
+            qid="LIVE-02",
+            title="Draft boundary: pasted snippet is validated as draft, not disk",
+            text=("check this section for errors:\n\n"
+                  "[printer]\n"
+                  "kinematics: corexy\n"
+                  "max_velocity: 300\n"),
+            # The snippet is IN the prompt — the draft tool is the right
+            # call; validate_config_project would check unrelated disk
+            # files. Ground truth (verified against the validator
+            # 2026-09-08): [printer] missing max_accel → error
+            # (max_z_velocity is OPTIONAL with default 5 — do NOT require
+            # the answer to mention it; criterion-bug pattern caught in
+            # the no-network smoke pass).
+            context_files=(),
+            expected_tools=("validate_klipper_config",),
+            require_tool=True,
+            criteria=(
+                # Must relay the genuinely missing required param
+                # (accept humanized phrasing — prose answers get no retry
+                # loop; catalog #14 underscore-vs-space rule).
+                ("regex", r"max[_\s]?accel"),
+                # Proof the DRAFT was validated (not disk files): the call
+                # must carry config_text.
+                ("tool_args", "validate_klipper_config:config_text"),
+            ),
+        ),
+        TestQuestion(
+            qid="LIVE-03",
+            title="Devices: list what's plugged in for an [mcu] serial line",
+            text=("what devices can I use for the serial: line in my [mcu] "
+                  "section? list what's actually plugged into this machine."),
+            # Dev-Pi ground truth: one Klipper RP2040 under
+            # /dev/serial/by-id/. The answer must quote a REAL device from
+            # the tool output, not a generic example path.
+            context_files=(),
+            expected_tools=("list_connected_devices",),
+            require_tool=True,
+            criteria=(
+                ("regex", r"rp2040|ttyACM0|by.id"),
+                # Must frame it as the serial:/by-id value.
+                ("regex", r"serial|/dev/"),
+            ),
+        ),
+        TestQuestion(
+            qid="LIVE-04",
+            title="Schema routing: allowed bed_mesh params (typed lookup expected)",
+            text=("what parameters are allowed in the [bed_mesh] section and "
+                  "which ones are required? don't explain what they do, just "
+                  "the parameter names and which are required."),
+            # Routing test for the 2026-09 reroute: expected_tools is the
+            # schema tool ALONE, so a correct-but-reference answer grades
+            # PASS_WRONG_TOOL — that IS the routing signal. bed_mesh has
+            # NO required params (all optional per schema), so the answer
+            # gate is param-name coverage only.
+            context_files=(),
+            expected_tools=("get_section_schema",),
+            require_tool=True,
+            criteria=(
+                ("contains", "mesh_min"),
+                ("contains", "probe_count"),
+                ("contains", "speed"),
+            ),
+        ),
+        TestQuestion(
+            qid="LIVE-05",
+            title="Reference routing: prose WHY question (input_shaper explanation)",
+            text=("what does the [input_shaper] section actually do and how do "
+                  "I choose a shaper frequency for my printer?"),
+            # The other half of the boundary: this NEEDS prose — schema
+            # alone can't answer 'how do I choose'. Any doc tool is
+            # legitimate (correct output = pass).
+            context_files=(),
+            expected_tools=("get_config_reference_section", "search_klipper_docs",
+                            "get_section_schema"),
+            require_tool=False,
+            criteria=(
+                # Explanatory substance, not a param dump.
+                ("regex", r"resonan|vibration|ringing"),
+                # Must name real shaper concepts, proving it read real
+                # content rather than vague advice.
+                ("regex", r"\bzv\b|mz_?h|shaper_type"),
+            ),
+        ),
+        TestQuestion(
+            qid="LIVE-06",
+            title="Klippy status: 'why won't the printer connect?' must check live state",
+            text="why won't my printer connect? is klipper even running?",
+            # Dev Pi: no klippy socket → correct answer relays
+            # 'not responding / socket not found'. On the Trident the
+            # correct readout is 'ready' — both accepted; the hard gate is
+            # the status tool call. Fabricated diagnoses without the tool
+            # fail tool_ok.
+            context_files=(),
+            expected_tools=("get_klippy_status",),
+            require_tool=True,
+            criteria=(
+                ("regex", r"not responding|not running|stopped|not found|"
+                          r"cannot (?:be )?reach|no socket|startup|"
+                          r"ready|shut ?down"),
+            ),
+        ),
+        TestQuestion(
+            qid="LIVE-07",
+            title="Restart safety: 'can I firmware restart now?' checks print state first",
+            text="can I do a FIRMWARE_RESTART right now to apply my config changes?",
+            # The tool description makes the model call status BEFORE
+            # recommending a restart (mid-print interruption guard).
+            # Criteria accept either correct verdict (ready/safe vs not
+            # running vs printing-warning); tool_ok is the assertion.
+            context_files=(),
+            expected_tools=("get_klippy_status",),
+            require_tool=True,
+            criteria=(
+                ("regex", r"restart"),
+                ("regex", r"not running|not responding|stopped|ready|safe|"
+                          r"startup|interrupt|printing|start klipper|already"),
+            ),
+        ),
+    ]
+
+
 _MEMORY_CONFIG_SNIPPET = """[mcu]
 serial: /dev/serial/by-id/usb-Klipper_stm32f446xx_3D002B000E50505734393820-if00
 
@@ -1948,7 +2112,7 @@ def main() -> int:
                              "printer memory, blank it, run MEMORY-01..03, then restore it")
     args = parser.parse_args()
 
-    questions = build_questions() + build_macro_questions() + build_trident_questions() + build_ambiguity_questions() + build_setup_questions()
+    questions = build_questions() + build_macro_questions() + build_trident_questions() + build_ambiguity_questions() + build_setup_questions() + build_live_context_questions()
     if args.include_memory:
         questions += build_memory_questions()
     if args.list_questions:

--- a/scripts/ai_chat_accuracy_test.py
+++ b/scripts/ai_chat_accuracy_test.py
@@ -1420,9 +1420,11 @@ def build_live_context_questions() -> list[TestQuestion]:
             qid="LIVE-06",
             title="Klippy status: 'why won't the printer connect?' must check live state",
             text="why won't my printer connect? is klipper even running?",
-            # Dev Pi: no klippy socket → correct answer relays
-            # 'not responding / socket not found'. On the Trident the
-            # correct readout is 'ready' — both accepted; the hard gate is
+            # Dev Pi's actual klippy state is STARTUP ERROR (KAMP missing
+            # include) — not the no-socket case the criteria first assumed;
+            # 'error' joined the verdict list after the 2026-09-08 live run
+            # false-failed a correct 'error state' relay. Correct relays of
+            # not-responding, ready, OR error all pass; the hard gate is
             # the status tool call. Fabricated diagnoses without the tool
             # fail tool_ok.
             context_files=(),
@@ -1431,24 +1433,27 @@ def build_live_context_questions() -> list[TestQuestion]:
             criteria=(
                 ("regex", r"not responding|not running|stopped|not found|"
                           r"cannot (?:be )?reach|no socket|startup|"
-                          r"ready|shut ?down"),
+                          r"ready|shut ?down|error|crash"),
             ),
         ),
         TestQuestion(
             qid="LIVE-07",
             title="Restart safety: 'can I firmware restart now?' checks print state first",
             text="can I do a FIRMWARE_RESTART right now to apply my config changes?",
-            # The tool description makes the model call status BEFORE
-            # recommending a restart (mid-print interruption guard).
-            # Criteria accept either correct verdict (ready/safe vs not
-            # running vs printing-warning); tool_ok is the assertion.
+            # Criteria accept any correct verdict (ready/safe vs not
+            # running vs startup-ERROR vs printing-warning). The dev Pi
+            # actually reports startup error (KAMP missing include) —
+            # 'error' had to join the verdict list after first live run
+            # (2026-09-08) when the model correctly relayed 'error state'
+            # and got false-failed. tool_ok is the assertion.
             context_files=(),
             expected_tools=("get_klippy_status",),
             require_tool=True,
             criteria=(
                 ("regex", r"restart"),
                 ("regex", r"not running|not responding|stopped|ready|safe|"
-                          r"startup|interrupt|printing|start klipper|already"),
+                          r"startup|interrupt|printing|start klipper|already|"
+                          r"error"),
             ),
         ),
     ]
@@ -1550,6 +1555,13 @@ ALL_TOOLS = (
     "list_user_configs",
     "list_user_config_sections",
     "read_user_config",
+    # Live-context tools (feature/config-mcp-tools, 2026-09). When adding
+    # an MCP tool, update this tuple too or the summary lists real calls
+    # under "Unknown tool attempts" (LIVE-01 false alarm, 2026-09-08).
+    "validate_config_project",
+    "list_connected_devices",
+    "get_section_schema",
+    "get_klippy_status",
     "detect_board",
     "calculate_rotation_distance",
     "generate_macro_template",

--- a/tests/test_ai_chat_routes.py
+++ b/tests/test_ai_chat_routes.py
@@ -751,6 +751,7 @@ def test_chat_proxy_local_openai_compatible_allows_missing_key(monkeypatch):
         'mcpToolNames': [],
         'toolCalls': [],
         'repromptCount': 0,
+        'serverRepair': None,
         'usage': {
             'completionTokens': 0,
             'reasoningTokens': 0,
@@ -861,6 +862,7 @@ def test_chat_proxy_returns_plain_content(monkeypatch):
         'mcpToolNames': [],
         'toolCalls': [],
         'repromptCount': 0,
+        'serverRepair': None,
         'usage': {
             'completionTokens': 0,
             'reasoningTokens': 0,

--- a/tests/test_ai_draft_apply.py
+++ b/tests/test_ai_draft_apply.py
@@ -162,3 +162,145 @@ I updated the `speed` to 8 and the `probe_count` to 3,3 as requested."""
     assert 'speed: 8' in seg
     assert 'horizontal_move_z: 2' in seg, 'untouched bed_mesh params must survive'
     assert 'zero_reference_position: 175, 175' in seg
+
+
+# ── Review finding #12: duplicate-active-key ambiguity must fail closed ──
+
+DUPKEY_CFG = """\
+[mcu mcu]
+serial: /dev/serial/by-id/usb-1a86_USB_Serial-if00-port0
+baud: 250000
+
+[mcu EBBCan]
+serial: /tmp/EBBCan
+canbus_uuid: aabbccddeeff
+
+[printer]
+kinematics: corexy
+"""
+
+
+def test_ambiguous_duplicate_key_stale_removal_fails_closed():
+    """Two candidate `serial:` lines + a stale value: key-tolerant matching
+    must NOT silently pick the first one (wrong-line edit that validation
+    cannot see). Fail the block atomically instead."""
+    block = """[mcu EBBCan]
+-serial: /dev/serial/by-id/usb-stale-wrong-path
++serial: /tmp/EBBCan2"""
+    # Target section [mcu EBBCan] has exactly ONE serial line; but a block
+    # targeting a file where the SAME header resolves once is unique — this
+    # case must APPLY (guards against over-tightening).
+    res = apply_mini_diff_block(block, DUPKEY_CFG)
+    assert res['applied']
+    params = _params(res['text'], '[mcu EBBCan]')
+    assert params['serial'] == '/tmp/EBBCan2'
+
+
+def test_duplicate_key_in_same_section_stale_removal_fails_closed():
+    """The true ambiguity: the TARGET section itself has two active lines
+    with the same key and the removal value matches neither."""
+    base = """[mcu mcu]
+serial: /dev/ttyUSB0
+serial: /dev/ttyAMA0
+baud: 250000
+"""
+    block = """[mcu mcu]
+-serial: /dev/ttyS999
++serial: /dev/ttyUSB5"""
+    res = apply_mini_diff_block(block, base)
+    assert not res['applied'], (
+        'ambiguous duplicate-key key-fallback must fail the block, '
+        'never silently pick the first same-key line'
+    )
+
+
+def test_duplicate_key_exact_value_still_matches():
+    """Stage-1 exact match is unaffected by duplicate keys: value-true
+    removal applies against the matching line, sibling untouched."""
+    base = """[mcu mcu]
+serial: /dev/ttyUSB0
+serial: /dev/ttyAMA0
+baud: 250000
+"""
+    block = """[mcu mcu]
+-serial: /dev/ttyAMA0
++serial: /dev/ttyAMA1"""
+    res = apply_mini_diff_block(block, base)
+    assert res['applied']
+    assert 'serial: /dev/ttyUSB0' in res['text']
+    assert 'serial: /dev/ttyAMA1' in res['text']
+    assert 'serial: /dev/ttyAMA0' not in res['text']
+
+
+# ── Review finding #5: target resolution mirrors TS inputs ──────────────
+
+MACROS_A = """\
+[gcode_macro PARK_A]
+gcode:
+    G91
+"""
+
+MACROS_B = """\
+[gcode_macro PARK_B]
+gcode:
+    G90
+"""
+
+REPLY_NO_HINT = """\
+Here you go:
+
+```cfg
+[gcode_macro NEW_PARK]
+gcode:
+    G28
+```
+"""
+
+
+def _two_file_project():
+    from parser.config_parser import parse_config as pc
+    return {
+        'config/macros_a.cfg': pc(MACROS_A, 'macros_a.cfg'),
+        'config/macros_b.cfg': pc(MACROS_B, 'macros_b.cfg'),
+    }
+
+
+def test_active_file_input_breaks_zero_overlap_tie():
+    """No hints, no section overlap anywhere: the supplied activeFile wins
+    over the old hardcoded first-loaded-file fallback."""
+    res = apply_reply_to_configs(
+        REPLY_NO_HINT, _two_file_project(), active_file='config/macros_b.cfg',
+    )
+    assert list(res['files'].keys()) == ['config/macros_b.cfg']
+
+
+def test_user_hint_texts_resolve_target_without_reply_hint():
+    """Reply carries no '# file:' hint but the USER named the file: the
+    mention scan sees reply + preceding user messages, mirroring the TS
+    hook. (Like TS, the mention must be the loaded path as named — bare
+    basenames never match the full 'config/...' path in either engine.)"""
+    res = apply_reply_to_configs(
+        REPLY_NO_HINT, _two_file_project(),
+        active_file='config/macros_a.cfg',
+        hint_texts=['edit my config/macros_b.cfg file please'],
+    )
+    assert list(res['files'].keys()) == ['config/macros_b.cfg']
+
+
+def test_reply_hint_beats_active_file_and_user_hint():
+    """Precedence preserved: explicit '# file:' hint in the reply still wins
+    over both other inputs (mirrors TS ?? chain)."""
+    reply = REPLY_NO_HINT.replace('```cfg', "```cfg\n# file: macros_a.cfg")
+    res = apply_reply_to_configs(
+        reply, _two_file_project(),
+        active_file='config/macros_b.cfg',
+        hint_texts=['edit config/macros_b.cfg'],
+    )
+    assert list(res['files'].keys()) == ['config/macros_a.cfg']
+
+
+def test_unknown_active_file_falls_back_to_first_loaded():
+    res = apply_reply_to_configs(
+        REPLY_NO_HINT, _two_file_project(), active_file='does_not_exist.cfg',
+    )
+    assert list(res['files'].keys()) == ['config/macros_a.cfg']

--- a/tests/test_ai_draft_apply.py
+++ b/tests/test_ai_draft_apply.py
@@ -1,0 +1,164 @@
+"""Tests for services/ai_draft_apply mini-diff application.
+
+Focus: the stale-removal key-tolerant fallback (2026-09-09 HARNESS-03
+finding). When the model emits a `-` removal line with a stale old value
+for a param key that DOES exist in the base section (e.g. the section was
+already at `probe_count: 3,3` but the model wrote `-probe_count: 7,7`),
+the removal must still match by param key instead of aborting the whole
+block. Before the fix the aborted block fell back to
+strip_mini_diff_markers + full-section write, which kept BOTH sides of
+every -/+ pair; the parser's first-wins then selected the OLD value,
+silently reversing the edit and dropping every untouched param of the
+section. The deterministic audit caught it ("asked for `speed` = `8`,
+merged config has 3/500") — correct alarm, wrong culprit.
+
+Mirrored in frontend/src/utils/miniDiff.ts (same tests in
+frontend/src/utils/__tests__/miniDiff.test.ts).
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'backend'))
+
+from parser.config_parser import parse_config  # noqa: E402
+from services.ai_draft_apply import (  # noqa: E402
+    apply_mini_diff_block,
+    apply_reply_to_configs,
+)
+from services.ai_reply_audit import check_stated_requirements  # noqa: E402
+
+
+BASE_CFG = """\
+[bed_mesh]
+speed: 500
+horizontal_move_z: 2
+mesh_min: 5,5
+mesh_max: 345, 345
+zero_reference_position: 175, 175
+mesh_pps: 10, 10
+
+probe_count: 3,3
+algorithm: bicubic
+
+[probe]
+speed: 3
+"""
+
+
+def _params(merged_text: str, header: str) -> dict[str, str]:
+    cfg = parse_config(merged_text, 'printer.cfg')
+    want = header.strip().strip('[]')
+    for section in cfg.sections:
+        if section.full_header.strip().strip('[]') == want:
+            return {p.key: p.value for p in section.params}
+    raise AssertionError(f'section {header} missing from merged text')
+
+
+def test_stale_removal_matches_by_param_key():
+    """-probe_count: 7,7 against a base already at 3,3 still applies the block."""
+    block = """[bed_mesh]
+-speed: 500
++speed: 8
+-probe_count: 7,7
++probe_count: 3,3"""
+    res = apply_mini_diff_block(block, BASE_CFG)
+    assert res['applied'], 'stale removal value must not abort the block'
+    params = _params(res['text'], '[bed_mesh]')
+    assert params['speed'] == '8'
+    assert params['probe_count'] == '3,3'
+    # untouched params survive — this is exactly what the aborted-block
+    # fallback silently destroyed:
+    assert params['horizontal_move_z'] == '2'
+    assert params['zero_reference_position'] == '175, 175'
+    assert params['mesh_pps'] == '10, 10'
+    assert params['algorithm'] == 'bicubic'
+
+
+def test_stale_removal_delete_only_matches_by_key():
+    """-speed: 999 (stale value) with no + line still deletes the speed line by key."""
+    block = """[bed_mesh]
+-speed: 999"""
+    res = apply_mini_diff_block(block, BASE_CFG)
+    assert res['applied']
+    params = _params(res['text'], '[bed_mesh]')
+    assert 'speed' not in params
+    assert params['probe_count'] == '3,3'
+
+
+def test_key_fallback_does_not_invent_keys():
+    """A removal whose KEY is absent from the section still fails (atomic)."""
+    block = """[bed_mesh]
+-not_a_param: 7,7
++not_a_param: 3,3"""
+    res = apply_mini_diff_block(block, BASE_CFG)
+    assert not res['applied']
+
+
+def test_key_fallback_is_scoped_to_the_section():
+    """Key matching operates inside the TARGET section's own lines only:
+    [probe] `speed: 3` gets key-matched by a stale `-speed: 500` removal,
+    and the block output is the edited section materialized in full
+    (untouched sections are the caller's merge job, not this function's)."""
+    block = """[probe]
+-speed: 500
++speed: 4"""
+    res = apply_mini_diff_block(block, BASE_CFG)
+    assert res['applied']
+    params = _params(res['text'], '[probe]')
+    assert params['speed'] == '4'
+    assert '[bed_mesh]' not in res['text']  # only edited sections returned
+
+
+def test_gcode_stale_removal_still_falls_back():
+    """Non-param-shaped removals (gcode lines) never key-match."""
+    gcode_base = """\
+[gcode_macro PARK]
+gcode:
+    G28 X
+    G1 Z5 F1500
+"""
+    block = """[gcode_macro PARK]
+-G1 Z9 F1500
++G1 Z10 F1500"""
+    res = apply_mini_diff_block(block, gcode_base)
+    assert not res['applied']  # stale gcode content: no param key -> legacy fallback
+
+
+def test_harness03_end_to_end_no_audit_footer():
+    """The exact HARNESS-03 reply against the planted fixture: the merged
+    config lands speed=8, and the stated-requirement audit stays silent."""
+    content = (
+        Path(__file__).resolve().parents[1]
+        / 'reference/Trident_backup/printer_data/config/printer.cfg'
+    ).read_text(encoding='utf-8')
+    base_content = content.replace('probe_count: 7,7', 'probe_count: 3,3', 1)
+    assert base_content != content, 'probe_count marker not found in fixture'
+
+    reply = """```cfg
+# file: printer.cfg
+[bed_mesh]
+-speed: 500
++speed: 8
+-probe_count: 7,7
++probe_count: 3,3
++mesh_min: 5,5
++mesh_max: 345, 345
+```
+
+I updated the `speed` to 8 and the `probe_count` to 3,3 as requested."""
+
+    base = {'printer.cfg': parse_config(base_content, 'printer.cfg')}
+    res = apply_reply_to_configs(reply, base)
+    merged = {f: e['merged_config'] for f, e in res['files'].items()}
+    notes = check_stated_requirements(
+        'Set my bed mesh probe speed to 8 in printer.cfg and keep '
+        'the current probe_count of 3x3.',
+        merged,
+    )
+    assert notes == [], f'audit footer must stay silent, got: {notes}'
+    text = res['files']['printer.cfg']['merged_text']
+    i = text.find('[bed_mesh]')
+    seg = text[i:i + 500]
+    assert 'speed: 8' in seg
+    assert 'horizontal_move_z: 2' in seg, 'untouched bed_mesh params must survive'
+    assert 'zero_reference_position: 175, 175' in seg

--- a/tests/test_ai_malformed_tool_calls.py
+++ b/tests/test_ai_malformed_tool_calls.py
@@ -235,3 +235,43 @@ def test_unterminated_fence_never_reaches_the_bubble(monkeypatch):
     assert response.status_code == 200
     body = response.json()
     assert '```tool' not in body.get('content', '')
+
+
+def test_unterminated_fence_preserves_answer_text_after_blank_line(monkeypatch):
+    """Review finding #11: the strip regex consumed to end-of-content, so a
+    model that opened a broken ```tool fence and then RECOVERED with real
+    prose lost the answer. Fence bodies never contain blank lines, so the
+    strip is bounded at the first blank line and trailing prose survives.
+    Every provider turn stays malformed so the recovery-prose cleanup path
+    (not the successful re-prompt path) produces the final bubble."""
+    monkeypatch.setattr(ai_routes, 'load_printer_memory', lambda: PrinterMemory())
+    monkeypatch.setattr(ai_routes, '_auto_search_context', lambda query: None)
+
+    broken = (
+        'Sure:\n\n```tool\n{"name": "search_klipper\n\n'
+        'The docs say horizontal_move_z is the Z hop between probed points.'
+    )
+
+    def fake_post(url, headers, payload):
+        return DummyResponse(
+            {'choices': [{'message': {'content': broken}}]}, url=url,
+        )
+
+    monkeypatch.setattr(httpx, 'AsyncClient', lambda *a, **k: FakeAsyncClient(post_handler=fake_post))
+
+    response = client.post(
+        '/ai/chat',
+        json={
+            'messages': [{'role': 'user', 'content': 'horizontal_move_z?'}],
+            'apiKey': 'openai-token',
+            'model': 'qwen3.5-4b',
+            'apiUrl': 'http://localhost:1234/v1/chat/completions',
+            'apiProvider': 'chatgpt',
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert '```tool' not in body.get('content', '')
+    # The recovery prose that followed the fence must NOT be silently eaten.
+    assert 'Z hop between probed points' in body.get('content', '')

--- a/tests/test_ai_malformed_tool_calls.py
+++ b/tests/test_ai_malformed_tool_calls.py
@@ -1,0 +1,226 @@
+"""Tests for the malformed tool-call guard in api.ai_routes.
+
+Small local models (qwen3.5-4B class) frequently malform the ```tool text
+protocol: unescaped quotes inside argument values, single/smart-quoted
+pseudo-JSON, python-style calls in the fence, or a truncated (unterminated)
+fence. Before the guard, the loop saw "no tool calls, non-empty text",
+terminated, and the raw broken markup leaked into the chat bubble.
+"""
+import sys
+from pathlib import Path
+
+import httpx
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'backend'))
+
+import api.ai_routes as ai_routes  # noqa: E402
+from main import app  # noqa: E402
+from api.printer_memory_routes import PrinterMemory  # noqa: E402
+from tests.test_ai_chat_routes import DummyResponse, FakeAsyncClient  # noqa: E402
+
+client = TestClient(app)
+
+
+# ── extractor-level recovery ─────────────────────────────────────────
+
+
+def test_extract_recovers_python_call_inside_tool_fence():
+    # name(k=v) inside an explicit ```tool fence is unambiguous tool
+    # intent — recovered mechanically, no re-prompt needed.
+    text = (
+        'Checking:\n\n```tool\n'
+        'call read_user_config(filename="printer.cfg", section="printer")\n'
+        '```'
+    )
+    calls = ai_routes._extract_tool_calls(text)
+    assert calls == [{
+        'name': 'read_user_config',
+        'arguments': {'filename': 'printer.cfg', 'section': 'printer'},
+    }]
+
+
+def test_extract_recovers_single_quoted_json_fence():
+    text = "```tool\n{'name': 'list_user_configs', 'arguments': {}}\n```"
+    calls = ai_routes._extract_tool_calls(text)
+    assert calls == [{'name': 'list_user_configs', 'arguments': {}}]
+
+
+def test_extract_recovers_smart_quoted_json_fence():
+    text = (
+        '```tool\n'
+        '{\u201cname\u201d: \u201csearch_klipper_docs\u201d, '
+        '\u201carguments\u201d: {\u201cquery\u201d: \u201cbed mesh\u201d}}\n'
+        '```'
+    )
+    calls = ai_routes._extract_tool_calls(text)
+    assert calls == [{'name': 'search_klipper_docs', 'arguments': {'query': 'bed mesh'}}]
+
+
+# ── detection gate ───────────────────────────────────────────────────
+
+
+def test_malformed_detection_fires_only_on_fence_intent():
+    broken = (
+        '```tool\n{"name": "read_user_config", "arguments": '
+        '{"section": "probe" pin: PB4"}}\n```'
+    )
+    assert ai_routes._malformed_tool_call_detected(broken, [])
+    unterminated = 'Let me look:\n\n```tool\n{"name": "search_klipper'
+    assert ai_routes._malformed_tool_call_detected(unterminated, [])
+    # Prose that merely mentions tools must never trigger the guard.
+    assert not ai_routes._malformed_tool_call_detected(
+        'You can call the BED_MESH_CALIBRATE macro after homing.', []
+    )
+    # A successfully parsed call also disables it.
+    assert not ai_routes._malformed_tool_call_detected(
+        broken, [{'name': 'x', 'arguments': {}}]
+    )
+
+
+# ── route-level guard behavior ───────────────────────────────────────
+
+
+def test_chat_proxy_malformed_tool_call_gets_one_format_reprompt(monkeypatch):
+    # Unescaped quotes inside an argument make json.loads fail; without the
+    # guard the loop terminates and the raw ```tool markup leaks into the
+    # chat bubble.
+    monkeypatch.setattr(ai_routes, 'load_printer_memory', lambda: PrinterMemory())
+    monkeypatch.setattr(ai_routes, '_execute_tool_call', lambda call: f"result for {call['name']}")
+    monkeypatch.setattr(ai_routes, '_auto_search_context', lambda query: None)
+
+    calls = []
+
+    def fake_post(url, headers, payload):
+        calls.append(payload)
+        if len(calls) == 1:
+            return DummyResponse(
+                {'choices': [{'message': {'content': (
+                    '```tool\n{"name": "read_user_config", "arguments": '
+                    '{"filename": "printer.cfg", "section": "probe" pin: PB4"}}\n```'
+                )}}]},
+                url=url,
+            )
+        if len(calls) == 2:
+            # After the format correction the model emits a valid call.
+            return DummyResponse(
+                {'choices': [{'message': {'content': (
+                    '```tool\n{"name": "read_user_config", "arguments": '
+                    '{"filename": "printer.cfg", "section": "probe"}}\n```'
+                )}}]},
+                url=url,
+            )
+        return DummyResponse(
+            {'choices': [{'message': {'content': 'Your probe pin is PB4.'}}]},
+            url=url,
+        )
+
+    monkeypatch.setattr(httpx, 'AsyncClient', lambda *a, **k: FakeAsyncClient(post_handler=fake_post))
+
+    response = client.post(
+        '/ai/chat',
+        json={
+            'messages': [{'role': 'user', 'content': 'what probe pin do I have?'}],
+            'apiKey': 'openai-token',
+            'model': 'qwen3.5-4b',
+            'apiUrl': 'http://localhost:1234/v1/chat/completions',
+            'apiProvider': 'chatgpt',
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body['content'] == 'Your probe pin is PB4.'
+    assert '```tool' not in body['content']
+    # The second request must be the format-correction re-prompt, and it
+    # must NOT quote the broken call (REPAIR-01: models copy broken drafts).
+    second_messages = [str(m.get('content', '')) for m in calls[1]['messages']]
+    assert any('could not be parsed' in m and 'Do not copy' in m for m in second_messages)
+    assert not any('could not be parsed' in m and 'pin: PB4' in m for m in second_messages)
+
+
+def test_chat_proxy_malformed_reprompt_is_bounded(monkeypatch):
+    # A model that keeps emitting broken fences must not loop forever:
+    # exactly ONE format correction, then the markup-stripped reply stands
+    # (empty after stripping → the existing empty-response backstop takes
+    # over, which never leaks markup either).
+    monkeypatch.setattr(ai_routes, 'load_printer_memory', lambda: PrinterMemory())
+    monkeypatch.setattr(ai_routes, '_auto_search_context', lambda query: None)
+
+    calls = []
+
+    def fake_post(url, headers, payload):
+        calls.append(payload)
+        return DummyResponse(
+            {'choices': [{'message': {'content': '```tool\n{"name": broken broken\n```'}}]},
+            url=url,
+        )
+
+    monkeypatch.setattr(httpx, 'AsyncClient', lambda *a, **k: FakeAsyncClient(post_handler=fake_post))
+
+    response = client.post(
+        '/ai/chat',
+        json={
+            'messages': [{'role': 'user', 'content': 'hi'}],
+            'apiKey': 'openai-token',
+            'model': 'qwen3.5-4b',
+            'apiUrl': 'http://localhost:1234/v1/chat/completions',
+            'apiProvider': 'chatgpt',
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    # Boundedness: 1 initial + exactly ONE format correction. After that the
+    # guard is spent, the loop terminates, fence stripping leaves the reply
+    # empty, and only the pre-existing empty-response backstop (limit 2)
+    # runs. Total provider requests must therefore be 1 + 1 + 2 = 4.
+    assert len(calls) == 4
+    assert body['mcpToolTurns'] == 1
+    assert body['repromptCount'] == 2
+    assert '```tool' not in body.get('content', '')
+    # The feedback phrase appears in the history exactly once (one feedback
+    # message, merged-forward in later payloads — never duplicated).
+    occurrences = sum(
+        str(m.get('content', '')).count('could not be parsed')
+        for m in calls[-1]['messages']
+    )
+    assert occurrences == 1
+
+
+def test_unterminated_fence_never_reaches_the_bubble(monkeypatch):
+    # A truncated stream (fence opened, never closed) must not leak markup
+    # even if every recovery path fails.
+    monkeypatch.setattr(ai_routes, 'load_printer_memory', lambda: PrinterMemory())
+    monkeypatch.setattr(ai_routes, '_auto_search_context', lambda query: None)
+
+    calls = []
+
+    def fake_post(url, headers, payload):
+        calls.append(payload)
+        if len(calls) == 1:
+            return DummyResponse(
+                {'choices': [{'message': {'content': 'Sure:\n\n```tool\n{"name": "search_klipper'}}]},
+                url=url,
+            )
+        return DummyResponse(
+            {'choices': [{'message': {'content': 'The docs say horizontal_move_z is the Z hop.'}}]},
+            url=url,
+        )
+
+    monkeypatch.setattr(httpx, 'AsyncClient', lambda *a, **k: FakeAsyncClient(post_handler=fake_post))
+
+    response = client.post(
+        '/ai/chat',
+        json={
+            'messages': [{'role': 'user', 'content': 'horizontal_move_z?'}],
+            'apiKey': 'openai-token',
+            'model': 'qwen3.5-4b',
+            'apiUrl': 'http://localhost:1234/v1/chat/completions',
+            'apiProvider': 'chatgpt',
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert '```tool' not in body.get('content', '')

--- a/tests/test_ai_malformed_tool_calls.py
+++ b/tests/test_ai_malformed_tool_calls.py
@@ -25,6 +25,17 @@ client = TestClient(app)
 # ── extractor-level recovery ─────────────────────────────────────────
 
 
+def test_extract_parses_same_line_closing_fence():
+    # qwen3.5-4b constantly closes the fence on the SAME line as the JSON:
+    # ```tool\n{"name": ...}``` — the newline-then-backticks requirement made
+    # these calls undetectable AND un-strippable (live 2026-09-09 bank).
+    text = '```tool\n{"name": "get_klippy_status", "arguments": {}}```'
+    calls = ai_routes._extract_tool_calls(text)
+    assert calls == [{"name": "get_klippy_status", "arguments": {}}]
+    # And the fence must not leak into cleaned content.
+    assert "```" not in ai_routes.MCP_TOOL_BLOCK_RE.sub("", text).strip()
+
+
 def test_extract_recovers_python_call_inside_tool_fence():
     # name(k=v) inside an explicit ```tool fence is unambiguous tool
     # intent — recovered mechanically, no re-prompt needed.

--- a/tests/test_ai_server_validation.py
+++ b/tests/test_ai_server_validation.py
@@ -86,6 +86,19 @@ def test_requirement_check_grid_value():
     assert check_stated_requirements("change probe_count to 3x3", files) == []
 
 
+def test_requirement_check_alias_param_name():
+    # "set max_acceleration to 9000" applied as `max_accel: 9000` must NOT
+    # warn: prefix-alias sibling (max_acceleration ⊃ max_accel) carries the
+    # value (HARNESS-01 live finding, 2026-09-09).
+    files = _files()
+    files["printer.cfg"].sections[0].params.append(
+        parse_config("[printer]\nmax_accel: 9000\n", "x.cfg").sections[0].params[0]
+    )
+    assert check_stated_requirements("set max_acceleration to 9000", files) == []
+    # ...but a different value still flags.
+    assert check_stated_requirements("set max_acceleration to 9500", files) != []
+
+
 def test_requirement_check_ignores_questions():
     assert check_stated_requirements("what is max_velocity?", _files()) == []
 

--- a/tests/test_ai_server_validation.py
+++ b/tests/test_ai_server_validation.py
@@ -323,8 +323,10 @@ def test_retry_exempt_does_not_burn_query(monkeypatch):
 
 
 def test_audit_footer_on_clean_apply(monkeypatch):
+    # Audit-only mode: both harness flags default ON (2026-09-09), so
+    # validation must be explicitly disabled to isolate the audit path.
     monkeypatch.setenv("KWC_POST_APPLY_AUDIT", "1")
-    monkeypatch.delenv("KWC_SERVER_DRAFT_VALIDATION", raising=False)
+    monkeypatch.setenv("KWC_SERVER_DRAFT_VALIDATION", "0")
     req = _chat_request(_ctx())
     req.messages = [{"role": "user", "content": "set max_accel to 99999"}]
     content, info = _run_validate(req, CLEAN_REPLY, repair_response=None)

--- a/tests/test_ai_server_validation.py
+++ b/tests/test_ai_server_validation.py
@@ -336,8 +336,8 @@ def test_retry_exempt_does_not_burn_query(monkeypatch):
 
 
 def test_audit_footer_on_clean_apply(monkeypatch):
-    # Audit-only mode: both harness flags default ON (2026-09-09), so
-    # validation must be explicitly disabled to isolate the audit path.
+    # Audit-only mode: KWC_POST_APPLY_AUDIT must be explicitly enabled
+    # (default is OFF since e351669), validation disabled to isolate it.
     monkeypatch.setenv("KWC_POST_APPLY_AUDIT", "1")
     monkeypatch.setenv("KWC_SERVER_DRAFT_VALIDATION", "0")
     req = _chat_request(_ctx())
@@ -347,3 +347,28 @@ def test_audit_footer_on_clean_apply(monkeypatch):
     # 99999 was NOT applied (reply set 12000) → requirement note attached.
     assert "Harness checks" in content
     assert "99999" in content
+
+
+def test_shipped_defaults_no_audit_footer(monkeypatch):
+    """Shipped default combo (no env set): validation ON, audit OFF (e351669).
+
+    A clean-apply reply must NOT carry the 'Harness checks' footer — the
+    audit call sites inside _server_validate_and_repair honor
+    _server_audit_enabled(). Regression guard for the finding that the
+    validation-on path ran the audit regardless of KWC_POST_APPLY_AUDIT.
+    The reply is a genuinely clean mini-diff (satisfies the requirement the
+    stated-req checker would inspect) and no repair stub is configured, so
+    any repair query also fails the test.
+    """
+    monkeypatch.delenv("KWC_POST_APPLY_AUDIT", raising=False)
+    monkeypatch.delenv("KWC_SERVER_DRAFT_VALIDATION", raising=False)
+    req = _chat_request(_ctx())
+    # Stated value (99999) deliberately NOT what the clean edit applies
+    # (12000): with the audit wrongly running, its requirement note would
+    # attach the footer. With the flag honored, zero notes, no footer.
+    req.messages = [{"role": "user", "content": "set max_accel to 99999"}]
+    clean_mini = "Sure:\n\n```cfg\n# file: printer.cfg\n[printer]\n-max_accel: 3000\n+max_accel: 12000\n```"
+    content, info = _run_validate(req, clean_mini, repair_response=None)
+    assert "Harness checks" not in content
+    # Validation path itself still ran, clean apply, no repair attempted.
+    assert info == {"attempted": False, "repaired": False, "issuesAfter": []}

--- a/tests/test_ai_server_validation.py
+++ b/tests/test_ai_server_validation.py
@@ -1,0 +1,334 @@
+"""Tests for the server-side AI draft pipeline (#1 apply+validate+repair,
+#3 deterministic audit).
+
+Covers:
+- services/ai_reply_audit: stated-requirement checker, precondition table,
+  LED inventory, footer assembly.
+- services/ai_draft_validation: delta semantics, retry-exempt, shadow
+  suppression, Jinja repair commands, REPAIR-01 feedback shape.
+- api/ai_routes._server_validate_and_repair: clean apply, dirty apply with
+  one successful repair, failed repair keeps the original, retry-exempt
+  skips the query, flags-off returns unchanged.
+"""
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'backend'))
+
+import api.ai_routes as ai_routes  # noqa: E402
+from parser.config_parser import parse_config  # noqa: E402
+from services.ai_reply_audit import (  # noqa: E402
+    build_audit_footer,
+    check_led_inventory,
+    check_macro_preconditions,
+    check_stated_requirements,
+)
+from services.ai_draft_validation import (  # noqa: E402
+    build_validation_feedback,
+    collect_new_validation_errors,
+    derive_jinja_repair_commands,
+    has_only_retry_exempt_issues,
+    suppress_errors_shadowed_by_full_rewrite,
+)
+
+
+BASE_CFG = """\
+[printer]
+kinematics: corexy
+max_velocity: 300
+max_accel: 3000
+
+[gcode_macro LEVEL_BED]
+gcode:
+  {% if "xyz" not in printer.toolhead.homed_axes %}
+  G28
+  {% endif %}
+  BED_MESH_CALIBRATE
+
+[neopixel CASE_LEDs]
+pin: PB3
+
+[neopixel SB_LEDs]
+pin: PB6
+"""
+
+
+def _files():
+    return {"printer.cfg": parse_config(BASE_CFG, "printer.cfg")}
+
+
+# ── #3 audit: stated requirements ────────────────────────────────────
+
+
+def test_requirement_check_passes_when_value_applied():
+    files = _files()
+    files["printer.cfg"].sections[0].params[2].value = "12000"  # max_accel
+    notes = check_stated_requirements("set max_accel to 12000", files)
+    assert notes == []
+
+
+def test_requirement_check_flags_missing_value():
+    notes = check_stated_requirements("set max_accel to 12000", _files())
+    assert len(notes) == 1
+    assert "max_accel" in notes[0] and "12000" in notes[0]
+
+
+def test_requirement_check_grid_value():
+    notes = check_stated_requirements("change probe_count to 3x3", _files())
+    assert len(notes) == 1 and "probe_count" in notes[0]
+    files = _files()
+    files["printer.cfg"].sections.append(
+        parse_config("[bed_mesh]\nprobe_count: 3,3\n", "printer.cfg").sections[0]
+    )
+    assert check_stated_requirements("change probe_count to 3x3", files) == []
+
+
+def test_requirement_check_ignores_questions():
+    assert check_stated_requirements("what is max_velocity?", _files()) == []
+
+
+# ── #3 audit: preconditions ──────────────────────────────────────────
+
+
+def test_precondition_flags_unhomed_bed_mesh():
+    notes = check_macro_preconditions(
+        [("gcode_macro LVL", "M104 S60\nBED_MESH_CALIBRATE\n")]
+    )
+    assert len(notes) == 1 and "G28" in notes[0]
+
+
+def test_precondition_ok_when_homed():
+    notes = check_macro_preconditions(
+        [("gcode_macro LVL", "G28\nBED_MESH_CALIBRATE\n")]
+    )
+    assert notes == []
+
+
+# ── #3 audit: LED inventory ──────────────────────────────────────────
+
+
+def test_led_inventory_lists_siblings():
+    notes = check_led_inventory(["neopixel CASE_LEDs"], _files())
+    assert len(notes) == 1
+    assert "SB_LEDs" in notes[0] and "CASE_LEDs" not in notes[0].split("were NOT changed")[1]
+
+
+def test_led_inventory_silent_for_non_led_change():
+    assert check_led_inventory(["printer"], _files()) == []
+
+
+def test_audit_footer_format():
+    assert build_audit_footer([]) == ""
+    footer = build_audit_footer(["note one"])
+    assert "Harness checks" in footer and "- note one" in footer
+
+
+# ── #1 validation port semantics ─────────────────────────────────────
+
+
+def _err(severity="error", section="s", param="", message="m", code=""):
+    return {"severity": severity, "section": section, "param": param,
+            "message": message, "line_number": 0, "code": code}
+
+
+def test_delta_drops_pre_existing_errors():
+    base = {"printer.cfg": {"errors": [_err(message="pre-existing")]}}
+    cand = {"printer.cfg": {"errors": [_err(message="pre-existing"), _err(message="new")]}}
+    issues = collect_new_validation_errors(base, cand)
+    assert len(issues) == 1 and len(issues[0]["errors"]) == 1
+    assert issues[0]["errors"][0]["message"] == "new"
+
+
+def test_delta_multiset_counts_duplicates():
+    base = {"f": {"errors": [_err(message="dup")]}}
+    cand = {"f": {"errors": [_err(message="dup"), _err(message="dup")]}}
+    issues = collect_new_validation_errors(base, cand)
+    assert issues[0]["errors"][0]["message"] == "dup"
+
+
+def test_retry_exempt_classification():
+    exempt = [{"filename": "f", "errors": [_err(code="shared_pin", severity="warning")]}]
+    assert has_only_retry_exempt_issues(exempt)
+    mixed = exempt + [{"filename": "f", "errors": [_err(code="unknown_param")]}]
+    assert not has_only_retry_exempt_issues(mixed)
+
+
+def test_jinja_repair_command_derivation():
+    issues = [{"filename": "f", "errors": [_err(
+        section="gcode_macro M300",
+        message="Template: Unexpected end of template. The innermost block that needs to be closed is 'if'",
+        code="macro_jinja_unterminated",
+    )]}]
+    cmds = derive_jinja_repair_commands(issues)
+    assert cmds == [
+        "The innermost open Jinja block in [gcode_macro M300] is 'if' — append {% endif %} at the end of its gcode body."
+    ]
+
+
+def test_feedback_shape_repair01():
+    issues = [{"filename": "printer.cfg", "errors": [_err(message="bad thing")]}]
+    fb = build_validation_feedback(issues, None)
+    assert "Do NOT copy or repeat your previous reply" in fb
+    assert "read_user_config" in fb
+    assert "bad thing" in fb
+    # The invalid content is never part of the feedback (lean by construction).
+    assert "Previous invalid reply" not in fb
+
+
+def test_full_rewrite_shadow_suppression():
+    issues = [{"filename": "f.cfg", "errors": [
+        _err(section="gcode_macro M300", message="full rewrite", code="macro_full_rewrite"),
+        _err(section="gcode_macro M300", param="gcode", message="artifact", code="unknown_param"),
+        _err(section="bed_mesh", param="mesh_min", message="real", code="unknown_param"),
+    ]}]
+    out = suppress_errors_shadowed_by_full_rewrite(issues)
+    kept = [(e["section"], e["message"]) for g in out for e in g["errors"]]
+    assert ("bed_mesh", "real") not in kept
+    assert ("gcode_macro M300", "full rewrite") in kept
+
+
+# ── #1 route-level flow ──────────────────────────────────────────────
+
+
+def _chat_request(context_files, **over):
+    return ai_routes.ChatRequest(
+        messages=[{"role": "user", "content": "tweak the config"}],
+        apiKey="",
+        model="test-model",
+        apiUrl="http://localhost:1234/v1/chat/completions",
+        apiProvider="chatgpt",
+        contextFiles=context_files,
+        **over,
+    )
+
+
+def _ctx():
+    return {"printer.cfg": {"content": BASE_CFG, "label": "Active config"}}
+
+
+DIRTY_REPLY = """\
+Sure:
+
+```cfg
+# file: printer.cfg
+[printer]
+bogus_param_here: 1
+```
+"""
+
+CLEAN_REPLY = """\
+Sure:
+
+```cfg
+# file: printer.cfg
+[printer]
+max_accel: 12000
+```
+"""
+
+
+def _run_validate(req, content, repair_response=None, capture=None):
+    """Call _server_validate_and_repair with a stubbed provider query."""
+
+    async def fake_query(client, url, headers, payload, provider, logger_context="", stop_event=None):
+        if capture is not None:
+            capture.append({"payload": payload, "context": logger_context})
+        if repair_response is None:
+            raise AssertionError("repair query issued but none configured")
+        return repair_response, {"choices": [{"message": {"content": repair_response}}]}
+
+    original = ai_routes._query_provider
+    ai_routes._query_provider = fake_query
+    try:
+        return asyncio.run(req and ai_routes._server_validate_and_repair(
+            None, req, {}, content, list(req.messages), [], None,
+        ))
+    finally:
+        ai_routes._query_provider = original
+
+
+def test_dirty_reply_repaired_by_one_query(monkeypatch):
+    monkeypatch.setenv("KWC_SERVER_DRAFT_VALIDATION", "1")
+    monkeypatch.setattr(ai_routes, "load_printer_memory", lambda: None, raising=False)
+    req = _chat_request(_ctx())
+    captured = []
+    # Realistic REPAIR-01 reply: the feedback reports both the unknown param
+    # and the missing required kinematics, so the model rewrites the full
+    # section (guard off by default → full writes accepted).
+    repair = (
+        "```cfg\n# file: printer.cfg\n[printer]\n"
+        "kinematics: corexy\nmax_velocity: 300\nmax_accel: 3000\n```"
+    )
+    content, info = _run_validate(req, DIRTY_REPLY, repair_response=repair, capture=captured)
+    assert info == {"attempted": True, "repaired": True, "issuesAfter": []}
+    assert content == repair
+    assert len(captured) == 1
+    assert captured[0]["context"] == "server-repair-1"
+    # Feedback must follow REPAIR-01: no quoting of the previous reply.
+    repair_user_msg = captured[0]["payload"]["messages"][-1]["content"]
+    assert "Do NOT copy or repeat your previous reply" in repair_user_msg
+    assert "bogus_param_here" in repair_user_msg
+
+
+def test_failed_repair_keeps_original(monkeypatch):
+    monkeypatch.setenv("KWC_SERVER_DRAFT_VALIDATION", "1")
+    req = _chat_request(_ctx())
+    still_bad = "```cfg\n# file: printer.cfg\n[printer]\nbogus_param_here: 2\n```"
+    content, info = _run_validate(req, DIRTY_REPLY, repair_response=still_bad)
+    assert info["attempted"] is True
+    assert info["repaired"] is False
+    # Original reply stands — never show a worse one.
+    assert content == DIRTY_REPLY
+    assert info["issuesAfter"]
+
+
+def test_prose_only_reply_untouched(monkeypatch):
+    monkeypatch.setenv("KWC_SERVER_DRAFT_VALIDATION", "1")
+    req = _chat_request(_ctx())
+    content, info = _run_validate(req, "Just an explanation, no cfg block.", repair_response=None)
+    assert content == "Just an explanation, no cfg block."
+    assert info is None
+
+
+def test_no_context_files_short_circuits(monkeypatch):
+    monkeypatch.setenv("KWC_SERVER_DRAFT_VALIDATION", "1")
+    req = _chat_request({})
+    content, info = _run_validate(req, DIRTY_REPLY, repair_response=None)
+    assert info is None and content == DIRTY_REPLY
+
+
+def test_retry_exempt_does_not_burn_query(monkeypatch):
+    monkeypatch.setenv("KWC_SERVER_DRAFT_VALIDATION", "1")
+    # A duplicate [printer] section is project_duplicate → retry-exempt.
+    dup_reply = "```cfg\n# file: printer.cfg\n[printer]\nkinematics: corexy\nmax_velocity: 300\nmax_accel: 3000\n```"
+    req = _chat_request(_ctx())
+
+    def boom(*a, **k):
+        raise AssertionError("repair query must not be issued for retry-exempt issues")
+
+    original = ai_routes._query_provider
+    ai_routes._query_provider = boom
+    try:
+        content, info = asyncio.run(ai_routes._server_validate_and_repair(
+            None, req, {}, dup_reply, list(req.messages), [], None,
+        ))
+    finally:
+        ai_routes._query_provider = original
+    # Same-section restate may merge identically (no new errors) OR surface
+    # project_duplicate; either way, no query was issued (boom unused).
+    assert content == dup_reply
+
+
+def test_audit_footer_on_clean_apply(monkeypatch):
+    monkeypatch.setenv("KWC_POST_APPLY_AUDIT", "1")
+    monkeypatch.delenv("KWC_SERVER_DRAFT_VALIDATION", raising=False)
+    req = _chat_request(_ctx())
+    req.messages = [{"role": "user", "content": "set max_accel to 99999"}]
+    content, info = _run_validate(req, CLEAN_REPLY, repair_response=None)
+    assert info is None  # audit-only mode returns no repair info
+    # 99999 was NOT applied (reply set 12000) → requirement note attached.
+    assert "Harness checks" in content
+    assert "99999" in content

--- a/tests/test_ai_server_validation.py
+++ b/tests/test_ai_server_validation.py
@@ -314,9 +314,15 @@ def test_no_context_files_short_circuits(monkeypatch):
 
 
 def test_retry_exempt_does_not_burn_query(monkeypatch):
+    """Shared-pin errors (code=shared_pin) are retry-exempt: regeneration
+    cannot fix a pin collision, so the harness must return with
+    reason='retry-exempt' and NEVER issue a repair query. (Rewritten per
+    review finding #6: the old dup-[printer] reply merged to a clean no-op
+    and silently exercised the clean-apply branch instead.)"""
     monkeypatch.setenv("KWC_SERVER_DRAFT_VALIDATION", "1")
-    # A duplicate [printer] section is project_duplicate → retry-exempt.
-    dup_reply = "```cfg\n# file: printer.cfg\n[printer]\nkinematics: corexy\nmax_velocity: 300\nmax_accel: 3000\n```"
+    # [fan] pin: PB3 collides with the base's [neopixel CASE] pin: PB3
+    # → NEW blocking error, code=shared_pin → retry-exempt.
+    shared_pin_reply = "```cfg\n# file: printer.cfg\n[fan]\npin: PB3\n```"
     req = _chat_request(_ctx())
 
     def boom(*a, **k):
@@ -326,13 +332,23 @@ def test_retry_exempt_does_not_burn_query(monkeypatch):
     ai_routes._query_provider = boom
     try:
         content, info = asyncio.run(ai_routes._server_validate_and_repair(
-            None, req, {}, dup_reply, list(req.messages), [], None,
+            None, req, {}, shared_pin_reply, list(req.messages), [], None,
         ))
     finally:
         ai_routes._query_provider = original
-    # Same-section restate may merge identically (no new errors) OR surface
-    # project_duplicate; either way, no query was issued (boom unused).
-    assert content == dup_reply
+    assert content == shared_pin_reply  # original reply stands
+    # The retry-exempt branch must be the one that returned (finding #6:
+    # assert the reason, not just the absence of a query).
+    assert info is not None
+    assert info["reason"] == "retry-exempt"
+    assert info["attempted"] is False
+    assert info["repaired"] is False
+    codes = {
+        e["code"]
+        for group in info["issuesAfter"]
+        for e in group["errors"]
+    }
+    assert codes == {"shared_pin"}
 
 
 def test_audit_footer_on_clean_apply(monkeypatch):

--- a/tests/test_mcp_config_tools.py
+++ b/tests/test_mcp_config_tools.py
@@ -1,0 +1,333 @@
+"""Tests for the live-context MCP tools (feature/config-mcp-tools).
+
+Covers the four tools added for AI-chat ↔ real-printer context:
+  - validate_config_project  (full schema engine over the live config project)
+  - list_connected_devices   (same data as the communication-line dropdowns)
+  - get_section_schema       (typed params from config_schema, not prose)
+  - get_klippy_status        (state + recent errors + targeted log excerpt)
+
+Plus the service extraction `load_native_project` that `validate_config_project`
+and the /api/native/config-files/read route share (include-closure semantics
+must not fork — see test_native_read_include_closure.py for the route lock).
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "backend"))
+
+import mcp_server  # noqa: E402
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────
+
+
+def _call(server, name, arguments):
+    """Invoke a tool via the JSON-RPC surface and return its text result."""
+    response = server.handle_jsonrpc({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": name, "arguments": arguments},
+    })
+    assert response is not None
+    assert "result" in response, response
+    content = response["result"].get("content", [])
+    return "\n".join(item.get("text", "") for item in content)
+
+
+def _server(tmp_path):
+    """Server with isolated config dirs (mirrors test_mcp_server_tools fixture)."""
+    server = mcp_server.McpServer()
+    mcp_server.LOCAL_CONFIGS_DIR = tmp_path / "user_configs"
+    mcp_server._system_config_path = lambda: tmp_path / "system_config"
+    return server, tmp_path / "system_config"
+
+
+# ── Tool registration ───────────────────────────────────────────────────
+
+
+def test_new_tools_registered():
+    names = {t["name"] for t in mcp_server.McpServer()._list_tools()}
+    for expected in (
+        "validate_config_project",
+        "list_connected_devices",
+        "get_section_schema",
+        "get_klippy_status",
+    ):
+        assert expected in names, f"{expected} must be registered"
+
+
+# ── validate_config_project ─────────────────────────────────────────────
+
+
+def _force_native(monkeypatch):
+    import services.native_services as ns
+
+    monkeypatch.setattr(ns, "is_native_platform", lambda: True)
+
+
+def test_validate_project_reports_severities(tmp_path, monkeypatch):
+    _force_native(monkeypatch)
+    server, config_dir = _server(tmp_path)
+    config_dir.mkdir(parents=True)
+    (config_dir / "printer.cfg").write_text(
+        "[include aux.cfg]\n"
+        "[printer]\n"
+        "kinematics: cartesian\n"
+        "max_velocity: 300\n"
+        "max_accel: 3000\n"
+        "max_z_velocity: 5\n"
+        "max_z_accel: 100\n",
+        encoding="utf-8",
+    )
+    # aux.cfg: an unknown section (warning) and an unknown param (error).
+    (config_dir / "aux.cfg").write_text(
+        "[bed_mesh]\n"
+        "speed: 100\n"
+        "totally_bogus_param: 1\n",
+        encoding="utf-8",
+    )
+
+    out = _call(server, "validate_config_project", {})
+    # Include closure: the tool validated the project, not just printer.cfg.
+    assert "aux.cfg" in out
+    # The unknown param must surface with its file/section location.
+    assert "totally_bogus_param" in out
+    # Severity classes appear as distinct labels (error vs warning).
+    assert "error" in out.lower()
+    # Clean file reported as such, not silently omitted.
+    assert "printer.cfg" in out
+
+
+def test_validate_project_accepts_filenames(tmp_path, monkeypatch):
+    _force_native(monkeypatch)
+    server, config_dir = _server(tmp_path)
+    config_dir.mkdir(parents=True)
+    (config_dir / "printer.cfg").write_text(
+        "[printer]\nkinematics: corexy\n", encoding="utf-8"
+    )
+    (config_dir / "other.cfg").write_text(
+        "[bed_screws]\nscrew1: 10, 10\n", encoding="utf-8"
+    )
+    out = _call(server, "validate_config_project", {"filenames": ["other.cfg"]})
+    assert "bed_screws" in out
+    # printer.cfg was explicitly excluded → not part of the validated set.
+    assert "printer.cfg" not in out
+
+
+def test_validate_project_no_config_dir(tmp_path, monkeypatch):
+    _force_native(monkeypatch)
+    server, config_dir = _server(tmp_path)
+    out = _call(server, "validate_config_project", {})
+    assert "no config files" in out.lower()
+
+
+# ── list_connected_devices ──────────────────────────────────────────────
+
+
+def test_list_devices_non_native(tmp_path, monkeypatch):
+    import services.native_services as ns
+
+    monkeypatch.setattr(ns, "is_native_platform", lambda: False)
+    server, _ = _server(tmp_path)
+    out = _call(server, "list_connected_devices", {})
+    assert "only available" in out.lower()
+
+
+def test_list_devices_formats_dropdown_data(tmp_path, monkeypatch):
+    import services.native_services as ns
+
+    monkeypatch.setattr(ns, "is_native_platform", lambda: True)
+    monkeypatch.setattr(ns, "get_all_devices", lambda: {
+        "usb_serial": [{
+            "path": "/dev/ttyACM0",
+            "description": "usb-Klipper_stm32f446xx_42-if00",
+            "by_id": "/dev/serial/by-id/usb-Klipper_stm32f446xx_42-if00",
+        }],
+        "uart": [{
+            "path": "/dev/ttyAMA0",
+            "description": "ttyAMA0",
+            "by_id": "",
+        }],
+        "can": [{"name": "can0", "state": "up", "bitrate": 1000000}],
+    })
+    monkeypatch.setattr(
+        ns, "query_canbus_uuids",
+        lambda interface: {"uuids": ["abc123def456"], "interface": interface, "error": None},
+    )
+
+    server, _ = _server(tmp_path)
+    out = _call(server, "list_connected_devices", {})
+    # Each dropdown group appears with its values.
+    assert "usb-Klipper_stm32f446xx_42-if00" in out
+    assert "/dev/ttyAMA0" in out
+    assert "can0" in out
+    # CAN UUID scan runs by default (the dropdown's second step).
+    assert "abc123def456" in out
+
+
+def test_list_devices_can_scan_toggle(tmp_path, monkeypatch):
+    import services.native_services as ns
+
+    monkeypatch.setattr(ns, "is_native_platform", lambda: True)
+    monkeypatch.setattr(ns, "get_all_devices", lambda: {
+        "usb_serial": [], "uart": [], "can": [{"name": "can0", "state": "down", "bitrate": None}],
+    })
+
+    def _boom(interface):
+        raise AssertionError("must not scan when scan_can_uuids=false")
+
+    monkeypatch.setattr(ns, "query_canbus_uuids", _boom)
+    server, _ = _server(tmp_path)
+    out = _call(server, "list_connected_devices", {"scan_can_uuids": False})
+    assert "can0" in out
+
+
+# ── get_section_schema ──────────────────────────────────────────────────
+
+
+def test_section_schema_single(tmp_path):
+    server, _ = _server(tmp_path)
+    out = _call(server, "get_section_schema", {"section": "bed_mesh"})
+    # Typed facts only the schema (not the prose reference) gives compactly.
+    assert "speed" in out
+    assert "lagrange" in out and "bicubic" in out  # enum values, verbatim
+    # Prose-vs-typed discriminator: the tool speaks in types/defaults.
+    assert "float" in out.lower() or "bool" in out.lower()
+
+
+def test_section_schema_batch_and_alias(tmp_path):
+    server, _ = _server(tmp_path)
+    out = _call(server, "get_section_schema", {"sections": ["extruder", "[gcode_arcs]"]})
+    assert "extruder" in out
+    assert "resolution" in out  # gcode_arcs' only param
+
+
+def test_section_schema_unknown_suggests(tmp_path):
+    server, _ = _server(tmp_path)
+    out = _call(server, "get_section_schema", {"section": "bed_msh"})
+    assert "not" in out.lower()  # explicit unknown-section message
+    assert "bed_mesh" in out     # close-match suggestion
+
+
+def test_section_schema_required_flag(tmp_path):
+    server, _ = _server(tmp_path)
+    # [extruder] nozzle_diameter is required per the schema.
+    out = _call(server, "get_section_schema", {"section": "extruder"})
+    assert "nozzle_diameter" in out
+    assert "required" in out.lower()
+
+
+# ── get_klippy_status ───────────────────────────────────────────────────
+
+
+def test_klippy_status_ready(tmp_path, monkeypatch):
+    import services.native_services as ns
+
+    monkeypatch.setattr(ns, "query_klipper_status", lambda: {
+        "status": "ok",
+        "socket_path": "/tmp/klippy_uds",
+        "state": "ready",
+        "state_message": "Printer is ready",
+        "recent_errors": [],
+        "log_path": None,
+        "is_printing": False,
+        "print_state": None,
+        "print_filename": None,
+    })
+    server, _ = _server(tmp_path)
+    out = _call(server, "get_klippy_status", {})
+    assert "ready" in out.lower()
+    # Ready + no excerpt request → no log fetch.
+    assert "log excerpt" not in out.lower()
+
+
+def test_klippy_status_not_ready_attaches_excerpt(tmp_path, monkeypatch):
+    import services.native_services as ns
+
+    monkeypatch.setattr(ns, "query_klipper_status", lambda: {
+        "status": "ok",
+        "socket_path": "/tmp/klippy_uds",
+        "state": "startup error",
+        "state_message": "Config error",
+        "recent_errors": ["Pin 'PB111' is not a valid pin name"],
+        "log_path": "/tmp/klippy.log",
+        "is_printing": False,
+        "print_state": None,
+        "print_filename": None,
+    })
+    calls = {}
+
+    def _excerpt(section_name=None, error_text=None, context_lines=40):
+        calls["section_name"] = section_name
+        calls["error_text"] = error_text
+        return {
+            "status": "ok",
+            "log_path": "/tmp/klippy.log",
+            "excerpt": "Traceback...\nPin 'PB111' is not a valid pin name",
+            "matched_on": "error",
+        }
+
+    monkeypatch.setattr(ns, "get_klippy_log_excerpt", _excerpt)
+    server, _ = _server(tmp_path)
+    out = _call(server, "get_klippy_status", {})
+    # Failure context auto-attaches when klippy is not ready.
+    assert "Pin 'PB111' is not a valid pin name" in out
+    assert "Traceback" in out
+    assert calls.get("error_text") is not None  # recent error fed into the match
+
+
+def test_klippy_status_explicit_excerpt_while_ready(tmp_path, monkeypatch):
+    import services.native_services as ns
+
+    monkeypatch.setattr(ns, "query_klipper_status", lambda: {
+        "status": "ok", "socket_path": "/x", "state": "ready",
+        "state_message": "", "recent_errors": [], "log_path": None,
+        "is_printing": False, "print_state": None, "print_filename": None,
+    })
+    monkeypatch.setattr(
+        ns, "get_klippy_log_excerpt",
+        lambda section_name=None, error_text=None, context_lines=40: {
+            "status": "ok", "log_path": "/tmp/klippy.log",
+            "excerpt": "old failure line", "matched_on": "probe",
+        },
+    )
+    server, _ = _server(tmp_path)
+    out = _call(server, "get_klippy_status", {
+        "include_log_excerpt": True, "section_name": "probe",
+    })
+    assert "old failure line" in out
+
+
+def test_klippy_status_socket_missing(tmp_path, monkeypatch):
+    import services.native_services as ns
+
+    def _missing():
+        raise FileNotFoundError("Klipper API socket not found.")
+
+    monkeypatch.setattr(ns, "query_klipper_status", _missing)
+    monkeypatch.setattr(
+        ns, "get_klippy_log_excerpt",
+        lambda section_name=None, error_text=None, context_lines=40: {
+            "status": "ok", "log_path": None, "excerpt": "", "matched_on": None,
+        },
+    )
+    server, _ = _server(tmp_path)
+    out = _call(server, "get_klippy_status", {})
+    assert "not found" in out.lower() or "not responding" in out.lower()
+
+
+def test_klippy_status_printing_warning(tmp_path, monkeypatch):
+    import services.native_services as ns
+
+    monkeypatch.setattr(ns, "query_klipper_status", lambda: {
+        "status": "ok", "socket_path": "/x", "state": "ready",
+        "state_message": "", "recent_errors": [], "log_path": None,
+        "is_printing": True, "print_state": "printing",
+        "print_filename": "benchy.gcode",
+    })
+    server, _ = _server(tmp_path)
+    out = _call(server, "get_klippy_status", {})
+    assert "benchy.gcode" in out
+    # Restart-safety note must appear whenever a print is active.
+    assert "interrupt" in out.lower() or "active" in out.lower()

--- a/tests/test_mcp_server_tools.py
+++ b/tests/test_mcp_server_tools.py
@@ -1094,7 +1094,9 @@ def test_tools_list(tmp_path):
     assert "list_user_configs" in names
     assert "list_config_reference_sections" in names
     assert "list_user_config_sections" in names
-    assert len(names) == 16  # get_section_schema removed (redundant w/ reference)
+    assert len(names) == 20  # +4 live-context tools (2026-09): validate_config_project,
+    # list_connected_devices, get_section_schema (re-added with typed output —
+    # the old prose-duplicate version was removed), get_klippy_status
 
 
 def test_tools_call_unknown_tool(tmp_path):


### PR DESCRIPTION
## Summary

**Live-context MCP tools** (`3477997`, `d12afe0` era): `validate_config_project`, `list_connected_devices`, `get_section_schema`, `get_klippy_status` wired into the AI chat tool loop, with live-context routing fixed after first LIVE-family run (`dib9376`… `d12afe0` range), trigger-phrase sharpening for the validate boundary, and LIVE-01..07 accuracy family.

**Server-side merged-result pipeline** (`d12afe0`): merged-result validation, ONE lean deterministic repair (unclosed-Jinja), and post-apply audit (LED-command/requirement checks, `_LED_CMD_RE` class). Defaults ON (`c0e7a9c`); malformed tool calls guarded instead of leaking raw markup (`2eb2984`).

**Harness** (`9125cf4`): production-parity contextFiles, 3 harness-probe questions (HARNESS-01..03), criterion refresh (AMBI family accepts legitimate clarifying questions; alias/LED-command upgrades).

## Accuracy evidence (2026-09-09, same-day A/B)

| Stack | Result |
|---|---|
| gemma-4-12b, flags **off** | 57+4 cond / 69 — **8 FAIL** |
| gemma-4-12b, flags **on** | 61+4 cond / 69 — **4 FAIL**, zero new fails (AMBI-04/05, Q04 fixed; MACRO-05 passes 4/4 rechecks) |
| qwen3.5-4b, flags on | 44/69 (expected small-model gap; no flags damage) |
| **klipper-expert** (gemma-12b + RAG proxy), flags on | **65+1 cond / 72 — best measured stack**; LIVE-02/05 (gemma's last routing misses) both PASS |

Remaining known fails: TRIDENT-15/16 (LED cross-file enumeration), AMBI-04 (diff on hypothetical), MINIDIFF-01 (context lines in mini-diff), MACRO-07 (correct answer, rigid criterion), HARNESS-03 (audit requirement-checker value cross-parse — probe caught a real harness bug, fix queued).

## Test plan (CI on this PR)
- pytest (repo-root tests/) — green locally
- vitest + tsc -b — green locally
- Accuracy suite runs recorded under reports/ai-chat-accuracy/ (gitignored)